### PR TITLE
feat(lexer): add operator lexing

### DIFF
--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -131,7 +131,40 @@ Token Lexer::nextToken() {
     int start_col = column_;
     advance();
 
-    return Token(TokenType::ERROR, std::string(1, ch), start_line, start_col);
+    switch (ch) {
+    case '+': return Token(TokenType::PLUS, "+", start_line, start_col);
+    case '-': return Token(TokenType::MINUS, "-", start_line, start_col);
+    case '*': return Token(TokenType::STAR, "*", start_line, start_col);
+    case '/': return Token(TokenType::SLASH, "/", start_line, start_col);
+    case '(': return Token(TokenType::LPAREN, "(", start_line, start_col);
+    case ')': return Token(TokenType::RPAREN, ")", start_line, start_col);
+    case '=':
+        if (!isAtEnd() && current() == '=') {
+            advance();
+            return Token(TokenType::EQUALS, "==", start_line, start_col);
+        }
+        return Token(TokenType::ASSIGN, "=", start_line, start_col);
+    case '!':
+        if (!isAtEnd() && current() == '=') {
+            advance();
+            return Token(TokenType::NOT_EQUALS, "!=", start_line, start_col);
+        }
+        return Token(TokenType::ERROR, "!", start_line, start_col);
+    case '>':
+        if (!isAtEnd() && current() == '=') {
+            advance();
+            return Token(TokenType::GREATER_EQUAL, ">=", start_line, start_col);
+        }
+        return Token(TokenType::GREATER, ">", start_line, start_col);
+    case '<':
+        if (!isAtEnd() && current() == '=') {
+            advance();
+            return Token(TokenType::LESS_EQUAL, "<=", start_line, start_col);
+        }
+        return Token(TokenType::LESS, "<", start_line, start_col);
+    default:
+        return Token(TokenType::ERROR, std::string(1, ch), start_line, start_col);
+    }
 }
 
 } // namespace spudplate

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -246,3 +246,108 @@ TEST(LexerTest, IntegerColumnTracking) {
     EXPECT_EQ(tok.type, TokenType::INTEGER_LITERAL);
     EXPECT_EQ(tok.column, 3);
 }
+
+TEST(LexerTest, SingleCharOperators) {
+    struct Case {
+        const char *input;
+        TokenType expected;
+        const char *value;
+    };
+    Case cases[] = {
+        {"+", TokenType::PLUS, "+"},
+        {"-", TokenType::MINUS, "-"},
+        {"*", TokenType::STAR, "*"},
+        {"/", TokenType::SLASH, "/"},
+        {"(", TokenType::LPAREN, "("},
+        {")", TokenType::RPAREN, ")"},
+    };
+    for (const auto &c : cases) {
+        Lexer lexer(c.input);
+        Token tok = lexer.nextToken();
+        EXPECT_EQ(tok.type, c.expected) << "Failed for: " << c.input;
+        EXPECT_EQ(tok.value, c.value);
+        EXPECT_EQ(tok.line, 1);
+        EXPECT_EQ(tok.column, 1);
+    }
+}
+
+TEST(LexerTest, AssignOperator) {
+    Lexer lexer("=");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::ASSIGN);
+    EXPECT_EQ(tok.value, "=");
+}
+
+TEST(LexerTest, EqualsOperator) {
+    Lexer lexer("==");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::EQUALS);
+    EXPECT_EQ(tok.value, "==");
+}
+
+TEST(LexerTest, NotEqualsOperator) {
+    Lexer lexer("!=");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::NOT_EQUALS);
+    EXPECT_EQ(tok.value, "!=");
+}
+
+TEST(LexerTest, BangAloneIsError) {
+    Lexer lexer("!");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::ERROR);
+    EXPECT_EQ(tok.value, "!");
+}
+
+TEST(LexerTest, GreaterOperator) {
+    Lexer lexer(">");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::GREATER);
+    EXPECT_EQ(tok.value, ">");
+}
+
+TEST(LexerTest, GreaterEqualOperator) {
+    Lexer lexer(">=");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::GREATER_EQUAL);
+    EXPECT_EQ(tok.value, ">=");
+}
+
+TEST(LexerTest, LessOperator) {
+    Lexer lexer("<");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::LESS);
+    EXPECT_EQ(tok.value, "<");
+}
+
+TEST(LexerTest, LessEqualOperator) {
+    Lexer lexer("<=");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::LESS_EQUAL);
+    EXPECT_EQ(tok.value, "<=");
+}
+
+TEST(LexerTest, OperatorColumnTracking) {
+    Lexer lexer("  + ==");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::PLUS);
+    EXPECT_EQ(tok1.column, 3);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::EQUALS);
+    EXPECT_EQ(tok2.column, 5);
+}
+
+TEST(LexerTest, OperatorsInExpression) {
+    Lexer lexer("x >= 10");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok1.value, "x");
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::GREATER_EQUAL);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::INTEGER_LITERAL);
+    EXPECT_EQ(tok3.value, "10");
+}


### PR DESCRIPTION
## Summary
Add lexer support for common operators

## Changes
- Add single-char operator lexing: `+`, `-`, `*`, `/`, `(`, `)`
- Add two-char comparison operators with peek: `==`, `!=`, `>=`, `<=`
- 11 new operator tests added

## Test plan
- All 37 (11 new) tests pass locally