### PR TITLE
feat(parser): add statement parsing

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -3,6 +3,9 @@
         {
             "name": "Mac",
             "compileCommands": "${workspaceFolder}/build/compile_commands.json",
+            "includePath": [
+                "${workspaceFolder}/include"
+            ],
             "cppStandard": "c++17"
         }
     ],

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -63,12 +63,64 @@ struct Expr {
     ExprData data;
 };
 
-// Statement types — stubs for branch 2
-struct AskStmt;
-struct LetStmt;
-struct MkdirStmt;
-struct FileStmt;
+// Variable types for ask statements
+enum class VarType { String, Bool, Int };
+
+// File source: either a path (from) or an expression (content)
+struct FileFromSource {
+    std::string path;
+    bool verbatim;
+};
+
+struct FileContentSource {
+    ExprPtr value;
+};
+
+using FileSource = std::variant<FileFromSource, FileContentSource>;
+
+// Statement types
+
+struct AskStmt {
+    std::string name;
+    std::string prompt;
+    VarType var_type;
+    bool required;
+    std::optional<ExprPtr> when_clause;
+    int line;
+    int column;
+};
+
+struct LetStmt {
+    std::string name;
+    ExprPtr value;
+    int line;
+    int column;
+};
+
+struct MkdirStmt {
+    std::string path;
+    std::optional<int> mode;
+    std::optional<ExprPtr> when_clause;
+    int line;
+    int column;
+};
+
+struct FileStmt {
+    std::string path;
+    FileSource source;
+    std::optional<int> mode;
+    std::optional<ExprPtr> when_clause;
+    int line;
+    int column;
+};
+
+// Forward declare RepeatStmt — defined in branch 3
 struct RepeatStmt;
