### PR TITLE
feat(lexer): add string and integer literal lexing

### DIFF
--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -26,6 +26,7 @@ class Lexer {
     void skipWhitespace();
     Token readIdentifierOrKeyword();
     Token readStringLiteral();
+    Token readIntegerLiteral();
 };
 
 } // namespace spudplate

--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -25,6 +25,7 @@ class Lexer {
     bool isAtEnd() const;
     void skipWhitespace();
     Token readIdentifierOrKeyword();
+    Token readStringLiteral();
 };
 
 } // namespace spudplate

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -74,6 +74,25 @@ Token Lexer::readIdentifierOrKeyword() {
     return Token(TokenType::IDENTIFIER, value, startLine, startCol);
 }
 
+Token Lexer::readStringLiteral() {
+    int startLine = line_;
+    int startCol = column_;
+    advance(); // skip opening "
+
+    std::string value;
+    while (!isAtEnd() && current() != '"') {
+        value += advance();
+    }
+
+    if (isAtEnd()) {
+        return Token(TokenType::ERROR, "unterminated string", startLine,
+                     startCol);
+    }
+
+    advance(); // skip closing "
+    return Token(TokenType::STRING_LITERAL, value, startLine, startCol);
+}
+
 Token Lexer::nextToken() {
     skipWhitespace();
 
@@ -85,6 +104,10 @@ Token Lexer::nextToken() {
 
     if (std::isalpha(static_cast<unsigned char>(ch)) || ch == '_') {
         return readIdentifierOrKeyword();
+    }
+
+    if (ch == '"') {
+        return readStringLiteral();
     }
 
     int startLine = line_;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -93,6 +93,19 @@ Token Lexer::readStringLiteral() {
     return Token(TokenType::STRING_LITERAL, value, startLine, startCol);
 }
 
+Token Lexer::readIntegerLiteral() {
+    int startLine = line_;
+    int startCol = column_;
+    std::string value;
+
+    while (!isAtEnd() &&
+           std::isdigit(static_cast<unsigned char>(current()))) {
+        value += advance();
+    }
+
+    return Token(TokenType::INTEGER_LITERAL, value, startLine, startCol);
+}
+
 Token Lexer::nextToken() {
     skipWhitespace();
 
@@ -108,6 +121,10 @@ Token Lexer::nextToken() {
 
     if (ch == '"') {
         return readStringLiteral();
+    }
+
+    if (std::isdigit(static_cast<unsigned char>(ch))) {
+        return readIntegerLiteral();
     }
 
     int startLine = line_;

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -57,8 +57,8 @@ void Lexer::skipWhitespace() {
 }
 
 Token Lexer::readIdentifierOrKeyword() {
-    int startLine = line_;
-    int startCol = column_;
+    int start_line = line_;
+    int start_col = column_;
     std::string value;
 
     while (!isAtEnd() &&
@@ -69,14 +69,14 @@ Token Lexer::readIdentifierOrKeyword() {
 
     auto it = keywords.find(value);
     if (it != keywords.end()) {
-        return Token(it->second, value, startLine, startCol);
+        return Token(it->second, value, start_line, start_col);
     }
-    return Token(TokenType::IDENTIFIER, value, startLine, startCol);
+    return Token(TokenType::IDENTIFIER, value, start_line, start_col);
 }
 
 Token Lexer::readStringLiteral() {
-    int startLine = line_;
-    int startCol = column_;
+    int start_line = line_;
+    int start_col = column_;
     advance(); // skip opening "
 
     std::string value;
@@ -85,17 +85,17 @@ Token Lexer::readStringLiteral() {
     }
 
     if (isAtEnd()) {
-        return Token(TokenType::ERROR, "unterminated string", startLine,
-                     startCol);
+        return Token(TokenType::ERROR, "unterminated string", start_line,
+                     start_col);
     }
 
     advance(); // skip closing "
-    return Token(TokenType::STRING_LITERAL, value, startLine, startCol);
+    return Token(TokenType::STRING_LITERAL, value, start_line, start_col);
 }
 
 Token Lexer::readIntegerLiteral() {
-    int startLine = line_;
-    int startCol = column_;
+    int start_line = line_;
+    int start_col = column_;
     std::string value;
 
     while (!isAtEnd() &&
@@ -103,7 +103,7 @@ Token Lexer::readIntegerLiteral() {
         value += advance();
     }
 
-    return Token(TokenType::INTEGER_LITERAL, value, startLine, startCol);
+    return Token(TokenType::INTEGER_LITERAL, value, start_line, start_col);
 }
 
 Token Lexer::nextToken() {
@@ -127,11 +127,11 @@ Token Lexer::nextToken() {
         return readIntegerLiteral();
     }
 
-    int startLine = line_;
-    int startCol = column_;
+    int start_line = line_;
+    int start_col = column_;
     advance();
 
-    return Token(TokenType::ERROR, std::string(1, ch), startLine, startCol);
+    return Token(TokenType::ERROR, std::string(1, ch), start_line, start_col);
 }
 
 } // namespace spudplate

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -157,3 +157,92 @@ TEST(LexerTest, KeywordPrefixIsIdentifier) {
     EXPECT_EQ(tok.type, TokenType::IDENTIFIER);
     EXPECT_EQ(tok.value, "asking");
 }
+
+TEST(LexerTest, SimpleString) {
+    Lexer lexer("\"hello\"");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok.value, "hello");
+    EXPECT_EQ(tok.line, 1);
+    EXPECT_EQ(tok.column, 1);
+}
+
+TEST(LexerTest, EmptyString) {
+    Lexer lexer("\"\"");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok.value, "");
+}
+
+TEST(LexerTest, StringWithSpaces) {
+    Lexer lexer("\"hello world\"");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok.value, "hello world");
+}
+
+TEST(LexerTest, UnterminatedString) {
+    Lexer lexer("\"hello");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::ERROR);
+    EXPECT_EQ(tok.value, "unterminated string");
+    EXPECT_EQ(tok.line, 1);
+    EXPECT_EQ(tok.column, 1);
+}
+
+TEST(LexerTest, StringThenKeyword) {
+    Lexer lexer("\"path\" file");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok1.value, "path");
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::FILE);
+}
+
+TEST(LexerTest, StringColumnTracking) {
+    Lexer lexer("  \"hi\"");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok.column, 3);
+}
+
+TEST(LexerTest, SimpleInteger) {
+    Lexer lexer("42");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::INTEGER_LITERAL);
+    EXPECT_EQ(tok.value, "42");
+    EXPECT_EQ(tok.line, 1);
+    EXPECT_EQ(tok.column, 1);
+}
+
+TEST(LexerTest, MultiDigitInteger) {
+    Lexer lexer("12345");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::INTEGER_LITERAL);
+    EXPECT_EQ(tok.value, "12345");
+}
+
+TEST(LexerTest, SingleDigitZero) {
+    Lexer lexer("0");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::INTEGER_LITERAL);
+    EXPECT_EQ(tok.value, "0");
+}
+
+TEST(LexerTest, IntegerThenKeyword) {
+    Lexer lexer("100 let");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::INTEGER_LITERAL);
+    EXPECT_EQ(tok1.value, "100");
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::LET);
+}
+
+TEST(LexerTest, IntegerColumnTracking) {
+    Lexer lexer("  99");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::INTEGER_LITERAL);
+    EXPECT_EQ(tok.column, 3);
+}


### PR DESCRIPTION
## Summary
Add lexer handling of string and integer literals.

## Changes
- Add string literal lexing with unterminated string error handling
- Add integer literal lexing
- Add 6 new string literal tests and 5 new integer literal tests

## Test plan
- All 26 (11 new) tests pass locally
