### PR TITLE
docs: license, syntax reference and Doxygen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ Testing/
 # Claude files
 .claude/
 CLAUDE.md
+
+# Doxygen generated html documentation 
+docs/html/
+
+# Apple tracking files
+*/.DS_Store
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,14 @@ add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)
+
+# Documentation
+find_package(Doxygen OPTIONAL_COMPONENTS dot)
+if(DOXYGEN_FOUND)
+    add_custom_target(docs
+        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Doxyfile
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Generating API documentation with Doxygen"
+        VERBATIM
+    )
+endif()

--- a/Doxyfile
+++ b/Doxyfile
@@ -5,7 +5,8 @@ PROJECT_NUMBER         =
 OUTPUT_DIRECTORY       = docs
 CREATE_SUBDIRS         = NO
 
-INPUT                  = include src
+INPUT                  = include src docs/syntax.md
+USE_MDFILE_AS_MAINPAGE = docs/syntax.md
 FILE_PATTERNS          = *.h *.cpp
 RECURSIVE              = YES
 
@@ -15,7 +16,6 @@ EXTRACT_STATIC         = YES
 
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
-HTML_TIMESTAMP         = NO
 
 GENERATE_LATEX         = NO
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -1,0 +1,38 @@
+PROJECT_NAME           = "spudplate"
+PROJECT_BRIEF          = "Template scaffolding compiler for spudlang .spud files"
+PROJECT_NUMBER         =
+
+OUTPUT_DIRECTORY       = docs
+CREATE_SUBDIRS         = NO
+
+INPUT                  = include src
+FILE_PATTERNS          = *.h *.cpp
+RECURSIVE              = YES
+
+EXTRACT_ALL            = NO
+EXTRACT_PRIVATE        = NO
+EXTRACT_STATIC         = YES
+
+GENERATE_HTML          = YES
+HTML_OUTPUT            = html
+HTML_TIMESTAMP         = NO
+
+GENERATE_LATEX         = NO
+
+QUIET                  = YES
+WARNINGS               = YES
+WARN_IF_UNDOCUMENTED   = YES
+
+JAVADOC_AUTOBRIEF      = YES
+QT_AUTOBRIEF           = NO
+
+SHOW_INCLUDE_FILES     = YES
+SHOW_USED_FILES        = NO
+SHOW_FILES             = YES
+
+SORT_MEMBER_DOCS       = NO
+
+SOURCE_BROWSER         = NO
+INLINE_SOURCES         = NO
+
+HAVE_DOT               = NO

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 spuddydev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ cmake -B build && cmake --build build
 ```bash
 ctest --test-dir build
 ```