+
+// Stmt variant and pointer type
+using Stmt =
+    std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt>;
+using StmtPtr = std::unique_ptr<Stmt>;
 
 struct Program {
     // Populated in branch 3

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -28,6 +28,11 @@ class Parser {
 
     ExprPtr parseExpression();
 
+    StmtPtr parseAsk();
+    StmtPtr parseLet();
+    StmtPtr parseMkdir();
+    StmtPtr parseFile();
+
   private:
     Lexer lexer_;
     Token current_;
@@ -38,6 +43,12 @@ class Parser {
     bool match(TokenType type);
     Token expect(TokenType type, const std::string &message);
     void skip_newlines();
+
+    // Statement helpers
+    VarType parse_var_type();
+    std::optional<ExprPtr> parse_when_clause();
+    std::optional<int> parse_mode_clause();
+    void expect_newline(const std::string &context);
 
     // Expression precedence climbing
     ExprPtr parse_or();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -35,6 +35,115 @@ void Parser::skip_newlines() {
     }
 }
 
+// Statement helpers
+
+VarType Parser::parse_var_type() {
+    if (match(TokenType::STRING_TYPE))
+        return VarType::String;
+    if (match(TokenType::BOOL_TYPE))
+        return VarType::Bool;
+    if (match(TokenType::INT_TYPE))
+        return VarType::Int;
+    throw ParseError("expected type (string, bool, or int)", current_.line,
+                     current_.column);
+}
+
+std::optional<ExprPtr> Parser::parse_when_clause() {
+    if (!match(TokenType::WHEN))
+        return std::nullopt;
+    return parseExpression();
+}
+
+std::optional<int> Parser::parse_mode_clause() {
+    if (!match(TokenType::MODE))
+        return std::nullopt;
+    Token tok = expect(TokenType::INTEGER_LITERAL,
+                       "expected octal integer after 'mode'");
+    return std::stoi(tok.value, nullptr, 8);
+}
+
+void Parser::expect_newline(const std::string &context) {
+    if (check(TokenType::EOF_TOKEN))
+        return;
+    expect(TokenType::NEWLINE, "expected newline after " + context);
+}
+
+// Statement parsers
+
+StmtPtr Parser::parseAsk() {
+    Token start = expect(TokenType::ASK, "expected 'ask'");
+    Token name = expect(TokenType::IDENTIFIER, "expected variable name after 'ask'");
+    Token prompt =
+        expect(TokenType::STRING_LITERAL, "expected prompt string after name");
+    VarType var_type = parse_var_type();
+    bool required = match(TokenType::REQUIRED);
+    auto when_clause = parse_when_clause();
+    expect_newline("ask statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    *stmt = AskStmt{name.value,         prompt.value,          var_type,
+                    required,            std::move(when_clause), start.line,
+                    start.column};
+    return stmt;
+}
+
+StmtPtr Parser::parseLet() {
+    Token start = expect(TokenType::LET, "expected 'let'");
+    Token name =
+        expect(TokenType::IDENTIFIER, "expected variable name after 'let'");
+    expect(TokenType::ASSIGN, "expected '=' after variable name");
+    auto value = parseExpression();
+    expect_newline("let statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    *stmt = LetStmt{name.value, std::move(value), start.line, start.column};
+    return stmt;
+}
+
+StmtPtr Parser::parseMkdir() {
+    Token start = expect(TokenType::MKDIR, "expected 'mkdir'");
+    Token path =
+        expect(TokenType::STRING_LITERAL, "expected path string after 'mkdir'");
+    auto mode = parse_mode_clause();
+    auto when_clause = parse_when_clause();
+    expect_newline("mkdir statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    *stmt = MkdirStmt{path.value, mode, std::move(when_clause), start.line,
+                      start.column};
+    return stmt;
+}
+
+StmtPtr Parser::parseFile() {
+    Token start = expect(TokenType::FILE, "expected 'file'");
+    Token path =
+        expect(TokenType::STRING_LITERAL, "expected path string after 'file'");
+
+    FileSource source = [&]() -> FileSource {
+        if (match(TokenType::FROM)) {
+            Token src = expect(TokenType::STRING_LITERAL,
+                               "expected source path after 'from'");
+            bool verbatim = match(TokenType::VERBATIM);
+            return FileFromSource{src.value, verbatim};
+        }
+        if (match(TokenType::CONTENT)) {
+            auto value = parseExpression();
+            return FileContentSource{std::move(value)};
+        }
+        throw ParseError("expected 'from' or 'content' after file path",
+                         current_.line, current_.column);
+    }();
+
+    auto mode = parse_mode_clause();
+    auto when_clause = parse_when_clause();
+    expect_newline("file statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    *stmt = FileStmt{path.value, std::move(source), mode,
+                     std::move(when_clause), start.line, start.column};
+    return stmt;
+}
+
 // Expression precedence: or < and < comparison < addition < multiplication <
 // unary < primary
 

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -4,18 +4,27 @@
 
 #include <gtest/gtest.h>
 
+using spudplate::AskStmt;
 using spudplate::BinaryExpr;
 using spudplate::Expr;
 using spudplate::ExprPtr;
+using spudplate::FileContentSource;
+using spudplate::FileFromSource;
+using spudplate::FileStmt;
 using spudplate::FunctionCallExpr;
 using spudplate::IdentifierExpr;
 using spudplate::IntegerLiteralExpr;
+using spudplate::LetStmt;
 using spudplate::Lexer;
+using spudplate::MkdirStmt;
 using spudplate::ParseError;
 using spudplate::Parser;
+using spudplate::Stmt;
+using spudplate::StmtPtr;
 using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
 using spudplate::UnaryExpr;
+using spudplate::VarType;
 
 static ExprPtr parse_expr(const std::string &input) {
     Lexer lexer(input);
@@ -177,4 +186,261 @@ TEST(ParserTest, ErrorUnexpectedToken) {
 
 TEST(ParserTest, ErrorMissingCloseParen) {
     EXPECT_THROW(parse_expr("(1 + 2"), ParseError);
+}
+
+// --- Statement parsing helpers ---
+
+static StmtPtr parse_ask(const std::string &input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseAsk();
+}
+
+static StmtPtr parse_let(const std::string &input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseLet();
+}
+
+static StmtPtr parse_mkdir(const std::string &input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseMkdir();
+}
+
+static StmtPtr parse_file(const std::string &input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseFile();
+}
+
+// --- Ask statement tests ---
+
+TEST(ParserTest, AskBasicString) {
+    auto stmt = parse_ask("ask name \"What is your name?\" string\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    EXPECT_EQ(ask.name, "name");
+    EXPECT_EQ(ask.prompt, "What is your name?");
+    EXPECT_EQ(ask.var_type, VarType::String);
+    EXPECT_FALSE(ask.required);
+    EXPECT_FALSE(ask.when_clause.has_value());
+    EXPECT_EQ(ask.line, 1);
+}
+
+TEST(ParserTest, AskBoolType) {
+    auto stmt = parse_ask("ask use_ci \"Enable CI?\" bool\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    EXPECT_EQ(ask.var_type, VarType::Bool);
+}
+
+TEST(ParserTest, AskIntType) {
+    auto stmt = parse_ask("ask count \"How many?\" int\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    EXPECT_EQ(ask.var_type, VarType::Int);
+}
+
+TEST(ParserTest, AskRequired) {
+    auto stmt = parse_ask("ask name \"Name?\" string required\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    EXPECT_TRUE(ask.required);
+}
+
+TEST(ParserTest, AskWhenClause) {
+    auto stmt = parse_ask("ask port \"Port?\" int when use_server\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    ASSERT_TRUE(ask.when_clause.has_value());
+    auto &cond = std::get<IdentifierExpr>((*ask.when_clause)->data);
+    EXPECT_EQ(cond.name, "use_server");
+}
+
+TEST(ParserTest, AskRequiredAndWhen) {
+    auto stmt = parse_ask("ask port \"Port?\" int required when use_server\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    EXPECT_TRUE(ask.required);
+    ASSERT_TRUE(ask.when_clause.has_value());
+}
+
+TEST(ParserTest, AskWhenExpression) {
+    auto stmt = parse_ask("ask x \"X?\" string when a and b\n");
+    auto &ask = std::get<AskStmt>(*stmt);
+    ASSERT_TRUE(ask.when_clause.has_value());
+    auto &bin = std::get<BinaryExpr>((*ask.when_clause)->data);
+    EXPECT_EQ(bin.op, TokenType::AND);
+}
+
+TEST(ParserTest, AskAtEof) {
+    auto stmt = parse_ask("ask name \"Name?\" string");
+    auto &ask = std::get<AskStmt>(*stmt);
+    EXPECT_EQ(ask.name, "name");
+}
+
+TEST(ParserTest, AskMissingName) {
+    EXPECT_THROW(parse_ask("ask \"prompt\" string\n"), ParseError);
+}
+
+TEST(ParserTest, AskMissingPrompt) {
+    EXPECT_THROW(parse_ask("ask name string\n"), ParseError);
+}
+
+TEST(ParserTest, AskMissingType) {
+    EXPECT_THROW(parse_ask("ask name \"prompt\"\n"), ParseError);
+}
+
+// --- Let statement tests ---
+
+TEST(ParserTest, LetBasic) {
+    auto stmt = parse_let("let x = 42\n");
+    auto &let = std::get<LetStmt>(*stmt);
+    EXPECT_EQ(let.name, "x");
+    auto &val = std::get<IntegerLiteralExpr>(let.value->data);
+    EXPECT_EQ(val.value, 42);
+}
+
+TEST(ParserTest, LetStringExpression) {
+    auto stmt = parse_let("let greeting = \"hello\" + name\n");
+    auto &let = std::get<LetStmt>(*stmt);
+    EXPECT_EQ(let.name, "greeting");
+    auto &bin = std::get<BinaryExpr>(let.value->data);
+    EXPECT_EQ(bin.op, TokenType::PLUS);
+}
+
+TEST(ParserTest, LetFunctionCall) {
+    auto stmt = parse_let("let lower_name = lower(name)\n");
+    auto &let = std::get<LetStmt>(*stmt);
+    auto &call = std::get<FunctionCallExpr>(let.value->data);
+    EXPECT_EQ(call.name, "lower");
+}
+
+TEST(ParserTest, LetAtEof) {
+    auto stmt = parse_let("let x = 1");
+    auto &let = std::get<LetStmt>(*stmt);
+    EXPECT_EQ(let.name, "x");
+}
+
+TEST(ParserTest, LetMissingAssign) {
+    EXPECT_THROW(parse_let("let x 42\n"), ParseError);
+}
+
+TEST(ParserTest, LetMissingName) {
+    EXPECT_THROW(parse_let("let = 42\n"), ParseError);
+}
+
+// --- Mkdir statement tests ---
+
+TEST(ParserTest, MkdirBasic) {
+    auto stmt = parse_mkdir("mkdir \"src\"\n");
+    auto &mk = std::get<MkdirStmt>(*stmt);
+    EXPECT_EQ(mk.path, "src");
+    EXPECT_FALSE(mk.mode.has_value());
+    EXPECT_FALSE(mk.when_clause.has_value());
+}
+
+TEST(ParserTest, MkdirWithMode) {
+    auto stmt = parse_mkdir("mkdir \"bin\" mode 0755\n");
+    auto &mk = std::get<MkdirStmt>(*stmt);
+    EXPECT_EQ(mk.path, "bin");
+    ASSERT_TRUE(mk.mode.has_value());
+    EXPECT_EQ(*mk.mode, 0755);
+}
+
+TEST(ParserTest, MkdirWithWhen) {
+    auto stmt = parse_mkdir("mkdir \"tests\" when use_tests\n");
+    auto &mk = std::get<MkdirStmt>(*stmt);
+    ASSERT_TRUE(mk.when_clause.has_value());
+    auto &cond = std::get<IdentifierExpr>((*mk.when_clause)->data);
+    EXPECT_EQ(cond.name, "use_tests");
+}
+
+TEST(ParserTest, MkdirWithModeAndWhen) {
+    auto stmt = parse_mkdir("mkdir \"bin\" mode 0755 when need_bin\n");
+    auto &mk = std::get<MkdirStmt>(*stmt);
+    ASSERT_TRUE(mk.mode.has_value());
+    EXPECT_EQ(*mk.mode, 0755);
+    ASSERT_TRUE(mk.when_clause.has_value());
+}
+
+TEST(ParserTest, MkdirAtEof) {
+    auto stmt = parse_mkdir("mkdir \"src\"");
+    auto &mk = std::get<MkdirStmt>(*stmt);
+    EXPECT_EQ(mk.path, "src");
+}
+
+TEST(ParserTest, MkdirMissingPath) {
+    EXPECT_THROW(parse_mkdir("mkdir\n"), ParseError);
+}
+
+// --- File statement tests ---
+
+TEST(ParserTest, FileFromBasic) {
+    auto stmt = parse_file("file \"out.txt\" from \"template.txt\"\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    EXPECT_EQ(file.path, "out.txt");
+    auto &src = std::get<FileFromSource>(file.source);
+    EXPECT_EQ(src.path, "template.txt");
+    EXPECT_FALSE(src.verbatim);
+}
+
+TEST(ParserTest, FileFromVerbatim) {
+    auto stmt = parse_file("file \"out.c\" from \"main.c\" verbatim\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    auto &src = std::get<FileFromSource>(file.source);
+    EXPECT_TRUE(src.verbatim);
+}
+
+TEST(ParserTest, FileContentExpression) {
+    auto stmt = parse_file("file \"readme.md\" content \"# \" + name\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    auto &src = std::get<FileContentSource>(file.source);
+    auto &bin = std::get<BinaryExpr>(src.value->data);
+    EXPECT_EQ(bin.op, TokenType::PLUS);
+}
+
+TEST(ParserTest, FileWithMode) {
+    auto stmt = parse_file("file \"run.sh\" from \"run.sh\" mode 0755\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    ASSERT_TRUE(file.mode.has_value());
+    EXPECT_EQ(*file.mode, 0755);
+}
+
+TEST(ParserTest, FileWithWhen) {
+    auto stmt = parse_file("file \"ci.yml\" from \"ci.yml\" when use_ci\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    ASSERT_TRUE(file.when_clause.has_value());
+}
+
+TEST(ParserTest, FileFromVerbatimModeWhen) {
+    auto stmt = parse_file(
+        "file \"main.c\" from \"main.c\" verbatim mode 0644 when need_c\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    auto &src = std::get<FileFromSource>(file.source);
+    EXPECT_TRUE(src.verbatim);
+    ASSERT_TRUE(file.mode.has_value());
+    EXPECT_EQ(*file.mode, 0644);
+    ASSERT_TRUE(file.when_clause.has_value());
+}
+
+TEST(ParserTest, FileContentWithMode) {
+    auto stmt = parse_file("file \"x\" content \"data\" mode 0444\n");
+    auto &file = std::get<FileStmt>(*stmt);
+    std::get<FileContentSource>(file.source);
+    ASSERT_TRUE(file.mode.has_value());
+    EXPECT_EQ(*file.mode, 0444);
+}
+
+TEST(ParserTest, FileAtEof) {
+    auto stmt = parse_file("file \"out.txt\" from \"in.txt\"");
+    auto &file = std::get<FileStmt>(*stmt);
+    EXPECT_EQ(file.path, "out.txt");
+}
+
+TEST(ParserTest, FileMissingSource) {
+    EXPECT_THROW(parse_file("file \"out.txt\"\n"), ParseError);
+}
+
+TEST(ParserTest, FileMissingPath) {
+    EXPECT_THROW(parse_file("file\n"), ParseError);
+}
+
+TEST(ParserTest, FileFromMissingSourcePath) {
+    EXPECT_THROW(parse_file("file \"out.txt\" from\n"), ParseError);
 }


### PR DESCRIPTION
## Summary
Add statement parsing with optional statement clauses/modifiers

## Changes                                     
- Add statement AST node types: `AskStmt`, `LetStmt`, `MkdirStmt`, `FileStmt`, plus `VarType` enum and `FileSource`                               
- Add `parseAsk()`, `parseLet()`, `parseMkdir()`, `parseFile()` parser methods with helpers for when/mode clauses                                
- Add 34 tests covering basic forms, all optional combinations, and error cases    

## Test plan
- All 97 (34 new) tests pass locally             
- Each statement type tested in basic form, with all optional parts, and with missing required tokens      
