### PR TITLE
 feat(parser): add repeat blocks and full program parsing

### DIFF
--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -114,16 +114,28 @@ struct FileStmt {
     int column;
 };
 
-// Forward declare RepeatStmt — defined in branch 3
-struct RepeatStmt;
-
-// Stmt variant and pointer type
-using Stmt =
-    std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt>;
+// Forward declare Stmt so RepeatStmt can hold a vector of them
+struct Stmt;
 using StmtPtr = std::unique_ptr<Stmt>;
 
+struct RepeatStmt {
+    std::string collection_var;
+    std::string iterator_var;
+    std::vector<StmtPtr> body;
+    int line;
+    int column;
+};
+
+// Stmt variant and pointer type
+using StmtData =
+    std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt>;
+
+struct Stmt {
+    StmtData data;
+};
+
 struct Program {
-    // Populated in branch 3
+    std::vector<StmtPtr> statements;
 };
 
 } // namespace spudplate

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -26,12 +26,16 @@ class Parser {
   public:
     explicit Parser(Lexer lexer);
 
+    Program parse();
+
     ExprPtr parseExpression();
 
     StmtPtr parseAsk();
     StmtPtr parseLet();
     StmtPtr parseMkdir();
     StmtPtr parseFile();
+    StmtPtr parseRepeat();
+    StmtPtr parseStatement();
 
   private:
     Lexer lexer_;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -81,7 +81,7 @@ StmtPtr Parser::parseAsk() {
     expect_newline("ask statement");
 
     auto stmt = std::make_unique<Stmt>();
-    *stmt = AskStmt{name.value,         prompt.value,          var_type,
+    stmt->data = AskStmt{name.value,         prompt.value,          var_type,
                     required,            std::move(when_clause), start.line,
                     start.column};
     return stmt;
@@ -96,7 +96,7 @@ StmtPtr Parser::parseLet() {
     expect_newline("let statement");
 
     auto stmt = std::make_unique<Stmt>();
-    *stmt = LetStmt{name.value, std::move(value), start.line, start.column};
+    stmt->data = LetStmt{name.value, std::move(value), start.line, start.column};
     return stmt;
 }
 
@@ -109,7 +109,7 @@ StmtPtr Parser::parseMkdir() {
     expect_newline("mkdir statement");
 
     auto stmt = std::make_unique<Stmt>();
-    *stmt = MkdirStmt{path.value, mode, std::move(when_clause), start.line,
+    stmt->data = MkdirStmt{path.value, mode, std::move(when_clause), start.line,
                       start.column};
     return stmt;
 }
@@ -139,7 +139,7 @@ StmtPtr Parser::parseFile() {
     expect_newline("file statement");
 
     auto stmt = std::make_unique<Stmt>();
-    *stmt = FileStmt{path.value, std::move(source), mode,
+    stmt->data = FileStmt{path.value, std::move(source), mode,
                      std::move(when_clause), start.line, start.column};
     return stmt;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -144,6 +144,62 @@ StmtPtr Parser::parseFile() {
     return stmt;
 }
 
+// Repeat block parser
+
+StmtPtr Parser::parseRepeat() {
+    Token start = expect(TokenType::REPEAT, "expected 'repeat'");
+    Token collection =
+        expect(TokenType::IDENTIFIER, "expected collection variable after 'repeat'");
+    expect(TokenType::AS, "expected 'as' after collection variable");
+    Token iterator =
+        expect(TokenType::IDENTIFIER, "expected iterator variable after 'as'");
+    expect_newline("repeat header");
+
+    std::vector<StmtPtr> body;
+    skip_newlines();
+    while (!check(TokenType::END) && !check(TokenType::EOF_TOKEN)) {
+        body.push_back(parseStatement());
+        skip_newlines();
+    }
+
+    expect(TokenType::END, "expected 'end' to close repeat block");
+    expect_newline("repeat block");
+
+    auto stmt = std::make_unique<Stmt>();
+    stmt->data = RepeatStmt{collection.value, iterator.value, std::move(body),
+                            start.line, start.column};
+    return stmt;
+}
+
+// Statement dispatch
+
+StmtPtr Parser::parseStatement() {
+    if (check(TokenType::ASK))
+        return parseAsk();
+    if (check(TokenType::LET))
+        return parseLet();
+    if (check(TokenType::MKDIR))
+        return parseMkdir();
+    if (check(TokenType::FILE))
+        return parseFile();
+    if (check(TokenType::REPEAT))
+        return parseRepeat();
+    throw ParseError("unexpected token: " + current_.value, current_.line,
+                     current_.column);
+}
+
+// Full program parser
+
+Program Parser::parse() {
+    Program program;
+    skip_newlines();
+    while (!check(TokenType::EOF_TOKEN)) {
+        program.statements.push_back(parseStatement());
+        skip_newlines();
+    }
+    return program;
+}
+
 // Expression precedence: or < and < comparison < addition < multiplication <
 // unary < primary
 

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -18,6 +18,8 @@ using spudplate::Lexer;
 using spudplate::MkdirStmt;
 using spudplate::ParseError;
 using spudplate::Parser;
+using spudplate::Program;
+using spudplate::RepeatStmt;
 using spudplate::StmtPtr;
 using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
@@ -441,4 +443,131 @@ TEST(ParserTest, FileMissingPath) {
 
 TEST(ParserTest, FileFromMissingSourcePath) {
     EXPECT_THROW(parse_file("file \"out.txt\" from\n"), ParseError);
+}
+
+// --- Repeat and program parsing helpers ---
+
+static Program parse_program(const std::string &input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parse();
+}
+
+// --- Program parsing tests ---
+
+TEST(ParserTest, SingleStatementProgram) {
+    auto program = parse_program("ask name \"Name?\" string\n");
+    ASSERT_EQ(program.statements.size(), 1);
+    auto &ask = std::get<AskStmt>(program.statements[0]->data);
+    EXPECT_EQ(ask.name, "name");
+}
+
+TEST(ParserTest, MultiStatementWithBlankLinesAndComments) {
+    auto program = parse_program(
+        "# A comment\n"
+        "\n"
+        "ask name \"Name?\" string\n"
+        "\n"
+        "# Another comment\n"
+        "let lower_name = lower(name)\n"
+        "\n"
+        "mkdir \"src\"\n");
+    ASSERT_EQ(program.statements.size(), 3);
+    std::get<AskStmt>(program.statements[0]->data);
+    std::get<LetStmt>(program.statements[1]->data);
+    std::get<MkdirStmt>(program.statements[2]->data);
+}
+
+// --- Repeat block tests ---
+
+TEST(ParserTest, RepeatBasic) {
+    auto program = parse_program(
+        "repeat items as item\n"
+        "  mkdir \"dir\"\n"
+        "end\n");
+    ASSERT_EQ(program.statements.size(), 1);
+    auto &rep = std::get<RepeatStmt>(program.statements[0]->data);
+    EXPECT_EQ(rep.collection_var, "items");
+    EXPECT_EQ(rep.iterator_var, "item");
+    ASSERT_EQ(rep.body.size(), 1);
+    std::get<MkdirStmt>(rep.body[0]->data);
+}
+
+TEST(ParserTest, RepeatMultipleBodyStatements) {
+    auto program = parse_program(
+        "repeat modules as mod\n"
+        "  mkdir \"src\"\n"
+        "  file \"main.c\" from \"template.c\"\n"
+        "  let x = 1\n"
+        "end\n");
+    ASSERT_EQ(program.statements.size(), 1);
+    auto &rep = std::get<RepeatStmt>(program.statements[0]->data);
+    ASSERT_EQ(rep.body.size(), 3);
+    std::get<MkdirStmt>(rep.body[0]->data);
+    std::get<FileStmt>(rep.body[1]->data);
+    std::get<LetStmt>(rep.body[2]->data);
+}
+
+TEST(ParserTest, RepeatNested) {
+    auto program = parse_program(
+        "repeat outer as o\n"
+        "  repeat inner as i\n"
+        "    mkdir \"dir\"\n"
+        "  end\n"
+        "end\n");
+    ASSERT_EQ(program.statements.size(), 1);
+    auto &outer = std::get<RepeatStmt>(program.statements[0]->data);
+    ASSERT_EQ(outer.body.size(), 1);
+    auto &inner = std::get<RepeatStmt>(outer.body[0]->data);
+    EXPECT_EQ(inner.collection_var, "inner");
+    EXPECT_EQ(inner.iterator_var, "i");
+    ASSERT_EQ(inner.body.size(), 1);
+    std::get<MkdirStmt>(inner.body[0]->data);
+}
+
+// --- Full integration test ---
+
+TEST(ParserTest, FullSpudFile) {
+    auto program = parse_program(
+        "# Project scaffolding\n"
+        "\n"
+        "ask name \"Project name?\" string required\n"
+        "ask use_ci \"Enable CI?\" bool\n"
+        "ask num_modules \"How many modules?\" int\n"
+        "\n"
+        "let lower_name = lower(name)\n"
+        "\n"
+        "mkdir \"src\"\n"
+        "mkdir \"tests\" when use_ci\n"
+        "\n"
+        "file \"README.md\" content \"# \" + name\n"
+        "file \"main.c\" from \"templates/main.c\" mode 0644\n"
+        "\n"
+        "repeat modules as mod\n"
+        "  mkdir \"src\"\n"
+        "  file \"mod.c\" from \"templates/mod.c\"\n"
+        "end\n");
+    ASSERT_EQ(program.statements.size(), 9);
+    std::get<AskStmt>(program.statements[0]->data);
+    std::get<AskStmt>(program.statements[1]->data);
+    std::get<AskStmt>(program.statements[2]->data);
+    std::get<LetStmt>(program.statements[3]->data);
+    std::get<MkdirStmt>(program.statements[4]->data);
+    std::get<MkdirStmt>(program.statements[5]->data);
+    std::get<FileStmt>(program.statements[6]->data);
+    std::get<FileStmt>(program.statements[7]->data);
+    auto &rep = std::get<RepeatStmt>(program.statements[8]->data);
+    ASSERT_EQ(rep.body.size(), 2);
+}
+
+// --- Error tests ---
+
+TEST(ParserTest, RepeatWithoutEnd) {
+    EXPECT_THROW(parse_program(
+        "repeat items as item\n"
+        "  mkdir \"dir\"\n"), ParseError);
+}
+
+TEST(ParserTest, UnexpectedTokenAtTopLevel) {
+    EXPECT_THROW(parse_program("42\n"), ParseError);
 }

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -6,7 +6,6 @@
 
 using spudplate::AskStmt;
 using spudplate::BinaryExpr;
-using spudplate::Expr;
 using spudplate::ExprPtr;
 using spudplate::FileContentSource;
 using spudplate::FileFromSource;
@@ -19,7 +18,6 @@ using spudplate::Lexer;
 using spudplate::MkdirStmt;
 using spudplate::ParseError;
 using spudplate::Parser;
-using spudplate::Stmt;
 using spudplate::StmtPtr;
 using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
@@ -218,7 +216,7 @@ static StmtPtr parse_file(const std::string &input) {
 
 TEST(ParserTest, AskBasicString) {
     auto stmt = parse_ask("ask name \"What is your name?\" string\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.name, "name");
     EXPECT_EQ(ask.prompt, "What is your name?");
     EXPECT_EQ(ask.var_type, VarType::String);
@@ -229,25 +227,25 @@ TEST(ParserTest, AskBasicString) {
 
 TEST(ParserTest, AskBoolType) {
     auto stmt = parse_ask("ask use_ci \"Enable CI?\" bool\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.var_type, VarType::Bool);
 }
 
 TEST(ParserTest, AskIntType) {
     auto stmt = parse_ask("ask count \"How many?\" int\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.var_type, VarType::Int);
 }
 
 TEST(ParserTest, AskRequired) {
     auto stmt = parse_ask("ask name \"Name?\" string required\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     EXPECT_TRUE(ask.required);
 }
 
 TEST(ParserTest, AskWhenClause) {
     auto stmt = parse_ask("ask port \"Port?\" int when use_server\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     ASSERT_TRUE(ask.when_clause.has_value());
     auto &cond = std::get<IdentifierExpr>((*ask.when_clause)->data);
     EXPECT_EQ(cond.name, "use_server");
@@ -255,14 +253,14 @@ TEST(ParserTest, AskWhenClause) {
 
 TEST(ParserTest, AskRequiredAndWhen) {
     auto stmt = parse_ask("ask port \"Port?\" int required when use_server\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     EXPECT_TRUE(ask.required);
     ASSERT_TRUE(ask.when_clause.has_value());
 }
 
 TEST(ParserTest, AskWhenExpression) {
     auto stmt = parse_ask("ask x \"X?\" string when a and b\n");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     ASSERT_TRUE(ask.when_clause.has_value());
     auto &bin = std::get<BinaryExpr>((*ask.when_clause)->data);
     EXPECT_EQ(bin.op, TokenType::AND);
@@ -270,7 +268,7 @@ TEST(ParserTest, AskWhenExpression) {
 
 TEST(ParserTest, AskAtEof) {
     auto stmt = parse_ask("ask name \"Name?\" string");
-    auto &ask = std::get<AskStmt>(*stmt);
+    auto &ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.name, "name");
 }
 
@@ -290,7 +288,7 @@ TEST(ParserTest, AskMissingType) {
 
 TEST(ParserTest, LetBasic) {
     auto stmt = parse_let("let x = 42\n");
-    auto &let = std::get<LetStmt>(*stmt);
+    auto &let = std::get<LetStmt>(stmt->data);
     EXPECT_EQ(let.name, "x");
     auto &val = std::get<IntegerLiteralExpr>(let.value->data);
     EXPECT_EQ(val.value, 42);
@@ -298,7 +296,7 @@ TEST(ParserTest, LetBasic) {
 
 TEST(ParserTest, LetStringExpression) {
     auto stmt = parse_let("let greeting = \"hello\" + name\n");
-    auto &let = std::get<LetStmt>(*stmt);
+    auto &let = std::get<LetStmt>(stmt->data);
     EXPECT_EQ(let.name, "greeting");
     auto &bin = std::get<BinaryExpr>(let.value->data);
     EXPECT_EQ(bin.op, TokenType::PLUS);
@@ -306,14 +304,14 @@ TEST(ParserTest, LetStringExpression) {
 
 TEST(ParserTest, LetFunctionCall) {
     auto stmt = parse_let("let lower_name = lower(name)\n");
-    auto &let = std::get<LetStmt>(*stmt);
+    auto &let = std::get<LetStmt>(stmt->data);
     auto &call = std::get<FunctionCallExpr>(let.value->data);
     EXPECT_EQ(call.name, "lower");
 }
 
 TEST(ParserTest, LetAtEof) {
     auto stmt = parse_let("let x = 1");
-    auto &let = std::get<LetStmt>(*stmt);
+    auto &let = std::get<LetStmt>(stmt->data);
     EXPECT_EQ(let.name, "x");
 }
 
@@ -329,7 +327,7 @@ TEST(ParserTest, LetMissingName) {
 
 TEST(ParserTest, MkdirBasic) {
     auto stmt = parse_mkdir("mkdir \"src\"\n");
-    auto &mk = std::get<MkdirStmt>(*stmt);
+    auto &mk = std::get<MkdirStmt>(stmt->data);
     EXPECT_EQ(mk.path, "src");
     EXPECT_FALSE(mk.mode.has_value());
     EXPECT_FALSE(mk.when_clause.has_value());
@@ -337,7 +335,7 @@ TEST(ParserTest, MkdirBasic) {
 
 TEST(ParserTest, MkdirWithMode) {
     auto stmt = parse_mkdir("mkdir \"bin\" mode 0755\n");
-    auto &mk = std::get<MkdirStmt>(*stmt);
+    auto &mk = std::get<MkdirStmt>(stmt->data);
     EXPECT_EQ(mk.path, "bin");
     ASSERT_TRUE(mk.mode.has_value());
     EXPECT_EQ(*mk.mode, 0755);
@@ -345,7 +343,7 @@ TEST(ParserTest, MkdirWithMode) {
 
 TEST(ParserTest, MkdirWithWhen) {
     auto stmt = parse_mkdir("mkdir \"tests\" when use_tests\n");
-    auto &mk = std::get<MkdirStmt>(*stmt);
+    auto &mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_TRUE(mk.when_clause.has_value());
     auto &cond = std::get<IdentifierExpr>((*mk.when_clause)->data);
     EXPECT_EQ(cond.name, "use_tests");
@@ -353,7 +351,7 @@ TEST(ParserTest, MkdirWithWhen) {
 
 TEST(ParserTest, MkdirWithModeAndWhen) {
     auto stmt = parse_mkdir("mkdir \"bin\" mode 0755 when need_bin\n");
-    auto &mk = std::get<MkdirStmt>(*stmt);
+    auto &mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_TRUE(mk.mode.has_value());
     EXPECT_EQ(*mk.mode, 0755);
     ASSERT_TRUE(mk.when_clause.has_value());
@@ -361,7 +359,7 @@ TEST(ParserTest, MkdirWithModeAndWhen) {
 
 TEST(ParserTest, MkdirAtEof) {
     auto stmt = parse_mkdir("mkdir \"src\"");
-    auto &mk = std::get<MkdirStmt>(*stmt);
+    auto &mk = std::get<MkdirStmt>(stmt->data);
     EXPECT_EQ(mk.path, "src");
 }
 
@@ -373,7 +371,7 @@ TEST(ParserTest, MkdirMissingPath) {
 
 TEST(ParserTest, FileFromBasic) {
     auto stmt = parse_file("file \"out.txt\" from \"template.txt\"\n");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     EXPECT_EQ(file.path, "out.txt");
     auto &src = std::get<FileFromSource>(file.source);
     EXPECT_EQ(src.path, "template.txt");
@@ -382,14 +380,14 @@ TEST(ParserTest, FileFromBasic) {
 
 TEST(ParserTest, FileFromVerbatim) {
     auto stmt = parse_file("file \"out.c\" from \"main.c\" verbatim\n");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     auto &src = std::get<FileFromSource>(file.source);
     EXPECT_TRUE(src.verbatim);
 }
 
 TEST(ParserTest, FileContentExpression) {
     auto stmt = parse_file("file \"readme.md\" content \"# \" + name\n");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     auto &src = std::get<FileContentSource>(file.source);
     auto &bin = std::get<BinaryExpr>(src.value->data);
     EXPECT_EQ(bin.op, TokenType::PLUS);
@@ -397,21 +395,21 @@ TEST(ParserTest, FileContentExpression) {
 
 TEST(ParserTest, FileWithMode) {
     auto stmt = parse_file("file \"run.sh\" from \"run.sh\" mode 0755\n");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0755);
 }
 
 TEST(ParserTest, FileWithWhen) {
     auto stmt = parse_file("file \"ci.yml\" from \"ci.yml\" when use_ci\n");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     ASSERT_TRUE(file.when_clause.has_value());
 }
 
 TEST(ParserTest, FileFromVerbatimModeWhen) {
     auto stmt = parse_file(
         "file \"main.c\" from \"main.c\" verbatim mode 0644 when need_c\n");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     auto &src = std::get<FileFromSource>(file.source);
     EXPECT_TRUE(src.verbatim);
     ASSERT_TRUE(file.mode.has_value());
@@ -421,15 +419,15 @@ TEST(ParserTest, FileFromVerbatimModeWhen) {
 
 TEST(ParserTest, FileContentWithMode) {
     auto stmt = parse_file("file \"x\" content \"data\" mode 0444\n");
-    auto &file = std::get<FileStmt>(*stmt);
-    std::get<FileContentSource>(file.source);
+    auto &file = std::get<FileStmt>(stmt->data);
+    std::get<FileContentSource>(file.source); // NOLINT
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0444);
 }
 
 TEST(ParserTest, FileAtEof) {
     auto stmt = parse_file("file \"out.txt\" from \"in.txt\"");
-    auto &file = std::get<FileStmt>(*stmt);
+    auto &file = std::get<FileStmt>(stmt->data);
     EXPECT_EQ(file.path, "out.txt");
 }
 


### PR DESCRIPTION
## Summary
Add repeat block parsing and full program-level parser. Parser now complete! 

## Changes
- Define `RepeatStmt`, introduce `StmtData` variant and `Stmt` struct, populate `Program` with `std::vector<StmtPtr>`  
- Add `parse()`, `parseRepeat()`, `parseStatement()` methods                                      
- 8 new tests 

## Test plan
- All 105 (8 new) tests pass locally                            
- Repeat blocks tested
- Error cases such as repeat without end, unexpected token at top level tested