+
+## Docs
+
+Requires [Doxygen](https://www.doxygen.nl/) (`brew install doxygen`).
+
+```bash
+cmake --build build --target docs
+```
+
+Opens `docs/html/index.html` — includes the full spudlang syntax reference and API documentation.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -1,0 +1,229 @@
+# Spudlang Syntax Reference
+
+`.spud` files are written in **spudlang**, a simple domain-specific language for template scaffolding. A `.spud` file describes a series of questions to ask the user and actions to take based on their answers.
+
+---
+
+## Overview
+
+A `.spud` file executes top-to-bottom. Questions (`ask`) and actions (`mkdir`, `file`) can be freely interleaved. The output binary, however, collects **all user input first**, then performs all actions — so no prompts appear mid-file-creation.
+
+---
+
+## Statements
+
+### `ask` — Prompt the user for input
+
+```
+ask <name> "<prompt>" <type> [required] [when <condition>]
+```
+
+Declares a variable `<name>` and asks the user a question at runtime.
+
+- All questions are **optional by default**. If the user skips an optional question (empty input), any actions that reference that variable are silently skipped.
+- Add `required` to force the user to provide a non-empty answer.
+- Add `when <condition>` to only ask the question if the condition is true.
+
+**Types:**
+
+| Type     | Description                        |
+|----------|------------------------------------|
+| `string` | Arbitrary text input               |
+| `bool`   | `true` / `false` (yes/no prompt)   |
+| `int`    | Integer input                      |
+
+**Examples:**
+
+```spud
+ask project_name "What is the project name?" string required
+ask use_tests "Include a test suite?" bool
+ask num_weeks "How many weeks is the project?" int when use_tests
+```
+
+---
+
+### `let` — Declare a derived variable
+
+```
+let <name> = <expression>
+```
+
+Computes a new variable from an expression. Useful for transforming user input before using it in paths or file content.
+
+**String operations:** `lower()`, `upper()`, `trim()`, `+` (concatenation)
+
+**Integer operations:** `+`, `-`, `*`, `/`
+
+**Examples:**
+
+```spud
+let slug = lower(trim(project_name))
+let dir = slug + "-project"
+let total_days = num_weeks * 7
+```
+
+---
+
+### `mkdir` — Create a directory
+
+```
+mkdir "<path>" [mode <octal>] [when <condition>]
+```
+
+Creates a directory at the given path. The path may contain `{variable}` interpolation.
+
+**Examples:**
+
+```spud
+mkdir "{dir}/src"
+mkdir "{dir}/tests" when use_tests
+mkdir "{dir}/private" mode 0700
+```
+
+---
+
+### `file` — Create or append to a file
+
+```
+file "<path>" [append] from "<source>" [verbatim] [mode <octal>] [when <condition>]
+file "<path>" [append] content <expression>  [mode <octal>] [when <condition>]
+```
+
+Creates a file at `<path>`, either from a source file (`from`) or from an inline expression (`content`).
+
+- `append` — appends to the file instead of overwriting. Without `append`, the file is created fresh (or overwritten if previously created in the same run).
+- `from "<source>"` — embeds the contents of `<source>` at compile time. `{var}` interpolation is applied at runtime unless `verbatim` is specified.
+- `content <expression>` — inline content; supports `{var}` interpolation via string concatenation.
+- `mode <octal>` — sets file permissions (e.g., `mode 0644`, `mode 0755`).
+- `when <condition>` — only creates the file if the condition is true.
+
+**Examples:**
+
+```spud
+file "{dir}/README.md" content "# " + project_name
+file "{dir}/.gitignore" from "templates/gitignore"
+file "{dir}/run.sh" from "templates/run.sh" mode 0755
+file "{dir}/main.tex" from "templates/main.tex" verbatim when format == "latex"
+file "{dir}/log.txt" append content "Created by spudplate\n"
+```
+
+---
+
+### `repeat` — Loop over a range
+
+```
+repeat <int_var> as <iter>
+    # nested statements
+end
+```
+
+Repeats the nested block `<int_var>` times. The loop variable `<iter>` holds the current iteration index (0-based). Nested `repeat` blocks and all action statements are allowed inside a `repeat`.
+
+**Example:**
+
+```spud
+ask num_modules "How many modules?" int
+repeat num_modules as i
+    mkdir "{dir}/module_{i}"
+    file "{dir}/module_{i}/README.md" content "# Module " + i
+end
+```
+
+---
+
+## Expressions
+
+Expressions appear in `let` values, `content` values, and `when` conditions.
+
+### Literals
+
+```spud
+"hello"      # string literal
+42           # integer literal
+true         # boolean literal
+false        # boolean literal
+```
+
+### Variables
+
+Any previously declared variable (from `ask` or `let`) can be referenced by name:
+
+```spud
+project_name
+num_weeks
+use_tests
+```
+
+### String functions
+
+| Function     | Description                        |
+|--------------|------------------------------------|
+| `lower(x)`   | Converts string to lowercase       |
+| `upper(x)`   | Converts string to uppercase       |
+| `trim(x)`    | Strips leading/trailing whitespace |
+
+### Operators
+
+| Operator | Types         | Description              |
+|----------|---------------|--------------------------|
+| `+`      | string, int   | Concatenation / addition |
+| `-`      | int           | Subtraction              |
+| `*`      | int           | Multiplication           |
+| `/`      | int           | Division                 |
+| `==`     | any           | Equal                    |
+| `!=`     | any           | Not equal                |
+| `>`      | int           | Greater than             |
+| `<`      | int           | Less than                |
+| `>=`     | int           | Greater than or equal    |
+| `<=`     | int           | Less than or equal       |
+| `and`    | bool          | Logical AND              |
+| `or`     | bool          | Logical OR               |
+| `not`    | bool          | Logical NOT              |
+
+---
+
+## Variable Interpolation
+
+`{var}` interpolation is available in:
+
+- File and directory **paths** (`"src/{slug}/main.cpp"`)
+- `content` expressions (via string concatenation)
+- Contents of **`from` source files** (unless `verbatim` is used)
+
+---
+
+## Comments
+
+Lines beginning with `#` are comments and are ignored by the compiler.
+
+```spud
+# This is a comment
+ask name "Your name?" string
+```
+
+---
+
+## Safety
+
+The output binary will **refuse to write to any path that already existed before the run**. It tracks paths it creates during execution and only allows overwriting those. This tracking is ephemeral — no metadata is left behind after the binary exits.
+
+---
+
+## Full Example
+
+```spud
+ask project_name "Project name?" string required
+ask use_tests "Include tests?" bool
+ask num_weeks "Estimated weeks?" int when use_tests
+
+let slug = lower(trim(project_name))
+let dir = slug + "-project"
+
+mkdir "{dir}"
+mkdir "{dir}/src"
+mkdir "{dir}/tests" when use_tests
+
+file "{dir}/README.md" content "# " + project_name
+file "{dir}/src/main.cpp" from "templates/main.cpp"
+file "{dir}/tests/test_main.cpp" from "templates/test_main.cpp" when use_tests
+```

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -11,132 +11,187 @@
 
 namespace spudplate {
 
+/** @brief A string literal expression node, e.g. `"hello"`. */
 struct StringLiteralExpr {
-    std::string value;
-    int line;
-    int column;
+    std::string value;  ///< The literal string value (without quotes).
+    int         line;
+    int         column;
 };
 
+/** @brief An integer literal expression node, e.g. `42`. */
 struct IntegerLiteralExpr {
-    int value;
+    int value; ///< The literal integer value.
     int line;
     int column;
 };
 
+/** @brief A variable reference expression node, e.g. `project_name`. */
 struct IdentifierExpr {
-    std::string name;
-    int line;
-    int column;
+    std::string name; ///< The variable name.
+    int         line;
+    int         column;
 };
 
 // Forward declare Expr so recursive types can hold pointers to it
 struct Expr;
+/** @brief Owning pointer to an expression node. */
 using ExprPtr = std::unique_ptr<Expr>;
 
+/** @brief A unary expression node, e.g. `not flag`. */
 struct UnaryExpr {
-    TokenType op;
-    ExprPtr operand;
-    int line;
-    int column;
+    TokenType op;      ///< The operator token (NOT).
+    ExprPtr   operand; ///< The operand expression.
+    int       line;
+    int       column;
 };
 
+/**
+ * @brief A binary expression node, e.g. `a + b` or `x == y`.
+ *
+ * Covers arithmetic, comparison, and logical binary operators.
+ */
 struct BinaryExpr {
-    TokenType op;
-    ExprPtr left;
-    ExprPtr right;
-    int line;
-    int column;
+    TokenType op;    ///< The operator token.
+    ExprPtr   left;  ///< Left-hand operand.
+    ExprPtr   right; ///< Right-hand operand.
+    int       line;
+    int       column;
 };
 
+/**
+ * @brief A built-in function call expression, e.g. `lower(name)`.
+ *
+ * All built-in functions take exactly one argument.
+ * Supported functions: `lower`, `upper`, `trim`.
+ */
 struct FunctionCallExpr {
-    std::string name;
-    ExprPtr argument;
-    int line;
-    int column;
+    std::string name;     ///< Function name.
+    ExprPtr     argument; ///< The single argument expression.
+    int         line;
+    int         column;
 };
 
+/** @brief Discriminated union of all expression node types. */
 using ExprData = std::variant<StringLiteralExpr, IntegerLiteralExpr,
                               IdentifierExpr, UnaryExpr, BinaryExpr,
                               FunctionCallExpr>;
 
+/** @brief An expression node wrapping an ExprData variant. */
 struct Expr {
     ExprData data;
 };
 
-// Variable types for ask statements
+/** @brief The type of a variable declared by an `ask` statement. */
 enum class VarType { String, Bool, Int };
 
-// File source: either a path (from) or an expression (content)
+/** @brief File source: content comes from an embedded source file. */
 struct FileFromSource {
-    std::string path;
-    bool verbatim;
+    std::string path;     ///< Path to the source file (resolved at compile time).
+    bool        verbatim; ///< If true, suppress `{var}` interpolation at runtime.
 };
 
+/** @brief File source: content comes from an inline expression. */
 struct FileContentSource {
-    ExprPtr value;
+    ExprPtr value; ///< The expression whose string value becomes the file content.
 };
 
+/** @brief Discriminated union of the two file content sources. */
 using FileSource = std::variant<FileFromSource, FileContentSource>;
 
+// ---------------------------------------------------------------------------
 // Statement types
+// ---------------------------------------------------------------------------
 
+/**
+ * @brief An `ask` statement — declares a variable and prompts the user.
+ *
+ * Example: `ask name "Your name?" string required`
+ */
 struct AskStmt {
-    std::string name;
-    std::string prompt;
-    VarType var_type;
-    bool required;
-    std::optional<ExprPtr> when_clause;
-    int line;
-    int column;
+    std::string            name;        ///< Variable name to bind the answer to.
+    std::string            prompt;      ///< The prompt string shown to the user.
+    VarType                var_type;    ///< Expected type of the answer.
+    bool                   required;    ///< Whether a non-empty answer is required.
+    std::optional<ExprPtr> when_clause; ///< Optional condition guarding the prompt.
+    int                    line;
+    int                    column;
 };
 
+/**
+ * @brief A `let` statement — declares a derived variable.
+ *
+ * Example: `let slug = lower(trim(name))`
+ */
 struct LetStmt {
-    std::string name;
-    ExprPtr value;
-    int line;
-    int column;
+    std::string name;  ///< Variable name to bind.
+    ExprPtr     value; ///< Expression whose value is assigned.
+    int         line;
+    int         column;
 };
 
+/**
+ * @brief A `mkdir` statement — creates a directory.
+ *
+ * Example: `mkdir "{slug}/src" mode 0755`
+ */
 struct MkdirStmt {
-    std::string path;
-    std::optional<int> mode;
-    std::optional<ExprPtr> when_clause;
-    int line;
-    int column;
+    std::string            path;        ///< Directory path (supports `{var}` interpolation).
+    std::optional<int>     mode;        ///< Optional permission bits (e.g. 0755).
+    std::optional<ExprPtr> when_clause; ///< Optional condition guarding creation.
+    int                    line;
+    int                    column;
 };
 
+/**
+ * @brief A `file` statement — creates or appends to a file.
+ *
+ * Example: `file "{slug}/README.md" content "# " + name`
+ */
 struct FileStmt {
-    std::string path;
-    FileSource source;
-    bool append;
-    std::optional<int> mode;
-    std::optional<ExprPtr> when_clause;
-    int line;
-    int column;
+    std::string            path;        ///< File path (supports `{var}` interpolation).
+    FileSource             source;      ///< Where the file content comes from.
+    bool                   append;      ///< If true, append; otherwise create/overwrite.
+    std::optional<int>     mode;        ///< Optional permission bits.
+    std::optional<ExprPtr> when_clause; ///< Optional condition guarding creation.
+    int                    line;
+    int                    column;
 };
 
 // Forward declare Stmt so RepeatStmt can hold a vector of them
 struct Stmt;
+/** @brief Owning pointer to a statement node. */
 using StmtPtr = std::unique_ptr<Stmt>;
 
+/**
+ * @brief A `repeat` statement — loops a block N times.
+ *
+ * Example:
+ * @code
+ * repeat count as i
+ *     mkdir "module_{i}"
+ * end
+ * @endcode
+ */
 struct RepeatStmt {
-    std::string collection_var;
-    std::string iterator_var;
-    std::vector<StmtPtr> body;
-    int line;
-    int column;
+    std::string          collection_var; ///< Name of the int variable holding the count.
+    std::string          iterator_var;   ///< Name of the loop index variable (0-based).
+    std::vector<StmtPtr> body;           ///< Statements inside the loop body.
+    int                  line;
+    int                  column;
 };
 
-// Stmt variant and pointer type
+/** @brief Discriminated union of all statement node types. */
 using StmtData =
     std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt>;
 
+/** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {
     StmtData data;
 };
 
+/** @brief The top-level AST node representing a complete `.spud` program. */
 struct Program {
-    std::vector<StmtPtr> statements;
+    std::vector<StmtPtr> statements; ///< Ordered list of top-level statements.
 };
 
 } // namespace spudplate

--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -8,22 +8,31 @@
 
 namespace spudplate {
 
+/**
+ * @brief Tokenises a spudlang source string into a stream of Token values.
+ *
+ * Call nextToken() repeatedly to consume tokens one at a time.
+ * The lexer returns an EOF_TOKEN once the entire input has been consumed, and
+ * an ERROR token for any unrecognised character.
+ */
 class Lexer {
   public:
+    /** @brief Constructs a Lexer over the given source string. */
     explicit Lexer(std::string source);
 
+    /** @brief Returns the next Token from the source, advancing the position. */
     Token nextToken();
 
   private:
-    std::string source_;
-    std::size_t pos_;
-    int line_;
-    int column_;
+    std::string  source_;
+    std::size_t  pos_;
+    int          line_;
+    int          column_;
 
-    char current() const;
-    char advance();
-    bool isAtEnd() const;
-    void skipWhitespace();
+    char  current() const;
+    char  advance();
+    bool  isAtEnd() const;
+    void  skipWhitespace();
     Token readIdentifierOrKeyword();
     Token readStringLiteral();
     Token readIntegerLiteral();

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -9,12 +9,20 @@
 
 namespace spudplate {
 
+/**
+ * @brief Exception thrown when the parser encounters invalid spudlang syntax.
+ *
+ * Carries the source location (line and column) alongside the error message so
+ * callers can produce precise diagnostics.
+ */
 class ParseError : public std::runtime_error {
   public:
     ParseError(const std::string &message, int line, int column)
         : std::runtime_error(message), line_(line), column_(column) {}
 
+    /** @brief 1-based line number where the error occurred. */
     int line() const { return line_; }
+    /** @brief 1-based column number where the error occurred. */
     int column() const { return column_; }
 
   private:
@@ -22,19 +30,37 @@ class ParseError : public std::runtime_error {
     int column_;
 };
 
+/**
+ * @brief Recursive-descent parser that produces an AST from a token stream.
+ *
+ * Construct with a Lexer over the source text, then call parse() to obtain a
+ * Program. Throws ParseError on any syntax violation.
+ *
+ * Individual statement parsers (parseAsk(), parseLet(), etc.) are public so
+ * they can be exercised directly in unit tests.
+ */
 class Parser {
   public:
+    /** @brief Constructs a Parser that reads tokens from the given Lexer. */
     explicit Parser(Lexer lexer);
 
+    /** @brief Parses the full program and returns the top-level AST node. */
     Program parse();
 
+    /** @brief Parses a single expression starting at the current token. */
     ExprPtr parseExpression();
 
+    /** @brief Parses an `ask` statement. */
     StmtPtr parseAsk();
+    /** @brief Parses a `let` statement. */
     StmtPtr parseLet();
+    /** @brief Parses a `mkdir` statement. */
     StmtPtr parseMkdir();
+    /** @brief Parses a `file` statement. */
     StmtPtr parseFile();
+    /** @brief Parses a `repeat` block. */
     StmtPtr parseRepeat();
+    /** @brief Dispatches to the appropriate statement parser based on the current token. */
     StmtPtr parseStatement();
 
   private:
@@ -43,16 +69,16 @@ class Parser {
 
     // Token consumption
     Token advance();
-    bool check(TokenType type) const;
-    bool match(TokenType type);
+    bool  check(TokenType type) const;
+    bool  match(TokenType type);
     Token expect(TokenType type, const std::string &message);
-    void skip_newlines();
+    void  skip_newlines();
 
     // Statement helpers
-    VarType parse_var_type();
+    VarType                parse_var_type();
     std::optional<ExprPtr> parse_when_clause();
-    std::optional<int> parse_mode_clause();
-    void expect_newline(const std::string &context);
+    std::optional<int>     parse_mode_clause();
+    void                   expect_newline(const std::string &context);
 
     // Expression precedence climbing
     ExprPtr parse_or();

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -5,70 +5,72 @@
 
 namespace spudplate {
 
+/** @brief All token types produced by the Lexer. */
 enum class TokenType {
     // Keywords
-    ASK,
-    LET,
-    MKDIR,
-    FILE,
-    FROM,
-    CONTENT,
-    WHEN,
-    REPEAT,
-    END,
-    REQUIRED,
-    VERBATIM,
-    APPEND,
-    MODE,
-    AS,
+    ASK,      ///< `ask` — declare a user prompt
+    LET,      ///< `let` — declare a derived variable
+    MKDIR,    ///< `mkdir` — create a directory
+    FILE,     ///< `file` — create or append to a file
+    FROM,     ///< `from` — source file path for file statements
+    CONTENT,  ///< `content` — inline content for file statements
+    WHEN,     ///< `when` — conditional modifier
+    REPEAT,   ///< `repeat` — begin a loop block
+    END,      ///< `end` — close a repeat block
+    REQUIRED, ///< `required` — mark an ask as mandatory
+    VERBATIM, ///< `verbatim` — suppress interpolation in from-file contents
+    APPEND,   ///< `append` — append to file instead of overwriting
+    MODE,     ///< `mode` — set file/directory permissions (octal)
+    AS,       ///< `as` — bind loop iterator variable in repeat
 
     // Logical operators (keywords)
-    AND,
-    OR,
-    NOT,
+    AND, ///< `and` — logical AND
+    OR,  ///< `or`  — logical OR
+    NOT, ///< `not` — logical NOT
 
     // Type keywords
-    STRING_TYPE,
-    BOOL_TYPE,
-    INT_TYPE,
+    STRING_TYPE, ///< `string` type annotation
+    BOOL_TYPE,   ///< `bool` type annotation
+    INT_TYPE,    ///< `int` type annotation
 
     // Literals
-    STRING_LITERAL,
-    INTEGER_LITERAL,
-    IDENTIFIER,
+    STRING_LITERAL,  ///< Quoted string literal, e.g. `"hello"`
+    INTEGER_LITERAL, ///< Integer literal, e.g. `42`
+    IDENTIFIER,      ///< Variable or function name
 
     // Comparison operators
-    EQUALS,
-    NOT_EQUALS,
-    GREATER,
-    LESS,
-    GREATER_EQUAL,
-    LESS_EQUAL,
+    EQUALS,        ///< `==`
+    NOT_EQUALS,    ///< `!=`
+    GREATER,       ///< `>`
+    LESS,          ///< `<`
+    GREATER_EQUAL, ///< `>=`
+    LESS_EQUAL,    ///< `<=`
 
     // Arithmetic operators
-    PLUS,
-    MINUS,
-    STAR,
-    SLASH,
+    PLUS,  ///< `+` — addition or string concatenation
+    MINUS, ///< `-` — subtraction
+    STAR,  ///< `*` — multiplication
+    SLASH, ///< `/` — division
 
     // Assignment
-    ASSIGN,
+    ASSIGN, ///< `=`
 
     // Structure
-    NEWLINE,
-    LPAREN,
-    RPAREN,
+    NEWLINE, ///< Logical line break (newline or semicolon)
+    LPAREN,  ///< `(`
+    RPAREN,  ///< `)`
 
     // Special
-    EOF_TOKEN,
-    ERROR,
+    EOF_TOKEN, ///< End of input
+    ERROR,     ///< Lexer error (unrecognised character)
 };
 
+/** @brief A single lexical token with source location. */
 struct Token {
-    TokenType type;
-    std::string value;
-    int line;
-    int column;
+    TokenType   type;   ///< The token's classification.
+    std::string value;  ///< The raw text of the token (empty for punctuation).
+    int         line;   ///< 1-based source line number.
+    int         column; ///< 1-based source column number.
 
     Token() : type(TokenType::EOF_TOKEN), value(""), line(0), column(0) {}
 
@@ -76,6 +78,7 @@ struct Token {
         : type(type), value(std::move(value)), line(line), column(column) {}
 };
 
+/** @brief Returns a human-readable string for a TokenType value. */
 inline std::string tokenTypeToString(TokenType type) {
     switch (type) {
     case TokenType::ASK: return "ASK";


### PR DESCRIPTION
## Summary
Add MIT license, a full spudlang syntax reference, and Doxygen API doc generation

## Changes
- Add LICENSE
- Full spudlang syntax reference with examples, set as Doxygen main page
- Add Doxyfile
- Add optional docs CMake target (`cmake --build build --target docs`)
- Add Doxygen comments to all four public headers
- Add docs section to README.md

## Test plan
- All 110 tests pass locally
