### PR TITLE
feat(lexer): add keyword and identifier lexing

### DIFF
--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -24,6 +24,7 @@ class Lexer {
     char advance();
     bool isAtEnd() const;
     void skipWhitespace();
+    Token readIdentifierOrKeyword();
 };
 
 } // namespace spudplate

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,6 +1,30 @@
 #include "spudplate/lexer.h"
 
+#include <unordered_map>
+
 namespace spudplate {
+
+static const std::unordered_map<std::string, TokenType> keywords = {
+    {"ask", TokenType::ASK},
+    {"let", TokenType::LET},
+    {"mkdir", TokenType::MKDIR},
+    {"file", TokenType::FILE},
+    {"from", TokenType::FROM},
+    {"content", TokenType::CONTENT},
+    {"when", TokenType::WHEN},
+    {"repeat", TokenType::REPEAT},
+    {"end", TokenType::END},
+    {"required", TokenType::REQUIRED},
+    {"verbatim", TokenType::VERBATIM},
+    {"mode", TokenType::MODE},
+    {"as", TokenType::AS},
+    {"and", TokenType::AND},
+    {"or", TokenType::OR},
+    {"not", TokenType::NOT},
+    {"string", TokenType::STRING_TYPE},
+    {"bool", TokenType::BOOL_TYPE},
+    {"int", TokenType::INT_TYPE},
+};
 
 Lexer::Lexer(std::string source)
     : source_(std::move(source)), pos_(0), line_(1), column_(1) {}
@@ -32,6 +56,24 @@ void Lexer::skipWhitespace() {
     }
 }
 
+Token Lexer::readIdentifierOrKeyword() {
+    int startLine = line_;
+    int startCol = column_;
+    std::string value;
+
+    while (!isAtEnd() &&
+           (std::isalnum(static_cast<unsigned char>(current())) ||
+            current() == '_')) {
+        value += advance();
+    }
+
+    auto it = keywords.find(value);
+    if (it != keywords.end()) {
+        return Token(it->second, value, startLine, startCol);
+    }
+    return Token(TokenType::IDENTIFIER, value, startLine, startCol);
+}
+
 Token Lexer::nextToken() {
     skipWhitespace();
 
@@ -39,9 +81,15 @@ Token Lexer::nextToken() {
         return Token(TokenType::EOF_TOKEN, "", line_, column_);
     }
 
+    char ch = current();
+
+    if (std::isalpha(static_cast<unsigned char>(ch)) || ch == '_') {
+        return readIdentifierOrKeyword();
+    }
+
     int startLine = line_;
     int startCol = column_;
-    char ch = advance();
+    advance();
 
     return Token(TokenType::ERROR, std::string(1, ch), startLine, startCol);
 }

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -73,3 +73,87 @@ TEST(LexerTest, WhitespaceBeforeUnrecognized) {
     EXPECT_EQ(tok.value, "@");
     EXPECT_EQ(tok.column, 3);
 }
+
+TEST(LexerTest, AllKeywords) {
+    struct Case {
+        const char *input;
+        TokenType expected;
+    };
+    Case cases[] = {
+        {"ask", TokenType::ASK},
+        {"let", TokenType::LET},
+        {"mkdir", TokenType::MKDIR},
+        {"file", TokenType::FILE},
+        {"from", TokenType::FROM},
+        {"content", TokenType::CONTENT},
+        {"when", TokenType::WHEN},
+        {"repeat", TokenType::REPEAT},
+        {"end", TokenType::END},
+        {"required", TokenType::REQUIRED},
+        {"verbatim", TokenType::VERBATIM},
+        {"mode", TokenType::MODE},
+        {"as", TokenType::AS},
+        {"and", TokenType::AND},
+        {"or", TokenType::OR},
+        {"not", TokenType::NOT},
+        {"string", TokenType::STRING_TYPE},
+        {"bool", TokenType::BOOL_TYPE},
+        {"int", TokenType::INT_TYPE},
+    };
+    for (const auto &c : cases) {
+        Lexer lexer(c.input);
+        Token tok = lexer.nextToken();
+        EXPECT_EQ(tok.type, c.expected)
+            << "Failed for keyword: " << c.input;
+        EXPECT_EQ(tok.value, c.input);
+        EXPECT_EQ(tok.line, 1);
+        EXPECT_EQ(tok.column, 1);
+    }
+}
+
+TEST(LexerTest, Identifier) {
+    Lexer lexer("my_var");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok.value, "my_var");
+}
+
+TEST(LexerTest, IdentifierWithDigits) {
+    Lexer lexer("name2");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok.value, "name2");
+}
+
+TEST(LexerTest, UnderscoreIdentifier) {
+    Lexer lexer("_private");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok.value, "_private");
+}
+
+TEST(LexerTest, KeywordsCaseSensitive) {
+    Lexer lexer("Ask");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok.value, "Ask");
+}
+
+TEST(LexerTest, MultipleTokens) {
+    Lexer lexer("ask name");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::ASK);
+    EXPECT_EQ(tok1.column, 1);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok2.value, "name");
+    EXPECT_EQ(tok2.column, 5);
+}
+
+TEST(LexerTest, KeywordPrefixIsIdentifier) {
+    Lexer lexer("asking");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok.value, "asking");
+}


### PR DESCRIPTION
## Summary
Add identifier/keyword recognition to the lexer. Alphanumeric sequences are matched against the 19 keywords, anything else becomes an IDENTIFIER

## Changes
- Add keyword lookup map and readIdentifierOrKeyword() to Lexer
- 7 new tests covering all keywords, identifiers, case sensitivity, and edge cases

## Test plan
- All 15 (7 new) tests pass locally
