### PR TITLE
feat(parser): add AST types and expression parsing

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,10 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "compileCommands": "${workspaceFolder}/build/compile_commands.json",
+            "cppStandard": "c++17"
+        }
+    ],
+    "version": 4
+}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Library
-add_library(spudplate_lib src/lexer.cpp)
+add_library(spudplate_lib src/lexer.cpp src/parser.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 
 # Executable
@@ -24,7 +24,7 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-add_executable(spudplate_tests tests/lexer_test.cpp)
+add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -1,0 +1,79 @@
+#ifndef SPUDPLATE_AST_H
+#define SPUDPLATE_AST_H
+
+#include "spudplate/token.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace spudplate {
+
+struct StringLiteralExpr {
+    std::string value;
+    int line;
+    int column;
+};
+
+struct IntegerLiteralExpr {
+    int value;
+    int line;
+    int column;
+};
+
+struct IdentifierExpr {
+    std::string name;
+    int line;
+    int column;
+};
+
+// Forward declare Expr so recursive types can hold pointers to it
+struct Expr;
+using ExprPtr = std::unique_ptr<Expr>;
+
+struct UnaryExpr {
+    TokenType op;
+    ExprPtr operand;
+    int line;
+    int column;
+};
+
+struct BinaryExpr {
+    TokenType op;
+    ExprPtr left;
+    ExprPtr right;
+    int line;
+    int column;
+};
+
+struct FunctionCallExpr {
+    std::string name;
+    ExprPtr argument;
+    int line;
+    int column;
+};
+
+using ExprData = std::variant<StringLiteralExpr, IntegerLiteralExpr,
+                              IdentifierExpr, UnaryExpr, BinaryExpr,
+                              FunctionCallExpr>;
+
+struct Expr {
+    ExprData data;
+};
+
+// Statement types — stubs for branch 2
+struct AskStmt;
+struct LetStmt;
+struct MkdirStmt;
+struct FileStmt;
+struct RepeatStmt;
+
+struct Program {
+    // Populated in branch 3
+};
+
+} // namespace spudplate
+
+#endif // SPUDPLATE_AST_H

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -1,0 +1,54 @@
+#ifndef SPUDPLATE_PARSER_H
+#define SPUDPLATE_PARSER_H
+
+#include "spudplate/ast.h"
+#include "spudplate/lexer.h"
+
+#include <stdexcept>
+#include <string>
+
+namespace spudplate {
+
+class ParseError : public std::runtime_error {
+  public:
+    ParseError(const std::string &message, int line, int column)
+        : std::runtime_error(message), line_(line), column_(column) {}
+
+    int line() const { return line_; }
+    int column() const { return column_; }
+
+  private:
+    int line_;
+    int column_;
+};
+
+class Parser {
+  public:
+    explicit Parser(Lexer lexer);
+
+    ExprPtr parseExpression();
+
+  private:
+    Lexer lexer_;
+    Token current_;
+
+    // Token consumption
+    Token advance();
+    bool check(TokenType type) const;
+    bool match(TokenType type);
+    Token expect(TokenType type, const std::string &message);
+    void skip_newlines();
+
+    // Expression precedence climbing
+    ExprPtr parse_or();
+    ExprPtr parse_and();
+    ExprPtr parse_comparison();
+    ExprPtr parse_addition();
+    ExprPtr parse_multiplication();
+    ExprPtr parse_unary();
+    ExprPtr parse_primary();
+};
+
+} // namespace spudplate
+
+#endif // SPUDPLATE_PARSER_H

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,0 +1,200 @@
+#include "spudplate/parser.h"
+
+namespace spudplate {
+
+Parser::Parser(Lexer lexer) : lexer_(std::move(lexer)) {
+    current_ = lexer_.nextToken();
+}
+
+Token Parser::advance() {
+    Token prev = current_;
+    current_ = lexer_.nextToken();
+    return prev;
+}
+
+bool Parser::check(TokenType type) const { return current_.type == type; }
+
+bool Parser::match(TokenType type) {
+    if (check(type)) {
+        advance();
+        return true;
+    }
+    return false;
+}
+
+Token Parser::expect(TokenType type, const std::string &message) {
+    if (check(type)) {
+        return advance();
+    }
+    throw ParseError(message, current_.line, current_.column);
+}
+
+void Parser::skip_newlines() {
+    while (check(TokenType::NEWLINE)) {
+        advance();
+    }
+}
+
+// Expression precedence: or < and < comparison < addition < multiplication <
+// unary < primary
+
+ExprPtr Parser::parseExpression() { return parse_or(); }
+
+ExprPtr Parser::parse_or() {
+    auto left = parse_and();
+
+    while (check(TokenType::OR)) {
+        int line = current_.line;
+        int col = current_.column;
+        advance();
+        auto right = parse_and();
+
+        auto expr = std::make_unique<Expr>();
+        expr->data = BinaryExpr{TokenType::OR, std::move(left), std::move(right),
+                                line, col};
+        left = std::move(expr);
+    }
+
+    return left;
+}
+
+ExprPtr Parser::parse_and() {
+    auto left = parse_comparison();
+
+    while (check(TokenType::AND)) {
+        int line = current_.line;
+        int col = current_.column;
+        advance();
+        auto right = parse_comparison();
+
+        auto expr = std::make_unique<Expr>();
+        expr->data = BinaryExpr{TokenType::AND, std::move(left),
+                                std::move(right), line, col};
+        left = std::move(expr);
+    }
+
+    return left;
+}
+
+ExprPtr Parser::parse_comparison() {
+    auto left = parse_addition();
+
+    while (check(TokenType::EQUALS) || check(TokenType::NOT_EQUALS) ||
+           check(TokenType::GREATER) || check(TokenType::LESS) ||
+           check(TokenType::GREATER_EQUAL) || check(TokenType::LESS_EQUAL)) {
+        TokenType op = current_.type;
+        int line = current_.line;
+        int col = current_.column;
+        advance();
+        auto right = parse_addition();
+
+        auto expr = std::make_unique<Expr>();
+        expr->data =
+            BinaryExpr{op, std::move(left), std::move(right), line, col};
+        left = std::move(expr);
+    }
+
+    return left;
+}
+
+ExprPtr Parser::parse_addition() {
+    auto left = parse_multiplication();
+
+    while (check(TokenType::PLUS) || check(TokenType::MINUS)) {
+        TokenType op = current_.type;
+        int line = current_.line;
+        int col = current_.column;
+        advance();
+        auto right = parse_multiplication();
+
+        auto expr = std::make_unique<Expr>();
+        expr->data =
+            BinaryExpr{op, std::move(left), std::move(right), line, col};
+        left = std::move(expr);
+    }
+
+    return left;
+}
+
+ExprPtr Parser::parse_multiplication() {
+    auto left = parse_unary();
+
+    while (check(TokenType::STAR) || check(TokenType::SLASH)) {
+        TokenType op = current_.type;
+        int line = current_.line;
+        int col = current_.column;
+        advance();
+        auto right = parse_unary();
+
+        auto expr = std::make_unique<Expr>();
+        expr->data =
+            BinaryExpr{op, std::move(left), std::move(right), line, col};
+        left = std::move(expr);
+    }
+
+    return left;
+}
+
+ExprPtr Parser::parse_unary() {
+    if (check(TokenType::NOT)) {
+        int line = current_.line;
+        int col = current_.column;
+        advance();
+        auto operand = parse_unary();
+
+        auto expr = std::make_unique<Expr>();
+        expr->data = UnaryExpr{TokenType::NOT, std::move(operand), line, col};
+        return expr;
+    }
+
+    return parse_primary();
+}
+
+ExprPtr Parser::parse_primary() {
+    if (check(TokenType::STRING_LITERAL)) {
+        Token tok = advance();
+        auto expr = std::make_unique<Expr>();
+        expr->data = StringLiteralExpr{tok.value, tok.line, tok.column};
+        return expr;
+    }
+
+    if (check(TokenType::INTEGER_LITERAL)) {
+        Token tok = advance();
+        auto expr = std::make_unique<Expr>();
+        expr->data =
+            IntegerLiteralExpr{std::stoi(tok.value), tok.line, tok.column};
+        return expr;
+    }
+
+    if (check(TokenType::IDENTIFIER)) {
+        Token tok = advance();
+
+        // Check for function call: name(expr)
+        if (check(TokenType::LPAREN)) {
+            advance();
+            auto arg = parseExpression();
+            expect(TokenType::RPAREN, "expected ')' after function argument");
+
+            auto expr = std::make_unique<Expr>();
+            expr->data = FunctionCallExpr{tok.value, std::move(arg), tok.line,
+                                          tok.column};
+            return expr;
+        }
+
+        auto expr = std::make_unique<Expr>();
+        expr->data = IdentifierExpr{tok.value, tok.line, tok.column};
+        return expr;
+    }
+
+    if (check(TokenType::LPAREN)) {
+        advance();
+        auto inner = parseExpression();
+        expect(TokenType::RPAREN, "expected ')' after expression");
+        return inner;
+    }
+
+    throw ParseError("unexpected token: " + current_.value, current_.line,
+                     current_.column);
+}
+
+} // namespace spudplate

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -1,0 +1,180 @@
+#include "spudplate/ast.h"
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+
+#include <gtest/gtest.h>
+
+using spudplate::BinaryExpr;
+using spudplate::Expr;
+using spudplate::ExprPtr;
+using spudplate::FunctionCallExpr;
+using spudplate::IdentifierExpr;
+using spudplate::IntegerLiteralExpr;
+using spudplate::Lexer;
+using spudplate::ParseError;
+using spudplate::Parser;
+using spudplate::StringLiteralExpr;
+using spudplate::TokenType;
+using spudplate::UnaryExpr;
+
+static ExprPtr parse_expr(const std::string &input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseExpression();
+}
+
+TEST(ParserTest, StringLiteral) {
+    auto expr = parse_expr("\"hello\"");
+    auto &lit = std::get<StringLiteralExpr>(expr->data);
+    EXPECT_EQ(lit.value, "hello");
+    EXPECT_EQ(lit.line, 1);
+    EXPECT_EQ(lit.column, 1);
+}
+
+TEST(ParserTest, IntegerLiteral) {
+    auto expr = parse_expr("42");
+    auto &lit = std::get<IntegerLiteralExpr>(expr->data);
+    EXPECT_EQ(lit.value, 42);
+}
+
+TEST(ParserTest, Identifier) {
+    auto expr = parse_expr("my_var");
+    auto &id = std::get<IdentifierExpr>(expr->data);
+    EXPECT_EQ(id.name, "my_var");
+}
+
+TEST(ParserTest, BinaryAddition) {
+    auto expr = parse_expr("1 + 2");
+    auto &bin = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(bin.op, TokenType::PLUS);
+
+    auto &left = std::get<IntegerLiteralExpr>(bin.left->data);
+    EXPECT_EQ(left.value, 1);
+
+    auto &right = std::get<IntegerLiteralExpr>(bin.right->data);
+    EXPECT_EQ(right.value, 2);
+}
+
+TEST(ParserTest, BinaryMultiplication) {
+    auto expr = parse_expr("3 * 4");
+    auto &bin = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(bin.op, TokenType::STAR);
+}
+
+TEST(ParserTest, PrecedenceMulOverAdd) {
+    // 1 + 2 * 3 should parse as 1 + (2 * 3)
+    auto expr = parse_expr("1 + 2 * 3");
+    auto &add = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(add.op, TokenType::PLUS);
+
+    auto &left = std::get<IntegerLiteralExpr>(add.left->data);
+    EXPECT_EQ(left.value, 1);
+
+    auto &mul = std::get<BinaryExpr>(add.right->data);
+    EXPECT_EQ(mul.op, TokenType::STAR);
+}
+
+TEST(ParserTest, PrecedenceSubDiv) {
+    // 10 - 5 / 2 should parse as 10 - (5 / 2)
+    auto expr = parse_expr("10 - 5 / 2");
+    auto &sub = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(sub.op, TokenType::MINUS);
+
+    auto &div = std::get<BinaryExpr>(sub.right->data);
+    EXPECT_EQ(div.op, TokenType::SLASH);
+}
+
+TEST(ParserTest, Comparison) {
+    auto expr = parse_expr("x > 5");
+    auto &cmp = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(cmp.op, TokenType::GREATER);
+
+    auto &left = std::get<IdentifierExpr>(cmp.left->data);
+    EXPECT_EQ(left.name, "x");
+
+    auto &right = std::get<IntegerLiteralExpr>(cmp.right->data);
+    EXPECT_EQ(right.value, 5);
+}
+
+TEST(ParserTest, EqualityComparison) {
+    auto expr = parse_expr("name == \"foo\"");
+    auto &cmp = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(cmp.op, TokenType::EQUALS);
+}
+
+TEST(ParserTest, LogicalAnd) {
+    auto expr = parse_expr("a and b");
+    auto &bin = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(bin.op, TokenType::AND);
+}
+
+TEST(ParserTest, LogicalOr) {
+    auto expr = parse_expr("a or b");
+    auto &bin = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(bin.op, TokenType::OR);
+}
+
+TEST(ParserTest, UnaryNot) {
+    auto expr = parse_expr("not x");
+    auto &un = std::get<UnaryExpr>(expr->data);
+    EXPECT_EQ(un.op, TokenType::NOT);
+
+    auto &operand = std::get<IdentifierExpr>(un.operand->data);
+    EXPECT_EQ(operand.name, "x");
+}
+
+TEST(ParserTest, CombinedPrecedence) {
+    // a + b > c and d → (((a + b) > c) and d)
+    auto expr = parse_expr("a + b > c and d");
+    auto &and_expr = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(and_expr.op, TokenType::AND);
+
+    auto &cmp = std::get<BinaryExpr>(and_expr.left->data);
+    EXPECT_EQ(cmp.op, TokenType::GREATER);
+
+    auto &add = std::get<BinaryExpr>(cmp.left->data);
+    EXPECT_EQ(add.op, TokenType::PLUS);
+}
+
+TEST(ParserTest, FunctionCall) {
+    auto expr = parse_expr("lower(name)");
+    auto &call = std::get<FunctionCallExpr>(expr->data);
+    EXPECT_EQ(call.name, "lower");
+
+    auto &arg = std::get<IdentifierExpr>(call.argument->data);
+    EXPECT_EQ(arg.name, "name");
+}
+
+TEST(ParserTest, FunctionCallUpper) {
+    auto expr = parse_expr("upper(x)");
+    auto &call = std::get<FunctionCallExpr>(expr->data);
+    EXPECT_EQ(call.name, "upper");
+}
+
+TEST(ParserTest, Parenthesized) {
+    // (a + b) * c → should multiply, not add at top
+    auto expr = parse_expr("(a + b) * c");
+    auto &mul = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(mul.op, TokenType::STAR);
+
+    auto &add = std::get<BinaryExpr>(mul.left->data);
+    EXPECT_EQ(add.op, TokenType::PLUS);
+}
+
+TEST(ParserTest, StringConcat) {
+    auto expr = parse_expr("\"hello\" + \" \" + name");
+    auto &outer = std::get<BinaryExpr>(expr->data);
+    EXPECT_EQ(outer.op, TokenType::PLUS);
+
+    // Left-associative: ("hello" + " ") + name
+    auto &inner = std::get<BinaryExpr>(outer.left->data);
+    EXPECT_EQ(inner.op, TokenType::PLUS);
+}
+
+TEST(ParserTest, ErrorUnexpectedToken) {
+    EXPECT_THROW(parse_expr("+"), ParseError);
+}
+
+TEST(ParserTest, ErrorMissingCloseParen) {
+    EXPECT_THROW(parse_expr("(1 + 2"), ParseError);
+}


### PR DESCRIPTION
## Summary
Add abstract syntax tree (AST) node types and expression parser

## Changes
- Define expression AST nodes: `StringLiteralExpr`, `IntegerLiteralExpr`, `IdentifierExpr`, `UnaryExpr`, `BinaryExpr`, `FunctionCallExpr`
- Implement Parser class
- Support function calls parenthesized expressions, and string concatenation
- Configure VSCode for C++17
- Add 18 tests for parser and AST nodes

## Test plan
- All 62 (18 new) tests pass locally