### PR TITLE
feat(parser): add file append support

### DIFF
--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -108,6 +108,7 @@ struct MkdirStmt {
 struct FileStmt {
     std::string path;
     FileSource source;
+    bool append;
     std::optional<int> mode;
     std::optional<ExprPtr> when_clause;
     int line;

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -18,6 +18,7 @@ enum class TokenType {
     END,
     REQUIRED,
     VERBATIM,
+    APPEND,
     MODE,
     AS,
 
@@ -88,6 +89,7 @@ inline std::string tokenTypeToString(TokenType type) {
     case TokenType::END: return "END";
     case TokenType::REQUIRED: return "REQUIRED";
     case TokenType::VERBATIM: return "VERBATIM";
+    case TokenType::APPEND: return "APPEND";
     case TokenType::MODE: return "MODE";
     case TokenType::AS: return "AS";
     case TokenType::AND: return "AND";

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -16,6 +16,7 @@ static const std::unordered_map<std::string, TokenType> keywords = {
     {"end", TokenType::END},
     {"required", TokenType::REQUIRED},
     {"verbatim", TokenType::VERBATIM},
+    {"append", TokenType::APPEND},
     {"mode", TokenType::MODE},
     {"as", TokenType::AS},
     {"and", TokenType::AND},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -119,6 +119,8 @@ StmtPtr Parser::parseFile() {
     Token path =
         expect(TokenType::STRING_LITERAL, "expected path string after 'file'");
 
+    bool append = match(TokenType::APPEND);
+
     FileSource source = [&]() -> FileSource {
         if (match(TokenType::FROM)) {
             Token src = expect(TokenType::STRING_LITERAL,
@@ -139,7 +141,7 @@ StmtPtr Parser::parseFile() {
     expect_newline("file statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = FileStmt{path.value, std::move(source), mode,
+    stmt->data = FileStmt{path.value, std::move(source), append, mode,
                      std::move(when_clause), start.line, start.column};
     return stmt;
 }

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -375,6 +375,7 @@ TEST(ParserTest, FileFromBasic) {
     auto stmt = parse_file("file \"out.txt\" from \"template.txt\"\n");
     auto &file = std::get<FileStmt>(stmt->data);
     EXPECT_EQ(file.path, "out.txt");
+    EXPECT_FALSE(file.append);
     auto &src = std::get<FileFromSource>(file.source);
     EXPECT_EQ(src.path, "template.txt");
     EXPECT_FALSE(src.verbatim);
@@ -443,6 +444,53 @@ TEST(ParserTest, FileMissingPath) {
 
 TEST(ParserTest, FileFromMissingSourcePath) {
     EXPECT_THROW(parse_file("file \"out.txt\" from\n"), ParseError);
+}
+
+// --- Append tests ---
+
+TEST(ParserTest, FileAppendFrom) {
+    auto stmt = parse_file("file \"log.txt\" append from \"entry.txt\"\n");
+    auto &file = std::get<FileStmt>(stmt->data);
+    EXPECT_EQ(file.path, "log.txt");
+    EXPECT_TRUE(file.append);
+    auto &src = std::get<FileFromSource>(file.source);
+    EXPECT_EQ(src.path, "entry.txt");
+    EXPECT_FALSE(src.verbatim);
+}
+
+TEST(ParserTest, FileAppendContent) {
+    auto stmt = parse_file("file \"log.txt\" append content \"new line\"\n");
+    auto &file = std::get<FileStmt>(stmt->data);
+    EXPECT_TRUE(file.append);
+    auto &src = std::get<FileContentSource>(file.source);
+    auto &lit = std::get<StringLiteralExpr>(src.value->data);
+    EXPECT_EQ(lit.value, "new line");
+}
+
+TEST(ParserTest, FileAppendFromVerbatim) {
+    auto stmt = parse_file("file \"out\" append from \"src\" verbatim\n");
+    auto &file = std::get<FileStmt>(stmt->data);
+    EXPECT_TRUE(file.append);
+    auto &src = std::get<FileFromSource>(file.source);
+    EXPECT_TRUE(src.verbatim);
+}
+
+TEST(ParserTest, FileAppendFromModeWhen) {
+    auto stmt = parse_file(
+        "file \"out\" append from \"src\" mode 0644 when active\n");
+    auto &file = std::get<FileStmt>(stmt->data);
+    EXPECT_TRUE(file.append);
+    auto &src = std::get<FileFromSource>(file.source);
+    EXPECT_EQ(src.path, "src");
+    ASSERT_TRUE(file.mode.has_value());
+    EXPECT_EQ(*file.mode, 0644);
+    ASSERT_TRUE(file.when_clause.has_value());
+}
+
+TEST(ParserTest, FileWithoutAppendDefaultsFalse) {
+    auto stmt = parse_file("file \"out\" from \"src\"\n");
+    auto &file = std::get<FileStmt>(stmt->data);
+    EXPECT_FALSE(file.append);
 }
 
 // --- Repeat and program parsing helpers ---


### PR DESCRIPTION
## Summary
Add `append` keyword to file statements, allowing content to be appended instead of overwriting.                               
                                                                
## Changes                                        
- Add `APPEND` token to lexer (token type, string conversion, keyword mapping)                                                
- Add `append` bool field to `FileStmt` AST node                
- Parse optional `append` keyword before `from`/`content` in `parseFile()`                                                   
            
## Test plan                                                    
- All 110 (5 new) tests pass locally                            
- Tested: `file "path" append from "source"`, `file "path" append content expr`, append with verbatim, append with mode+when, default false without append                         
                                               