### PR TITLE
style: add clang-format, clang-tidy and update README

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,38 @@
+BasedOnStyle: Google
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+
+# Brace style
+BreakBeforeBraces: Attach
+
+# Column limit
+ColumnLimit: 90
+
+# Access modifiers
+AccessModifierOffset: -2
+
+# Constructor initializers
+BreakConstructorInitializers: BeforeColon
+ConstructorInitializerIndentWidth: 4
+
+# Includes
+SortIncludes: CaseSensitive
+IncludeBlocks: Regroup
+
+# Alignment
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignTrailingComments: true
+
+# Pointers and references
+PointerAlignment: Left
+
+# Short forms
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Inline
+
+# Penalties (discourage breaking in awkward places)
+PenaltyBreakBeforeFirstCallParameter: 100
+PenaltyReturnTypeOnItsOwnLine: 200

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+Checks: >
+    clang-analyzer-*,
+    modernize-*,
+    readability-*,
+    performance-*,
+    -modernize-use-trailing-return-type,
+    -readability-magic-numbers,
+    -readability-named-parameter
+
+WarningsAsErrors: ''
+
+HeaderFilterRegex: 'include/spudplate/.*'
+
+CheckOptions:
+    - key: readability-identifier-naming.NamespaceCase
+      value: lower_case
+    - key: readability-identifier-naming.ClassCase
+      value: CamelCase
+    - key: readability-identifier-naming.StructCase
+      value: CamelCase
+    - key: readability-identifier-naming.EnumCase
+      value: CamelCase
+    - key: readability-identifier-naming.FunctionCase
+      value: camelBack
+    - key: readability-identifier-naming.MethodCase
+      value: camelBack
+    - key: readability-identifier-naming.MemberCase
+      value: lower_case
+    - key: readability-identifier-naming.MemberSuffix
+      value: _
+    - key: readability-identifier-naming.ParameterCase
+      value: lower_case
+    - key: readability-identifier-naming.LocalVariableCase
+      value: lower_case
+    - key: readability-identifier-naming.EnumConstantCase
+      value: CamelCase

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,33 +4,14 @@ Checks: >
     readability-*,
     performance-*,
     -modernize-use-trailing-return-type,
+    -modernize-return-braced-init-list,
     -readability-magic-numbers,
-    -readability-named-parameter
+    -readability-named-parameter,
+    -readability-identifier-length,
+    -readability-identifier-naming,
+    -performance-enum-size
 
 WarningsAsErrors: ''
 
 HeaderFilterRegex: 'include/spudplate/.*'
 
-CheckOptions:
-    - key: readability-identifier-naming.NamespaceCase
-      value: lower_case
-    - key: readability-identifier-naming.ClassCase
-      value: CamelCase
-    - key: readability-identifier-naming.StructCase
-      value: CamelCase
-    - key: readability-identifier-naming.EnumCase
-      value: CamelCase
-    - key: readability-identifier-naming.FunctionCase
-      value: camelBack
-    - key: readability-identifier-naming.MethodCase
-      value: camelBack
-    - key: readability-identifier-naming.MemberCase
-      value: lower_case
-    - key: readability-identifier-naming.MemberSuffix
-      value: _
-    - key: readability-identifier-naming.ParameterCase
-      value: lower_case
-    - key: readability-identifier-naming.LocalVariableCase
-      value: lower_case
-    - key: readability-identifier-naming.EnumConstantCase
-      value: CamelCase

--- a/README.md
+++ b/README.md
@@ -1,8 +1,48 @@
 # spudplate
 
-A template scaffolding compiler. Write a `.spud` file, compile it into a standalone binary that interactively creates files and directories.
+[![CI](https://github.com/spuddydev/spudplate/actions/workflows/ci.yml/badge.svg)](https://github.com/spuddydev/spudplate/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![C++20](https://img.shields.io/badge/C%2B%2B-20-blue.svg)](https://en.cppreference.com/w/cpp/20)
+
+**Templating made for spuds!**
+
+Write a `.spud` file in spudlang, compile it into a standalone binary that asks the user questions and creates files and directories based on their answers.
+
+## How it works
+
+1. Write a `.spud` file describing your template
+2. Compile it with `spudplate` into a standalone binary
+3. Distribute or run the binary, it prompts the user and scaffolds the project!
+
+```
+spudplate my_template.spud -o my_template
+./my_template
+```
+
+## Example
+
+```
+ask project_name "Project name?" string required
+ask use_tests "Include a test suite?" bool
+
+let slug = lower(trim(project_name))
+
+mkdir "{slug}"
+mkdir "{slug}/src"
+mkdir "{slug}/tests" when use_tests
+
+file "{slug}/README.md" content "# " + project_name
+file "{slug}/src/main.cpp" from "templates/main.cpp"
+file "{slug}/tests/test_main.cpp" from "templates/test_main.cpp" when use_tests
+```
+
+Spudlang supports variables, string/int expressions, conditionals (`when`), and `repeat` loops. See [docs/syntax.md](docs/syntax.md) for the full language reference.
 
 ## Build
+
+> **Note:** spudplate is currently in active development. The lexer and parser are complete, but the compiler is not yet functional. Compiled binaries cannot be produced yet.
+
+Requires CMake and a C++20 compiler.
 
 ```bash
 cmake -B build && cmake --build build
@@ -23,3 +63,7 @@ cmake --build build --target docs
 ```
 
 Opens `docs/html/index.html` — includes the full spudlang syntax reference and API documentation.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -34,7 +34,7 @@ Declares a variable `<name>` and asks the user a question at runtime.
 
 **Examples:**
 
-```spud
+```
 ask project_name "What is the project name?" string required
 ask use_tests "Include a test suite?" bool
 ask num_weeks "How many weeks is the project?" int when use_tests
@@ -56,7 +56,7 @@ Computes a new variable from an expression. Useful for transforming user input b
 
 **Examples:**
 
-```spud
+```
 let slug = lower(trim(project_name))
 let dir = slug + "-project"
 let total_days = num_weeks * 7
@@ -74,7 +74,7 @@ Creates a directory at the given path. The path may contain `{variable}` interpo
 
 **Examples:**
 
-```spud
+```
 mkdir "{dir}/src"
 mkdir "{dir}/tests" when use_tests
 mkdir "{dir}/private" mode 0700
@@ -99,7 +99,7 @@ Creates a file at `<path>`, either from a source file (`from`) or from an inline
 
 **Examples:**
 
-```spud
+```
 file "{dir}/README.md" content "# " + project_name
 file "{dir}/.gitignore" from "templates/gitignore"
 file "{dir}/run.sh" from "templates/run.sh" mode 0755
@@ -121,7 +121,7 @@ Repeats the nested block `<int_var>` times. The loop variable `<iter>` holds the
 
 **Example:**
 
-```spud
+```
 ask num_modules "How many modules?" int
 repeat num_modules as i
     mkdir "{dir}/module_{i}"
@@ -137,7 +137,7 @@ Expressions appear in `let` values, `content` values, and `when` conditions.
 
 ### Literals
 
-```spud
+```
 "hello"      # string literal
 42           # integer literal
 true         # boolean literal
@@ -148,7 +148,7 @@ false        # boolean literal
 
 Any previously declared variable (from `ask` or `let`) can be referenced by name:
 
-```spud
+```
 project_name
 num_weeks
 use_tests
@@ -196,7 +196,7 @@ use_tests
 
 Lines beginning with `#` are comments and are ignored by the compiler.
 
-```spud
+```
 # This is a comment
 ask name "Your name?" string
 ```
@@ -211,7 +211,7 @@ The output binary will **refuse to write to any path that already existed before
 
 ## Full Example
 
-```spud
+```
 ask project_name "Project name?" string required
 ask use_tests "Include tests?" bool
 ask num_weeks "Estimated weeks?" int when use_tests

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -1,35 +1,35 @@
 #ifndef SPUDPLATE_AST_H
 #define SPUDPLATE_AST_H
 
-#include "spudplate/token.h"
-
 #include <memory>
 #include <optional>
 #include <string>
 #include <variant>
 #include <vector>
 
+#include "spudplate/token.h"
+
 namespace spudplate {
 
 /** @brief A string literal expression node, e.g. `"hello"`. */
 struct StringLiteralExpr {
     std::string value;  ///< The literal string value (without quotes).
-    int         line;
-    int         column;
+    int line;
+    int column;
 };
 
 /** @brief An integer literal expression node, e.g. `42`. */
 struct IntegerLiteralExpr {
-    int value; ///< The literal integer value.
+    int value;  ///< The literal integer value.
     int line;
     int column;
 };
 
 /** @brief A variable reference expression node, e.g. `project_name`. */
 struct IdentifierExpr {
-    std::string name; ///< The variable name.
-    int         line;
-    int         column;
+    std::string name;  ///< The variable name.
+    int line;
+    int column;
 };
 
 // Forward declare Expr so recursive types can hold pointers to it
@@ -39,10 +39,10 @@ using ExprPtr = std::unique_ptr<Expr>;
 
 /** @brief A unary expression node, e.g. `not flag`. */
 struct UnaryExpr {
-    TokenType op;      ///< The operator token (NOT).
-    ExprPtr   operand; ///< The operand expression.
-    int       line;
-    int       column;
+    TokenType op;     ///< The operator token (NOT).
+    ExprPtr operand;  ///< The operand expression.
+    int line;
+    int column;
 };
 
 /**
@@ -51,11 +51,11 @@ struct UnaryExpr {
  * Covers arithmetic, comparison, and logical binary operators.
  */
 struct BinaryExpr {
-    TokenType op;    ///< The operator token.
-    ExprPtr   left;  ///< Left-hand operand.
-    ExprPtr   right; ///< Right-hand operand.
-    int       line;
-    int       column;
+    TokenType op;   ///< The operator token.
+    ExprPtr left;   ///< Left-hand operand.
+    ExprPtr right;  ///< Right-hand operand.
+    int line;
+    int column;
 };
 
 /**
@@ -65,16 +65,15 @@ struct BinaryExpr {
  * Supported functions: `lower`, `upper`, `trim`.
  */
 struct FunctionCallExpr {
-    std::string name;     ///< Function name.
-    ExprPtr     argument; ///< The single argument expression.
-    int         line;
-    int         column;
+    std::string name;  ///< Function name.
+    ExprPtr argument;  ///< The single argument expression.
+    int line;
+    int column;
 };
 
 /** @brief Discriminated union of all expression node types. */
-using ExprData = std::variant<StringLiteralExpr, IntegerLiteralExpr,
-                              IdentifierExpr, UnaryExpr, BinaryExpr,
-                              FunctionCallExpr>;
+using ExprData = std::variant<StringLiteralExpr, IntegerLiteralExpr, IdentifierExpr,
+                              UnaryExpr, BinaryExpr, FunctionCallExpr>;
 
 /** @brief An expression node wrapping an ExprData variant. */
 struct Expr {
@@ -86,13 +85,13 @@ enum class VarType { String, Bool, Int };
 
 /** @brief File source: content comes from an embedded source file. */
 struct FileFromSource {
-    std::string path;     ///< Path to the source file (resolved at compile time).
-    bool        verbatim; ///< If true, suppress `{var}` interpolation at runtime.
+    std::string path;  ///< Path to the source file (resolved at compile time).
+    bool verbatim;     ///< If true, suppress `{var}` interpolation at runtime.
 };
 
 /** @brief File source: content comes from an inline expression. */
 struct FileContentSource {
-    ExprPtr value; ///< The expression whose string value becomes the file content.
+    ExprPtr value;  ///< The expression whose string value becomes the file content.
 };
 
 /** @brief Discriminated union of the two file content sources. */
@@ -108,13 +107,13 @@ using FileSource = std::variant<FileFromSource, FileContentSource>;
  * Example: `ask name "Your name?" string required`
  */
 struct AskStmt {
-    std::string            name;        ///< Variable name to bind the answer to.
-    std::string            prompt;      ///< The prompt string shown to the user.
-    VarType                var_type;    ///< Expected type of the answer.
-    bool                   required;    ///< Whether a non-empty answer is required.
-    std::optional<ExprPtr> when_clause; ///< Optional condition guarding the prompt.
-    int                    line;
-    int                    column;
+    std::string name;                    ///< Variable name to bind the answer to.
+    std::string prompt;                  ///< The prompt string shown to the user.
+    VarType var_type;                    ///< Expected type of the answer.
+    bool required;                       ///< Whether a non-empty answer is required.
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the prompt.
+    int line;
+    int column;
 };
 
 /**
@@ -124,9 +123,9 @@ struct AskStmt {
  */
 struct LetStmt {
     std::string name;  ///< Variable name to bind.
-    ExprPtr     value; ///< Expression whose value is assigned.
-    int         line;
-    int         column;
+    ExprPtr value;     ///< Expression whose value is assigned.
+    int line;
+    int column;
 };
 
 /**
@@ -135,11 +134,11 @@ struct LetStmt {
  * Example: `mkdir "{slug}/src" mode 0755`
  */
 struct MkdirStmt {
-    std::string            path;        ///< Directory path (supports `{var}` interpolation).
-    std::optional<int>     mode;        ///< Optional permission bits (e.g. 0755).
-    std::optional<ExprPtr> when_clause; ///< Optional condition guarding creation.
-    int                    line;
-    int                    column;
+    std::string path;         ///< Directory path (supports `{var}` interpolation).
+    std::optional<int> mode;  ///< Optional permission bits (e.g. 0755).
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding creation.
+    int line;
+    int column;
 };
 
 /**
@@ -148,13 +147,13 @@ struct MkdirStmt {
  * Example: `file "{slug}/README.md" content "# " + name`
  */
 struct FileStmt {
-    std::string            path;        ///< File path (supports `{var}` interpolation).
-    FileSource             source;      ///< Where the file content comes from.
-    bool                   append;      ///< If true, append; otherwise create/overwrite.
-    std::optional<int>     mode;        ///< Optional permission bits.
-    std::optional<ExprPtr> when_clause; ///< Optional condition guarding creation.
-    int                    line;
-    int                    column;
+    std::string path;                    ///< File path (supports `{var}` interpolation).
+    FileSource source;                   ///< Where the file content comes from.
+    bool append;                         ///< If true, append; otherwise create/overwrite.
+    std::optional<int> mode;             ///< Optional permission bits.
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding creation.
+    int line;
+    int column;
 };
 
 // Forward declare Stmt so RepeatStmt can hold a vector of them
@@ -173,16 +172,15 @@ using StmtPtr = std::unique_ptr<Stmt>;
  * @endcode
  */
 struct RepeatStmt {
-    std::string          collection_var; ///< Name of the int variable holding the count.
-    std::string          iterator_var;   ///< Name of the loop index variable (0-based).
-    std::vector<StmtPtr> body;           ///< Statements inside the loop body.
-    int                  line;
-    int                  column;
+    std::string collection_var;  ///< Name of the int variable holding the count.
+    std::string iterator_var;    ///< Name of the loop index variable (0-based).
+    std::vector<StmtPtr> body;   ///< Statements inside the loop body.
+    int line;
+    int column;
 };
 
 /** @brief Discriminated union of all statement node types. */
-using StmtData =
-    std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt>;
+using StmtData = std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt>;
 
 /** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {
@@ -191,9 +189,9 @@ struct Stmt {
 
 /** @brief The top-level AST node representing a complete `.spud` program. */
 struct Program {
-    std::vector<StmtPtr> statements; ///< Ordered list of top-level statements.
+    std::vector<StmtPtr> statements;  ///< Ordered list of top-level statements.
 };
 
-} // namespace spudplate
+}  // namespace spudplate
 
-#endif // SPUDPLATE_AST_H
+#endif  // SPUDPLATE_AST_H

--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -1,10 +1,10 @@
 #ifndef SPUDPLATE_LEXER_H
 #define SPUDPLATE_LEXER_H
 
-#include "spudplate/token.h"
-
 #include <cstddef>
 #include <string>
+
+#include "spudplate/token.h"
 
 namespace spudplate {
 
@@ -24,20 +24,20 @@ class Lexer {
     Token nextToken();
 
   private:
-    std::string  source_;
-    std::size_t  pos_;
-    int          line_;
-    int          column_;
+    std::string source_;
+    std::size_t pos_;
+    int line_;
+    int column_;
 
-    char  current() const;
-    char  advance();
-    bool  isAtEnd() const;
-    void  skipWhitespace();
+    char current() const;
+    char advance();
+    bool isAtEnd() const;
+    void skipWhitespace();
     Token readIdentifierOrKeyword();
     Token readStringLiteral();
     Token readIntegerLiteral();
 };
 
-} // namespace spudplate
+}  // namespace spudplate
 
-#endif // SPUDPLATE_LEXER_H
+#endif  // SPUDPLATE_LEXER_H

--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -29,9 +29,9 @@ class Lexer {
     int line_;
     int column_;
 
-    char current() const;
+    [[nodiscard]] char current() const;
     char advance();
-    bool isAtEnd() const;
+    [[nodiscard]] bool isAtEnd() const;
     void skipWhitespace();
     Token readIdentifierOrKeyword();
     Token readStringLiteral();

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -21,9 +21,9 @@ class ParseError : public std::runtime_error {
         : std::runtime_error(message), line_(line), column_(column) {}
 
     /** @brief 1-based line number where the error occurred. */
-    int line() const { return line_; }
+    [[nodiscard]] int line() const { return line_; }
     /** @brief 1-based column number where the error occurred. */
-    int column() const { return column_; }
+    [[nodiscard]] int column() const { return column_; }
 
   private:
     int line_;
@@ -70,7 +70,7 @@ class Parser {
 
     // Token consumption
     Token advance();
-    bool check(TokenType type) const;
+    [[nodiscard]] bool check(TokenType type) const;
     bool match(TokenType type);
     Token expect(TokenType type, const std::string& message);
     void skip_newlines();

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -1,11 +1,11 @@
 #ifndef SPUDPLATE_PARSER_H
 #define SPUDPLATE_PARSER_H
 
-#include "spudplate/ast.h"
-#include "spudplate/lexer.h"
-
 #include <stdexcept>
 #include <string>
+
+#include "spudplate/ast.h"
+#include "spudplate/lexer.h"
 
 namespace spudplate {
 
@@ -17,7 +17,7 @@ namespace spudplate {
  */
 class ParseError : public std::runtime_error {
   public:
-    ParseError(const std::string &message, int line, int column)
+    ParseError(const std::string& message, int line, int column)
         : std::runtime_error(message), line_(line), column_(column) {}
 
     /** @brief 1-based line number where the error occurred. */
@@ -60,7 +60,8 @@ class Parser {
     StmtPtr parseFile();
     /** @brief Parses a `repeat` block. */
     StmtPtr parseRepeat();
-    /** @brief Dispatches to the appropriate statement parser based on the current token. */
+    /** @brief Dispatches to the appropriate statement parser based on the current token.
+     */
     StmtPtr parseStatement();
 
   private:
@@ -69,16 +70,16 @@ class Parser {
 
     // Token consumption
     Token advance();
-    bool  check(TokenType type) const;
-    bool  match(TokenType type);
-    Token expect(TokenType type, const std::string &message);
-    void  skip_newlines();
+    bool check(TokenType type) const;
+    bool match(TokenType type);
+    Token expect(TokenType type, const std::string& message);
+    void skip_newlines();
 
     // Statement helpers
-    VarType                parse_var_type();
+    VarType parse_var_type();
     std::optional<ExprPtr> parse_when_clause();
-    std::optional<int>     parse_mode_clause();
-    void                   expect_newline(const std::string &context);
+    std::optional<int> parse_mode_clause();
+    void expect_newline(const std::string& context);
 
     // Expression precedence climbing
     ExprPtr parse_or();
@@ -90,6 +91,6 @@ class Parser {
     ExprPtr parse_primary();
 };
 
-} // namespace spudplate
+}  // namespace spudplate
 
-#endif // SPUDPLATE_PARSER_H
+#endif  // SPUDPLATE_PARSER_H

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -8,69 +8,69 @@ namespace spudplate {
 /** @brief All token types produced by the Lexer. */
 enum class TokenType {
     // Keywords
-    ASK,      ///< `ask` — declare a user prompt
-    LET,      ///< `let` — declare a derived variable
-    MKDIR,    ///< `mkdir` — create a directory
-    FILE,     ///< `file` — create or append to a file
-    FROM,     ///< `from` — source file path for file statements
-    CONTENT,  ///< `content` — inline content for file statements
-    WHEN,     ///< `when` — conditional modifier
-    REPEAT,   ///< `repeat` — begin a loop block
-    END,      ///< `end` — close a repeat block
-    REQUIRED, ///< `required` — mark an ask as mandatory
-    VERBATIM, ///< `verbatim` — suppress interpolation in from-file contents
-    APPEND,   ///< `append` — append to file instead of overwriting
-    MODE,     ///< `mode` — set file/directory permissions (octal)
-    AS,       ///< `as` — bind loop iterator variable in repeat
+    ASK,       ///< `ask` — declare a user prompt
+    LET,       ///< `let` — declare a derived variable
+    MKDIR,     ///< `mkdir` — create a directory
+    FILE,      ///< `file` — create or append to a file
+    FROM,      ///< `from` — source file path for file statements
+    CONTENT,   ///< `content` — inline content for file statements
+    WHEN,      ///< `when` — conditional modifier
+    REPEAT,    ///< `repeat` — begin a loop block
+    END,       ///< `end` — close a repeat block
+    REQUIRED,  ///< `required` — mark an ask as mandatory
+    VERBATIM,  ///< `verbatim` — suppress interpolation in from-file contents
+    APPEND,    ///< `append` — append to file instead of overwriting
+    MODE,      ///< `mode` — set file/directory permissions (octal)
+    AS,        ///< `as` — bind loop iterator variable in repeat
 
     // Logical operators (keywords)
-    AND, ///< `and` — logical AND
-    OR,  ///< `or`  — logical OR
-    NOT, ///< `not` — logical NOT
+    AND,  ///< `and` — logical AND
+    OR,   ///< `or`  — logical OR
+    NOT,  ///< `not` — logical NOT
 
     // Type keywords
-    STRING_TYPE, ///< `string` type annotation
-    BOOL_TYPE,   ///< `bool` type annotation
-    INT_TYPE,    ///< `int` type annotation
+    STRING_TYPE,  ///< `string` type annotation
+    BOOL_TYPE,    ///< `bool` type annotation
+    INT_TYPE,     ///< `int` type annotation
 
     // Literals
-    STRING_LITERAL,  ///< Quoted string literal, e.g. `"hello"`
-    INTEGER_LITERAL, ///< Integer literal, e.g. `42`
-    IDENTIFIER,      ///< Variable or function name
+    STRING_LITERAL,   ///< Quoted string literal, e.g. `"hello"`
+    INTEGER_LITERAL,  ///< Integer literal, e.g. `42`
+    IDENTIFIER,       ///< Variable or function name
 
     // Comparison operators
-    EQUALS,        ///< `==`
-    NOT_EQUALS,    ///< `!=`
-    GREATER,       ///< `>`
-    LESS,          ///< `<`
-    GREATER_EQUAL, ///< `>=`
-    LESS_EQUAL,    ///< `<=`
+    EQUALS,         ///< `==`
+    NOT_EQUALS,     ///< `!=`
+    GREATER,        ///< `>`
+    LESS,           ///< `<`
+    GREATER_EQUAL,  ///< `>=`
+    LESS_EQUAL,     ///< `<=`
 
     // Arithmetic operators
-    PLUS,  ///< `+` — addition or string concatenation
-    MINUS, ///< `-` — subtraction
-    STAR,  ///< `*` — multiplication
-    SLASH, ///< `/` — division
+    PLUS,   ///< `+` — addition or string concatenation
+    MINUS,  ///< `-` — subtraction
+    STAR,   ///< `*` — multiplication
+    SLASH,  ///< `/` — division
 
     // Assignment
-    ASSIGN, ///< `=`
+    ASSIGN,  ///< `=`
 
     // Structure
-    NEWLINE, ///< Logical line break (newline or semicolon)
-    LPAREN,  ///< `(`
-    RPAREN,  ///< `)`
+    NEWLINE,  ///< Logical line break (newline or semicolon)
+    LPAREN,   ///< `(`
+    RPAREN,   ///< `)`
 
     // Special
-    EOF_TOKEN, ///< End of input
-    ERROR,     ///< Lexer error (unrecognised character)
+    EOF_TOKEN,  ///< End of input
+    ERROR,      ///< Lexer error (unrecognised character)
 };
 
 /** @brief A single lexical token with source location. */
 struct Token {
-    TokenType   type;   ///< The token's classification.
+    TokenType type;     ///< The token's classification.
     std::string value;  ///< The raw text of the token (empty for punctuation).
-    int         line;   ///< 1-based source line number.
-    int         column; ///< 1-based source column number.
+    int line;           ///< 1-based source line number.
+    int column;         ///< 1-based source column number.
 
     Token() : type(TokenType::EOF_TOKEN), value(""), line(0), column(0) {}
 
@@ -81,49 +81,88 @@ struct Token {
 /** @brief Returns a human-readable string for a TokenType value. */
 inline std::string tokenTypeToString(TokenType type) {
     switch (type) {
-    case TokenType::ASK: return "ASK";
-    case TokenType::LET: return "LET";
-    case TokenType::MKDIR: return "MKDIR";
-    case TokenType::FILE: return "FILE";
-    case TokenType::FROM: return "FROM";
-    case TokenType::CONTENT: return "CONTENT";
-    case TokenType::WHEN: return "WHEN";
-    case TokenType::REPEAT: return "REPEAT";
-    case TokenType::END: return "END";
-    case TokenType::REQUIRED: return "REQUIRED";
-    case TokenType::VERBATIM: return "VERBATIM";
-    case TokenType::APPEND: return "APPEND";
-    case TokenType::MODE: return "MODE";
-    case TokenType::AS: return "AS";
-    case TokenType::AND: return "AND";
-    case TokenType::OR: return "OR";
-    case TokenType::NOT: return "NOT";
-    case TokenType::STRING_TYPE: return "STRING_TYPE";
-    case TokenType::BOOL_TYPE: return "BOOL_TYPE";
-    case TokenType::INT_TYPE: return "INT_TYPE";
-    case TokenType::STRING_LITERAL: return "STRING_LITERAL";
-    case TokenType::INTEGER_LITERAL: return "INTEGER_LITERAL";
-    case TokenType::IDENTIFIER: return "IDENTIFIER";
-    case TokenType::EQUALS: return "EQUALS";
-    case TokenType::NOT_EQUALS: return "NOT_EQUALS";
-    case TokenType::GREATER: return "GREATER";
-    case TokenType::LESS: return "LESS";
-    case TokenType::GREATER_EQUAL: return "GREATER_EQUAL";
-    case TokenType::LESS_EQUAL: return "LESS_EQUAL";
-    case TokenType::PLUS: return "PLUS";
-    case TokenType::MINUS: return "MINUS";
-    case TokenType::STAR: return "STAR";
-    case TokenType::SLASH: return "SLASH";
-    case TokenType::ASSIGN: return "ASSIGN";
-    case TokenType::NEWLINE: return "NEWLINE";
-    case TokenType::LPAREN: return "LPAREN";
-    case TokenType::RPAREN: return "RPAREN";
-    case TokenType::EOF_TOKEN: return "EOF_TOKEN";
-    case TokenType::ERROR: return "ERROR";
+        case TokenType::ASK:
+            return "ASK";
+        case TokenType::LET:
+            return "LET";
+        case TokenType::MKDIR:
+            return "MKDIR";
+        case TokenType::FILE:
+            return "FILE";
+        case TokenType::FROM:
+            return "FROM";
+        case TokenType::CONTENT:
+            return "CONTENT";
+        case TokenType::WHEN:
+            return "WHEN";
+        case TokenType::REPEAT:
+            return "REPEAT";
+        case TokenType::END:
+            return "END";
+        case TokenType::REQUIRED:
+            return "REQUIRED";
+        case TokenType::VERBATIM:
+            return "VERBATIM";
+        case TokenType::APPEND:
+            return "APPEND";
+        case TokenType::MODE:
+            return "MODE";
+        case TokenType::AS:
+            return "AS";
+        case TokenType::AND:
+            return "AND";
+        case TokenType::OR:
+            return "OR";
+        case TokenType::NOT:
+            return "NOT";
+        case TokenType::STRING_TYPE:
+            return "STRING_TYPE";
+        case TokenType::BOOL_TYPE:
+            return "BOOL_TYPE";
+        case TokenType::INT_TYPE:
+            return "INT_TYPE";
+        case TokenType::STRING_LITERAL:
+            return "STRING_LITERAL";
+        case TokenType::INTEGER_LITERAL:
+            return "INTEGER_LITERAL";
+        case TokenType::IDENTIFIER:
+            return "IDENTIFIER";
+        case TokenType::EQUALS:
+            return "EQUALS";
+        case TokenType::NOT_EQUALS:
+            return "NOT_EQUALS";
+        case TokenType::GREATER:
+            return "GREATER";
+        case TokenType::LESS:
+            return "LESS";
+        case TokenType::GREATER_EQUAL:
+            return "GREATER_EQUAL";
+        case TokenType::LESS_EQUAL:
+            return "LESS_EQUAL";
+        case TokenType::PLUS:
+            return "PLUS";
+        case TokenType::MINUS:
+            return "MINUS";
+        case TokenType::STAR:
+            return "STAR";
+        case TokenType::SLASH:
+            return "SLASH";
+        case TokenType::ASSIGN:
+            return "ASSIGN";
+        case TokenType::NEWLINE:
+            return "NEWLINE";
+        case TokenType::LPAREN:
+            return "LPAREN";
+        case TokenType::RPAREN:
+            return "RPAREN";
+        case TokenType::EOF_TOKEN:
+            return "EOF_TOKEN";
+        case TokenType::ERROR:
+            return "ERROR";
     }
     return "UNKNOWN";
 }
 
-} // namespace spudplate
+}  // namespace spudplate
 
-#endif // SPUDPLATE_TOKEN_H
+#endif  // SPUDPLATE_TOKEN_H

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -72,7 +72,7 @@ struct Token {
     int line;           ///< 1-based source line number.
     int column;         ///< 1-based source column number.
 
-    Token() : type(TokenType::EOF_TOKEN), value(""), line(0), column(0) {}
+    Token() : type(TokenType::EOF_TOKEN), line(0), column(0) {}
 
     Token(TokenType type, std::string value, int line, int column)
         : type(type), value(std::move(value)), line(line), column(column) {}

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -5,26 +5,16 @@
 namespace spudplate {
 
 static const std::unordered_map<std::string, TokenType> keywords = {
-    {"ask", TokenType::ASK},
-    {"let", TokenType::LET},
-    {"mkdir", TokenType::MKDIR},
-    {"file", TokenType::FILE},
-    {"from", TokenType::FROM},
-    {"content", TokenType::CONTENT},
-    {"when", TokenType::WHEN},
-    {"repeat", TokenType::REPEAT},
-    {"end", TokenType::END},
-    {"required", TokenType::REQUIRED},
-    {"verbatim", TokenType::VERBATIM},
-    {"append", TokenType::APPEND},
-    {"mode", TokenType::MODE},
-    {"as", TokenType::AS},
-    {"and", TokenType::AND},
-    {"or", TokenType::OR},
-    {"not", TokenType::NOT},
-    {"string", TokenType::STRING_TYPE},
-    {"bool", TokenType::BOOL_TYPE},
-    {"int", TokenType::INT_TYPE},
+    {"ask", TokenType::ASK},           {"let", TokenType::LET},
+    {"mkdir", TokenType::MKDIR},       {"file", TokenType::FILE},
+    {"from", TokenType::FROM},         {"content", TokenType::CONTENT},
+    {"when", TokenType::WHEN},         {"repeat", TokenType::REPEAT},
+    {"end", TokenType::END},           {"required", TokenType::REQUIRED},
+    {"verbatim", TokenType::VERBATIM}, {"append", TokenType::APPEND},
+    {"mode", TokenType::MODE},         {"as", TokenType::AS},
+    {"and", TokenType::AND},           {"or", TokenType::OR},
+    {"not", TokenType::NOT},           {"string", TokenType::STRING_TYPE},
+    {"bool", TokenType::BOOL_TYPE},    {"int", TokenType::INT_TYPE},
 };
 
 Lexer::Lexer(std::string source)
@@ -49,7 +39,9 @@ char Lexer::advance() {
     return ch;
 }
 
-bool Lexer::isAtEnd() const { return pos_ >= source_.size(); }
+bool Lexer::isAtEnd() const {
+    return pos_ >= source_.size();
+}
 
 void Lexer::skipWhitespace() {
     while (!isAtEnd() && (current() == ' ' || current() == '\t')) {
@@ -63,8 +55,7 @@ Token Lexer::readIdentifierOrKeyword() {
     std::string value;
 
     while (!isAtEnd() &&
-           (std::isalnum(static_cast<unsigned char>(current())) ||
-            current() == '_')) {
+           (std::isalnum(static_cast<unsigned char>(current())) || current() == '_')) {
         value += advance();
     }
 
@@ -78,7 +69,7 @@ Token Lexer::readIdentifierOrKeyword() {
 Token Lexer::readStringLiteral() {
     int start_line = line_;
     int start_col = column_;
-    advance(); // skip opening "
+    advance();  // skip opening "
 
     std::string value;
     while (!isAtEnd() && current() != '"') {
@@ -86,11 +77,10 @@ Token Lexer::readStringLiteral() {
     }
 
     if (isAtEnd()) {
-        return Token(TokenType::ERROR, "unterminated string", start_line,
-                     start_col);
+        return Token(TokenType::ERROR, "unterminated string", start_line, start_col);
     }
 
-    advance(); // skip closing "
+    advance();  // skip closing "
     return Token(TokenType::STRING_LITERAL, value, start_line, start_col);
 }
 
@@ -99,8 +89,7 @@ Token Lexer::readIntegerLiteral() {
     int start_col = column_;
     std::string value;
 
-    while (!isAtEnd() &&
-           std::isdigit(static_cast<unsigned char>(current()))) {
+    while (!isAtEnd() && std::isdigit(static_cast<unsigned char>(current()))) {
         value += advance();
     }
 
@@ -147,39 +136,45 @@ Token Lexer::nextToken() {
     advance();
 
     switch (ch) {
-    case '+': return Token(TokenType::PLUS, "+", start_line, start_col);
-    case '-': return Token(TokenType::MINUS, "-", start_line, start_col);
-    case '*': return Token(TokenType::STAR, "*", start_line, start_col);
-    case '/': return Token(TokenType::SLASH, "/", start_line, start_col);
-    case '(': return Token(TokenType::LPAREN, "(", start_line, start_col);
-    case ')': return Token(TokenType::RPAREN, ")", start_line, start_col);
-    case '=':
-        if (!isAtEnd() && current() == '=') {
-            advance();
-            return Token(TokenType::EQUALS, "==", start_line, start_col);
-        }
-        return Token(TokenType::ASSIGN, "=", start_line, start_col);
-    case '!':
-        if (!isAtEnd() && current() == '=') {
-            advance();
-            return Token(TokenType::NOT_EQUALS, "!=", start_line, start_col);
-        }
-        return Token(TokenType::ERROR, "!", start_line, start_col);
-    case '>':
-        if (!isAtEnd() && current() == '=') {
-            advance();
-            return Token(TokenType::GREATER_EQUAL, ">=", start_line, start_col);
-        }
-        return Token(TokenType::GREATER, ">", start_line, start_col);
-    case '<':
-        if (!isAtEnd() && current() == '=') {
-            advance();
-            return Token(TokenType::LESS_EQUAL, "<=", start_line, start_col);
-        }
-        return Token(TokenType::LESS, "<", start_line, start_col);
-    default:
-        return Token(TokenType::ERROR, std::string(1, ch), start_line, start_col);
+        case '+':
+            return Token(TokenType::PLUS, "+", start_line, start_col);
+        case '-':
+            return Token(TokenType::MINUS, "-", start_line, start_col);
+        case '*':
+            return Token(TokenType::STAR, "*", start_line, start_col);
+        case '/':
+            return Token(TokenType::SLASH, "/", start_line, start_col);
+        case '(':
+            return Token(TokenType::LPAREN, "(", start_line, start_col);
+        case ')':
+            return Token(TokenType::RPAREN, ")", start_line, start_col);
+        case '=':
+            if (!isAtEnd() && current() == '=') {
+                advance();
+                return Token(TokenType::EQUALS, "==", start_line, start_col);
+            }
+            return Token(TokenType::ASSIGN, "=", start_line, start_col);
+        case '!':
+            if (!isAtEnd() && current() == '=') {
+                advance();
+                return Token(TokenType::NOT_EQUALS, "!=", start_line, start_col);
+            }
+            return Token(TokenType::ERROR, "!", start_line, start_col);
+        case '>':
+            if (!isAtEnd() && current() == '=') {
+                advance();
+                return Token(TokenType::GREATER_EQUAL, ">=", start_line, start_col);
+            }
+            return Token(TokenType::GREATER, ">", start_line, start_col);
+        case '<':
+            if (!isAtEnd() && current() == '=') {
+                advance();
+                return Token(TokenType::LESS_EQUAL, "<=", start_line, start_col);
+            }
+            return Token(TokenType::LESS, "<", start_line, start_col);
+        default:
+            return Token(TokenType::ERROR, std::string(1, ch), start_line, start_col);
     }
 }
 
-} // namespace spudplate
+}  // namespace spudplate

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -55,7 +55,7 @@ Token Lexer::readIdentifierOrKeyword() {
     std::string value;
 
     while (!isAtEnd() &&
-           (std::isalnum(static_cast<unsigned char>(current())) || current() == '_')) {
+           (std::isalnum(static_cast<unsigned char>(current())) != 0 || current() == '_')) {
         value += advance();
     }
 
@@ -89,7 +89,7 @@ Token Lexer::readIntegerLiteral() {
     int start_col = column_;
     std::string value;
 
-    while (!isAtEnd() && std::isdigit(static_cast<unsigned char>(current()))) {
+    while (!isAtEnd() && std::isdigit(static_cast<unsigned char>(current())) != 0) {
         value += advance();
     }
 
@@ -119,7 +119,7 @@ Token Lexer::nextToken() {
 
     char ch = current();
 
-    if (std::isalpha(static_cast<unsigned char>(ch)) || ch == '_') {
+    if (std::isalpha(static_cast<unsigned char>(ch)) != 0 || ch == '_') {
         return readIdentifierOrKeyword();
     }
 
@@ -127,7 +127,7 @@ Token Lexer::nextToken() {
         return readStringLiteral();
     }
 
-    if (std::isdigit(static_cast<unsigned char>(ch))) {
+    if (std::isdigit(static_cast<unsigned char>(ch)) != 0) {
         return readIntegerLiteral();
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,10 @@
 
 int main(int argc, char* argv[]) {
     if (argc < 2) {
-        std::cerr << "Usage: spudplate <file.spud>" << std::endl;
+        std::cerr << "Usage: spudplate <file.spud>" << '\n';
         return 1;
     }
 
-    std::cout << "spudplate: " << argv[1] << std::endl;
+    std::cout << "spudplate: " << argv[1] << '\n';
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
     if (argc < 2) {
         std::cerr << "Usage: spudplate <file.spud>" << std::endl;
         return 1;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -12,7 +12,9 @@ Token Parser::advance() {
     return prev;
 }
 
-bool Parser::check(TokenType type) const { return current_.type == type; }
+bool Parser::check(TokenType type) const {
+    return current_.type == type;
+}
 
 bool Parser::match(TokenType type) {
     if (check(type)) {
@@ -22,7 +24,7 @@ bool Parser::match(TokenType type) {
     return false;
 }
 
-Token Parser::expect(TokenType type, const std::string &message) {
+Token Parser::expect(TokenType type, const std::string& message) {
     if (check(type)) {
         return advance();
     }
@@ -57,12 +59,11 @@ std::optional<ExprPtr> Parser::parse_when_clause() {
 std::optional<int> Parser::parse_mode_clause() {
     if (!match(TokenType::MODE))
         return std::nullopt;
-    Token tok = expect(TokenType::INTEGER_LITERAL,
-                       "expected octal integer after 'mode'");
+    Token tok = expect(TokenType::INTEGER_LITERAL, "expected octal integer after 'mode'");
     return std::stoi(tok.value, nullptr, 8);
 }
 
-void Parser::expect_newline(const std::string &context) {
+void Parser::expect_newline(const std::string& context) {
     if (check(TokenType::EOF_TOKEN))
         return;
     expect(TokenType::NEWLINE, "expected newline after " + context);
@@ -73,24 +74,22 @@ void Parser::expect_newline(const std::string &context) {
 StmtPtr Parser::parseAsk() {
     Token start = expect(TokenType::ASK, "expected 'ask'");
     Token name = expect(TokenType::IDENTIFIER, "expected variable name after 'ask'");
-    Token prompt =
-        expect(TokenType::STRING_LITERAL, "expected prompt string after name");
+    Token prompt = expect(TokenType::STRING_LITERAL, "expected prompt string after name");
     VarType var_type = parse_var_type();
     bool required = match(TokenType::REQUIRED);
     auto when_clause = parse_when_clause();
     expect_newline("ask statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = AskStmt{name.value,         prompt.value,          var_type,
-                    required,            std::move(when_clause), start.line,
-                    start.column};
+    stmt->data =
+        AskStmt{name.value, prompt.value, var_type, required, std::move(when_clause),
+                start.line, start.column};
     return stmt;
 }
 
 StmtPtr Parser::parseLet() {
     Token start = expect(TokenType::LET, "expected 'let'");
-    Token name =
-        expect(TokenType::IDENTIFIER, "expected variable name after 'let'");
+    Token name = expect(TokenType::IDENTIFIER, "expected variable name after 'let'");
     expect(TokenType::ASSIGN, "expected '=' after variable name");
     auto value = parseExpression();
     expect_newline("let statement");
@@ -102,29 +101,27 @@ StmtPtr Parser::parseLet() {
 
 StmtPtr Parser::parseMkdir() {
     Token start = expect(TokenType::MKDIR, "expected 'mkdir'");
-    Token path =
-        expect(TokenType::STRING_LITERAL, "expected path string after 'mkdir'");
+    Token path = expect(TokenType::STRING_LITERAL, "expected path string after 'mkdir'");
     auto mode = parse_mode_clause();
     auto when_clause = parse_when_clause();
     expect_newline("mkdir statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = MkdirStmt{path.value, mode, std::move(when_clause), start.line,
-                      start.column};
+    stmt->data =
+        MkdirStmt{path.value, mode, std::move(when_clause), start.line, start.column};
     return stmt;
 }
 
 StmtPtr Parser::parseFile() {
     Token start = expect(TokenType::FILE, "expected 'file'");
-    Token path =
-        expect(TokenType::STRING_LITERAL, "expected path string after 'file'");
+    Token path = expect(TokenType::STRING_LITERAL, "expected path string after 'file'");
 
     bool append = match(TokenType::APPEND);
 
     FileSource source = [&]() -> FileSource {
         if (match(TokenType::FROM)) {
-            Token src = expect(TokenType::STRING_LITERAL,
-                               "expected source path after 'from'");
+            Token src =
+                expect(TokenType::STRING_LITERAL, "expected source path after 'from'");
             bool verbatim = match(TokenType::VERBATIM);
             return FileFromSource{src.value, verbatim};
         }
@@ -132,8 +129,8 @@ StmtPtr Parser::parseFile() {
             auto value = parseExpression();
             return FileContentSource{std::move(value)};
         }
-        throw ParseError("expected 'from' or 'content' after file path",
-                         current_.line, current_.column);
+        throw ParseError("expected 'from' or 'content' after file path", current_.line,
+                         current_.column);
     }();
 
     auto mode = parse_mode_clause();
@@ -141,8 +138,9 @@ StmtPtr Parser::parseFile() {
     expect_newline("file statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = FileStmt{path.value, std::move(source), append, mode,
-                     std::move(when_clause), start.line, start.column};
+    stmt->data =
+        FileStmt{path.value, std::move(source), append, mode, std::move(when_clause),
+                 start.line, start.column};
     return stmt;
 }
 
@@ -168,8 +166,8 @@ StmtPtr Parser::parseRepeat() {
     expect_newline("repeat block");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = RepeatStmt{collection.value, iterator.value, std::move(body),
-                            start.line, start.column};
+    stmt->data = RepeatStmt{collection.value, iterator.value, std::move(body), start.line,
+                            start.column};
     return stmt;
 }
 
@@ -205,7 +203,9 @@ Program Parser::parse() {
 // Expression precedence: or < and < comparison < addition < multiplication <
 // unary < primary
 
-ExprPtr Parser::parseExpression() { return parse_or(); }
+ExprPtr Parser::parseExpression() {
+    return parse_or();
+}
 
 ExprPtr Parser::parse_or() {
     auto left = parse_and();
@@ -217,8 +217,8 @@ ExprPtr Parser::parse_or() {
         auto right = parse_and();
 
         auto expr = std::make_unique<Expr>();
-        expr->data = BinaryExpr{TokenType::OR, std::move(left), std::move(right),
-                                line, col};
+        expr->data =
+            BinaryExpr{TokenType::OR, std::move(left), std::move(right), line, col};
         left = std::move(expr);
     }
 
@@ -235,8 +235,8 @@ ExprPtr Parser::parse_and() {
         auto right = parse_comparison();
 
         auto expr = std::make_unique<Expr>();
-        expr->data = BinaryExpr{TokenType::AND, std::move(left),
-                                std::move(right), line, col};
+        expr->data =
+            BinaryExpr{TokenType::AND, std::move(left), std::move(right), line, col};
         left = std::move(expr);
     }
 
@@ -256,8 +256,7 @@ ExprPtr Parser::parse_comparison() {
         auto right = parse_addition();
 
         auto expr = std::make_unique<Expr>();
-        expr->data =
-            BinaryExpr{op, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{op, std::move(left), std::move(right), line, col};
         left = std::move(expr);
     }
 
@@ -275,8 +274,7 @@ ExprPtr Parser::parse_addition() {
         auto right = parse_multiplication();
 
         auto expr = std::make_unique<Expr>();
-        expr->data =
-            BinaryExpr{op, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{op, std::move(left), std::move(right), line, col};
         left = std::move(expr);
     }
 
@@ -294,8 +292,7 @@ ExprPtr Parser::parse_multiplication() {
         auto right = parse_unary();
 
         auto expr = std::make_unique<Expr>();
-        expr->data =
-            BinaryExpr{op, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{op, std::move(left), std::move(right), line, col};
         left = std::move(expr);
     }
 
@@ -328,8 +325,7 @@ ExprPtr Parser::parse_primary() {
     if (check(TokenType::INTEGER_LITERAL)) {
         Token tok = advance();
         auto expr = std::make_unique<Expr>();
-        expr->data =
-            IntegerLiteralExpr{std::stoi(tok.value), tok.line, tok.column};
+        expr->data = IntegerLiteralExpr{std::stoi(tok.value), tok.line, tok.column};
         return expr;
     }
 
@@ -343,8 +339,8 @@ ExprPtr Parser::parse_primary() {
             expect(TokenType::RPAREN, "expected ')' after function argument");
 
             auto expr = std::make_unique<Expr>();
-            expr->data = FunctionCallExpr{tok.value, std::move(arg), tok.line,
-                                          tok.column};
+            expr->data =
+                FunctionCallExpr{tok.value, std::move(arg), tok.line, tok.column};
             return expr;
         }
 
@@ -364,4 +360,4 @@ ExprPtr Parser::parse_primary() {
                      current_.column);
 }
 
-} // namespace spudplate
+}  // namespace spudplate

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -40,32 +40,38 @@ void Parser::skip_newlines() {
 // Statement helpers
 
 VarType Parser::parse_var_type() {
-    if (match(TokenType::STRING_TYPE))
+    if (match(TokenType::STRING_TYPE)) {
         return VarType::String;
-    if (match(TokenType::BOOL_TYPE))
+    }
+    if (match(TokenType::BOOL_TYPE)) {
         return VarType::Bool;
-    if (match(TokenType::INT_TYPE))
+    }
+    if (match(TokenType::INT_TYPE)) {
         return VarType::Int;
+    }
     throw ParseError("expected type (string, bool, or int)", current_.line,
                      current_.column);
 }
 
 std::optional<ExprPtr> Parser::parse_when_clause() {
-    if (!match(TokenType::WHEN))
+    if (!match(TokenType::WHEN)) {
         return std::nullopt;
+    }
     return parseExpression();
 }
 
 std::optional<int> Parser::parse_mode_clause() {
-    if (!match(TokenType::MODE))
+    if (!match(TokenType::MODE)) {
         return std::nullopt;
+    }
     Token tok = expect(TokenType::INTEGER_LITERAL, "expected octal integer after 'mode'");
     return std::stoi(tok.value, nullptr, 8);
 }
 
 void Parser::expect_newline(const std::string& context) {
-    if (check(TokenType::EOF_TOKEN))
+    if (check(TokenType::EOF_TOKEN)) {
         return;
+    }
     expect(TokenType::NEWLINE, "expected newline after " + context);
 }
 
@@ -81,9 +87,13 @@ StmtPtr Parser::parseAsk() {
     expect_newline("ask statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data =
-        AskStmt{name.value, prompt.value, var_type, required, std::move(when_clause),
-                start.line, start.column};
+    stmt->data = AskStmt{.name = name.value,
+                         .prompt = prompt.value,
+                         .var_type = var_type,
+                         .required = required,
+                         .when_clause = std::move(when_clause),
+                         .line = start.line,
+                         .column = start.column};
     return stmt;
 }
 
@@ -95,7 +105,10 @@ StmtPtr Parser::parseLet() {
     expect_newline("let statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = LetStmt{name.value, std::move(value), start.line, start.column};
+    stmt->data = LetStmt{.name = name.value,
+                         .value = std::move(value),
+                         .line = start.line,
+                         .column = start.column};
     return stmt;
 }
 
@@ -107,8 +120,11 @@ StmtPtr Parser::parseMkdir() {
     expect_newline("mkdir statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data =
-        MkdirStmt{path.value, mode, std::move(when_clause), start.line, start.column};
+    stmt->data = MkdirStmt{.path = path.value,
+                            .mode = mode,
+                            .when_clause = std::move(when_clause),
+                            .line = start.line,
+                            .column = start.column};
     return stmt;
 }
 
@@ -123,7 +139,7 @@ StmtPtr Parser::parseFile() {
             Token src =
                 expect(TokenType::STRING_LITERAL, "expected source path after 'from'");
             bool verbatim = match(TokenType::VERBATIM);
-            return FileFromSource{src.value, verbatim};
+            return FileFromSource{.path = src.value, .verbatim = verbatim};
         }
         if (match(TokenType::CONTENT)) {
             auto value = parseExpression();
@@ -138,9 +154,13 @@ StmtPtr Parser::parseFile() {
     expect_newline("file statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data =
-        FileStmt{path.value, std::move(source), append, mode, std::move(when_clause),
-                 start.line, start.column};
+    stmt->data = FileStmt{.path = path.value,
+                          .source = std::move(source),
+                          .append = append,
+                          .mode = mode,
+                          .when_clause = std::move(when_clause),
+                          .line = start.line,
+                          .column = start.column};
     return stmt;
 }
 
@@ -166,24 +186,32 @@ StmtPtr Parser::parseRepeat() {
     expect_newline("repeat block");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = RepeatStmt{collection.value, iterator.value, std::move(body), start.line,
-                            start.column};
+    stmt->data = RepeatStmt{.collection_var = collection.value,
+                             .iterator_var = iterator.value,
+                             .body = std::move(body),
+                             .line = start.line,
+                             .column = start.column};
     return stmt;
 }
 
 // Statement dispatch
 
 StmtPtr Parser::parseStatement() {
-    if (check(TokenType::ASK))
+    if (check(TokenType::ASK)) {
         return parseAsk();
-    if (check(TokenType::LET))
+    }
+    if (check(TokenType::LET)) {
         return parseLet();
-    if (check(TokenType::MKDIR))
+    }
+    if (check(TokenType::MKDIR)) {
         return parseMkdir();
-    if (check(TokenType::FILE))
+    }
+    if (check(TokenType::FILE)) {
         return parseFile();
-    if (check(TokenType::REPEAT))
+    }
+    if (check(TokenType::REPEAT)) {
         return parseRepeat();
+    }
     throw ParseError("unexpected token: " + current_.value, current_.line,
                      current_.column);
 }
@@ -217,8 +245,11 @@ ExprPtr Parser::parse_or() {
         auto right = parse_and();
 
         auto expr = std::make_unique<Expr>();
-        expr->data =
-            BinaryExpr{TokenType::OR, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{.op = TokenType::OR,
+                                 .left = std::move(left),
+                                 .right = std::move(right),
+                                 .line = line,
+                                 .column = col};
         left = std::move(expr);
     }
 
@@ -235,8 +266,11 @@ ExprPtr Parser::parse_and() {
         auto right = parse_comparison();
 
         auto expr = std::make_unique<Expr>();
-        expr->data =
-            BinaryExpr{TokenType::AND, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{.op = TokenType::AND,
+                                 .left = std::move(left),
+                                 .right = std::move(right),
+                                 .line = line,
+                                 .column = col};
         left = std::move(expr);
     }
 
@@ -256,7 +290,11 @@ ExprPtr Parser::parse_comparison() {
         auto right = parse_addition();
 
         auto expr = std::make_unique<Expr>();
-        expr->data = BinaryExpr{op, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{.op = op,
+                                 .left = std::move(left),
+                                 .right = std::move(right),
+                                 .line = line,
+                                 .column = col};
         left = std::move(expr);
     }
 
@@ -274,7 +312,11 @@ ExprPtr Parser::parse_addition() {
         auto right = parse_multiplication();
 
         auto expr = std::make_unique<Expr>();
-        expr->data = BinaryExpr{op, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{.op = op,
+                                 .left = std::move(left),
+                                 .right = std::move(right),
+                                 .line = line,
+                                 .column = col};
         left = std::move(expr);
     }
 
@@ -292,7 +334,11 @@ ExprPtr Parser::parse_multiplication() {
         auto right = parse_unary();
 
         auto expr = std::make_unique<Expr>();
-        expr->data = BinaryExpr{op, std::move(left), std::move(right), line, col};
+        expr->data = BinaryExpr{.op = op,
+                                 .left = std::move(left),
+                                 .right = std::move(right),
+                                 .line = line,
+                                 .column = col};
         left = std::move(expr);
     }
 
@@ -307,7 +353,10 @@ ExprPtr Parser::parse_unary() {
         auto operand = parse_unary();
 
         auto expr = std::make_unique<Expr>();
-        expr->data = UnaryExpr{TokenType::NOT, std::move(operand), line, col};
+        expr->data = UnaryExpr{.op = TokenType::NOT,
+                                .operand = std::move(operand),
+                                .line = line,
+                                .column = col};
         return expr;
     }
 
@@ -318,14 +367,16 @@ ExprPtr Parser::parse_primary() {
     if (check(TokenType::STRING_LITERAL)) {
         Token tok = advance();
         auto expr = std::make_unique<Expr>();
-        expr->data = StringLiteralExpr{tok.value, tok.line, tok.column};
+        expr->data =
+            StringLiteralExpr{.value = tok.value, .line = tok.line, .column = tok.column};
         return expr;
     }
 
     if (check(TokenType::INTEGER_LITERAL)) {
         Token tok = advance();
         auto expr = std::make_unique<Expr>();
-        expr->data = IntegerLiteralExpr{std::stoi(tok.value), tok.line, tok.column};
+        expr->data = IntegerLiteralExpr{
+            .value = std::stoi(tok.value), .line = tok.line, .column = tok.column};
         return expr;
     }
 
@@ -339,13 +390,16 @@ ExprPtr Parser::parse_primary() {
             expect(TokenType::RPAREN, "expected ')' after function argument");
 
             auto expr = std::make_unique<Expr>();
-            expr->data =
-                FunctionCallExpr{tok.value, std::move(arg), tok.line, tok.column};
+            expr->data = FunctionCallExpr{.name = tok.value,
+                                           .argument = std::move(arg),
+                                           .line = tok.line,
+                                           .column = tok.column};
             return expr;
         }
 
         auto expr = std::make_unique<Expr>();
-        expr->data = IdentifierExpr{tok.value, tok.line, tok.column};
+        expr->data =
+            IdentifierExpr{.name = tok.value, .line = tok.line, .column = tok.column};
         return expr;
     }
 

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -1,7 +1,8 @@
 #include "spudplate/lexer.h"
-#include "spudplate/token.h"
 
 #include <gtest/gtest.h>
+
+#include "spudplate/token.h"
 
 using spudplate::Lexer;
 using spudplate::Token;
@@ -76,7 +77,7 @@ TEST(LexerTest, WhitespaceBeforeUnrecognized) {
 
 TEST(LexerTest, AllKeywords) {
     struct Case {
-        const char *input;
+        const char* input;
         TokenType expected;
     };
     Case cases[] = {
@@ -100,11 +101,10 @@ TEST(LexerTest, AllKeywords) {
         {"bool", TokenType::BOOL_TYPE},
         {"int", TokenType::INT_TYPE},
     };
-    for (const auto &c : cases) {
+    for (const auto& c : cases) {
         Lexer lexer(c.input);
         Token tok = lexer.nextToken();
-        EXPECT_EQ(tok.type, c.expected)
-            << "Failed for keyword: " << c.input;
+        EXPECT_EQ(tok.type, c.expected) << "Failed for keyword: " << c.input;
         EXPECT_EQ(tok.value, c.input);
         EXPECT_EQ(tok.line, 1);
         EXPECT_EQ(tok.column, 1);
@@ -249,19 +249,16 @@ TEST(LexerTest, IntegerColumnTracking) {
 
 TEST(LexerTest, SingleCharOperators) {
     struct Case {
-        const char *input;
+        const char* input;
         TokenType expected;
-        const char *value;
+        const char* value;
     };
     Case cases[] = {
-        {"+", TokenType::PLUS, "+"},
-        {"-", TokenType::MINUS, "-"},
-        {"*", TokenType::STAR, "*"},
-        {"/", TokenType::SLASH, "/"},
-        {"(", TokenType::LPAREN, "("},
-        {")", TokenType::RPAREN, ")"},
+        {"+", TokenType::PLUS, "+"},   {"-", TokenType::MINUS, "-"},
+        {"*", TokenType::STAR, "*"},   {"/", TokenType::SLASH, "/"},
+        {"(", TokenType::LPAREN, "("}, {")", TokenType::RPAREN, ")"},
     };
-    for (const auto &c : cases) {
+    for (const auto& c : cases) {
         Lexer lexer(c.input);
         Token tok = lexer.nextToken();
         EXPECT_EQ(tok.type, c.expected) << "Failed for: " << c.input;

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -1,8 +1,9 @@
-#include "spudplate/ast.h"
-#include "spudplate/lexer.h"
 #include "spudplate/parser.h"
 
 #include <gtest/gtest.h>
+
+#include "spudplate/ast.h"
+#include "spudplate/lexer.h"
 
 using spudplate::AskStmt;
 using spudplate::BinaryExpr;
@@ -26,7 +27,7 @@ using spudplate::TokenType;
 using spudplate::UnaryExpr;
 using spudplate::VarType;
 
-static ExprPtr parse_expr(const std::string &input) {
+static ExprPtr parse_expr(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parseExpression();
@@ -34,7 +35,7 @@ static ExprPtr parse_expr(const std::string &input) {
 
 TEST(ParserTest, StringLiteral) {
     auto expr = parse_expr("\"hello\"");
-    auto &lit = std::get<StringLiteralExpr>(expr->data);
+    auto& lit = std::get<StringLiteralExpr>(expr->data);
     EXPECT_EQ(lit.value, "hello");
     EXPECT_EQ(lit.line, 1);
     EXPECT_EQ(lit.column, 1);
@@ -42,141 +43,141 @@ TEST(ParserTest, StringLiteral) {
 
 TEST(ParserTest, IntegerLiteral) {
     auto expr = parse_expr("42");
-    auto &lit = std::get<IntegerLiteralExpr>(expr->data);
+    auto& lit = std::get<IntegerLiteralExpr>(expr->data);
     EXPECT_EQ(lit.value, 42);
 }
 
 TEST(ParserTest, Identifier) {
     auto expr = parse_expr("my_var");
-    auto &id = std::get<IdentifierExpr>(expr->data);
+    auto& id = std::get<IdentifierExpr>(expr->data);
     EXPECT_EQ(id.name, "my_var");
 }
 
 TEST(ParserTest, BinaryAddition) {
     auto expr = parse_expr("1 + 2");
-    auto &bin = std::get<BinaryExpr>(expr->data);
+    auto& bin = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(bin.op, TokenType::PLUS);
 
-    auto &left = std::get<IntegerLiteralExpr>(bin.left->data);
+    auto& left = std::get<IntegerLiteralExpr>(bin.left->data);
     EXPECT_EQ(left.value, 1);
 
-    auto &right = std::get<IntegerLiteralExpr>(bin.right->data);
+    auto& right = std::get<IntegerLiteralExpr>(bin.right->data);
     EXPECT_EQ(right.value, 2);
 }
 
 TEST(ParserTest, BinaryMultiplication) {
     auto expr = parse_expr("3 * 4");
-    auto &bin = std::get<BinaryExpr>(expr->data);
+    auto& bin = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(bin.op, TokenType::STAR);
 }
 
 TEST(ParserTest, PrecedenceMulOverAdd) {
     // 1 + 2 * 3 should parse as 1 + (2 * 3)
     auto expr = parse_expr("1 + 2 * 3");
-    auto &add = std::get<BinaryExpr>(expr->data);
+    auto& add = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(add.op, TokenType::PLUS);
 
-    auto &left = std::get<IntegerLiteralExpr>(add.left->data);
+    auto& left = std::get<IntegerLiteralExpr>(add.left->data);
     EXPECT_EQ(left.value, 1);
 
-    auto &mul = std::get<BinaryExpr>(add.right->data);
+    auto& mul = std::get<BinaryExpr>(add.right->data);
     EXPECT_EQ(mul.op, TokenType::STAR);
 }
 
 TEST(ParserTest, PrecedenceSubDiv) {
     // 10 - 5 / 2 should parse as 10 - (5 / 2)
     auto expr = parse_expr("10 - 5 / 2");
-    auto &sub = std::get<BinaryExpr>(expr->data);
+    auto& sub = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(sub.op, TokenType::MINUS);
 
-    auto &div = std::get<BinaryExpr>(sub.right->data);
+    auto& div = std::get<BinaryExpr>(sub.right->data);
     EXPECT_EQ(div.op, TokenType::SLASH);
 }
 
 TEST(ParserTest, Comparison) {
     auto expr = parse_expr("x > 5");
-    auto &cmp = std::get<BinaryExpr>(expr->data);
+    auto& cmp = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(cmp.op, TokenType::GREATER);
 
-    auto &left = std::get<IdentifierExpr>(cmp.left->data);
+    auto& left = std::get<IdentifierExpr>(cmp.left->data);
     EXPECT_EQ(left.name, "x");
 
-    auto &right = std::get<IntegerLiteralExpr>(cmp.right->data);
+    auto& right = std::get<IntegerLiteralExpr>(cmp.right->data);
     EXPECT_EQ(right.value, 5);
 }
 
 TEST(ParserTest, EqualityComparison) {
     auto expr = parse_expr("name == \"foo\"");
-    auto &cmp = std::get<BinaryExpr>(expr->data);
+    auto& cmp = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(cmp.op, TokenType::EQUALS);
 }
 
 TEST(ParserTest, LogicalAnd) {
     auto expr = parse_expr("a and b");
-    auto &bin = std::get<BinaryExpr>(expr->data);
+    auto& bin = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(bin.op, TokenType::AND);
 }
 
 TEST(ParserTest, LogicalOr) {
     auto expr = parse_expr("a or b");
-    auto &bin = std::get<BinaryExpr>(expr->data);
+    auto& bin = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(bin.op, TokenType::OR);
 }
 
 TEST(ParserTest, UnaryNot) {
     auto expr = parse_expr("not x");
-    auto &un = std::get<UnaryExpr>(expr->data);
+    auto& un = std::get<UnaryExpr>(expr->data);
     EXPECT_EQ(un.op, TokenType::NOT);
 
-    auto &operand = std::get<IdentifierExpr>(un.operand->data);
+    auto& operand = std::get<IdentifierExpr>(un.operand->data);
     EXPECT_EQ(operand.name, "x");
 }
 
 TEST(ParserTest, CombinedPrecedence) {
     // a + b > c and d → (((a + b) > c) and d)
     auto expr = parse_expr("a + b > c and d");
-    auto &and_expr = std::get<BinaryExpr>(expr->data);
+    auto& and_expr = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(and_expr.op, TokenType::AND);
 
-    auto &cmp = std::get<BinaryExpr>(and_expr.left->data);
+    auto& cmp = std::get<BinaryExpr>(and_expr.left->data);
     EXPECT_EQ(cmp.op, TokenType::GREATER);
 
-    auto &add = std::get<BinaryExpr>(cmp.left->data);
+    auto& add = std::get<BinaryExpr>(cmp.left->data);
     EXPECT_EQ(add.op, TokenType::PLUS);
 }
 
 TEST(ParserTest, FunctionCall) {
     auto expr = parse_expr("lower(name)");
-    auto &call = std::get<FunctionCallExpr>(expr->data);
+    auto& call = std::get<FunctionCallExpr>(expr->data);
     EXPECT_EQ(call.name, "lower");
 
-    auto &arg = std::get<IdentifierExpr>(call.argument->data);
+    auto& arg = std::get<IdentifierExpr>(call.argument->data);
     EXPECT_EQ(arg.name, "name");
 }
 
 TEST(ParserTest, FunctionCallUpper) {
     auto expr = parse_expr("upper(x)");
-    auto &call = std::get<FunctionCallExpr>(expr->data);
+    auto& call = std::get<FunctionCallExpr>(expr->data);
     EXPECT_EQ(call.name, "upper");
 }
 
 TEST(ParserTest, Parenthesized) {
     // (a + b) * c → should multiply, not add at top
     auto expr = parse_expr("(a + b) * c");
-    auto &mul = std::get<BinaryExpr>(expr->data);
+    auto& mul = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(mul.op, TokenType::STAR);
 
-    auto &add = std::get<BinaryExpr>(mul.left->data);
+    auto& add = std::get<BinaryExpr>(mul.left->data);
     EXPECT_EQ(add.op, TokenType::PLUS);
 }
 
 TEST(ParserTest, StringConcat) {
     auto expr = parse_expr("\"hello\" + \" \" + name");
-    auto &outer = std::get<BinaryExpr>(expr->data);
+    auto& outer = std::get<BinaryExpr>(expr->data);
     EXPECT_EQ(outer.op, TokenType::PLUS);
 
     // Left-associative: ("hello" + " ") + name
-    auto &inner = std::get<BinaryExpr>(outer.left->data);
+    auto& inner = std::get<BinaryExpr>(outer.left->data);
     EXPECT_EQ(inner.op, TokenType::PLUS);
 }
 
@@ -190,25 +191,25 @@ TEST(ParserTest, ErrorMissingCloseParen) {
 
 // --- Statement parsing helpers ---
 
-static StmtPtr parse_ask(const std::string &input) {
+static StmtPtr parse_ask(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parseAsk();
 }
 
-static StmtPtr parse_let(const std::string &input) {
+static StmtPtr parse_let(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parseLet();
 }
 
-static StmtPtr parse_mkdir(const std::string &input) {
+static StmtPtr parse_mkdir(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parseMkdir();
 }
 
-static StmtPtr parse_file(const std::string &input) {
+static StmtPtr parse_file(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parseFile();
@@ -218,7 +219,7 @@ static StmtPtr parse_file(const std::string &input) {
 
 TEST(ParserTest, AskBasicString) {
     auto stmt = parse_ask("ask name \"What is your name?\" string\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.name, "name");
     EXPECT_EQ(ask.prompt, "What is your name?");
     EXPECT_EQ(ask.var_type, VarType::String);
@@ -229,48 +230,48 @@ TEST(ParserTest, AskBasicString) {
 
 TEST(ParserTest, AskBoolType) {
     auto stmt = parse_ask("ask use_ci \"Enable CI?\" bool\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.var_type, VarType::Bool);
 }
 
 TEST(ParserTest, AskIntType) {
     auto stmt = parse_ask("ask count \"How many?\" int\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.var_type, VarType::Int);
 }
 
 TEST(ParserTest, AskRequired) {
     auto stmt = parse_ask("ask name \"Name?\" string required\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     EXPECT_TRUE(ask.required);
 }
 
 TEST(ParserTest, AskWhenClause) {
     auto stmt = parse_ask("ask port \"Port?\" int when use_server\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     ASSERT_TRUE(ask.when_clause.has_value());
-    auto &cond = std::get<IdentifierExpr>((*ask.when_clause)->data);
+    auto& cond = std::get<IdentifierExpr>((*ask.when_clause)->data);
     EXPECT_EQ(cond.name, "use_server");
 }
 
 TEST(ParserTest, AskRequiredAndWhen) {
     auto stmt = parse_ask("ask port \"Port?\" int required when use_server\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     EXPECT_TRUE(ask.required);
     ASSERT_TRUE(ask.when_clause.has_value());
 }
 
 TEST(ParserTest, AskWhenExpression) {
     auto stmt = parse_ask("ask x \"X?\" string when a and b\n");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     ASSERT_TRUE(ask.when_clause.has_value());
-    auto &bin = std::get<BinaryExpr>((*ask.when_clause)->data);
+    auto& bin = std::get<BinaryExpr>((*ask.when_clause)->data);
     EXPECT_EQ(bin.op, TokenType::AND);
 }
 
 TEST(ParserTest, AskAtEof) {
     auto stmt = parse_ask("ask name \"Name?\" string");
-    auto &ask = std::get<AskStmt>(stmt->data);
+    auto& ask = std::get<AskStmt>(stmt->data);
     EXPECT_EQ(ask.name, "name");
 }
 
@@ -290,30 +291,30 @@ TEST(ParserTest, AskMissingType) {
 
 TEST(ParserTest, LetBasic) {
     auto stmt = parse_let("let x = 42\n");
-    auto &let = std::get<LetStmt>(stmt->data);
+    auto& let = std::get<LetStmt>(stmt->data);
     EXPECT_EQ(let.name, "x");
-    auto &val = std::get<IntegerLiteralExpr>(let.value->data);
+    auto& val = std::get<IntegerLiteralExpr>(let.value->data);
     EXPECT_EQ(val.value, 42);
 }
 
 TEST(ParserTest, LetStringExpression) {
     auto stmt = parse_let("let greeting = \"hello\" + name\n");
-    auto &let = std::get<LetStmt>(stmt->data);
+    auto& let = std::get<LetStmt>(stmt->data);
     EXPECT_EQ(let.name, "greeting");
-    auto &bin = std::get<BinaryExpr>(let.value->data);
+    auto& bin = std::get<BinaryExpr>(let.value->data);
     EXPECT_EQ(bin.op, TokenType::PLUS);
 }
 
 TEST(ParserTest, LetFunctionCall) {
     auto stmt = parse_let("let lower_name = lower(name)\n");
-    auto &let = std::get<LetStmt>(stmt->data);
-    auto &call = std::get<FunctionCallExpr>(let.value->data);
+    auto& let = std::get<LetStmt>(stmt->data);
+    auto& call = std::get<FunctionCallExpr>(let.value->data);
     EXPECT_EQ(call.name, "lower");
 }
 
 TEST(ParserTest, LetAtEof) {
     auto stmt = parse_let("let x = 1");
-    auto &let = std::get<LetStmt>(stmt->data);
+    auto& let = std::get<LetStmt>(stmt->data);
     EXPECT_EQ(let.name, "x");
 }
 
@@ -329,7 +330,7 @@ TEST(ParserTest, LetMissingName) {
 
 TEST(ParserTest, MkdirBasic) {
     auto stmt = parse_mkdir("mkdir \"src\"\n");
-    auto &mk = std::get<MkdirStmt>(stmt->data);
+    auto& mk = std::get<MkdirStmt>(stmt->data);
     EXPECT_EQ(mk.path, "src");
     EXPECT_FALSE(mk.mode.has_value());
     EXPECT_FALSE(mk.when_clause.has_value());
@@ -337,7 +338,7 @@ TEST(ParserTest, MkdirBasic) {
 
 TEST(ParserTest, MkdirWithMode) {
     auto stmt = parse_mkdir("mkdir \"bin\" mode 0755\n");
-    auto &mk = std::get<MkdirStmt>(stmt->data);
+    auto& mk = std::get<MkdirStmt>(stmt->data);
     EXPECT_EQ(mk.path, "bin");
     ASSERT_TRUE(mk.mode.has_value());
     EXPECT_EQ(*mk.mode, 0755);
@@ -345,15 +346,15 @@ TEST(ParserTest, MkdirWithMode) {
 
 TEST(ParserTest, MkdirWithWhen) {
     auto stmt = parse_mkdir("mkdir \"tests\" when use_tests\n");
-    auto &mk = std::get<MkdirStmt>(stmt->data);
+    auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_TRUE(mk.when_clause.has_value());
-    auto &cond = std::get<IdentifierExpr>((*mk.when_clause)->data);
+    auto& cond = std::get<IdentifierExpr>((*mk.when_clause)->data);
     EXPECT_EQ(cond.name, "use_tests");
 }
 
 TEST(ParserTest, MkdirWithModeAndWhen) {
     auto stmt = parse_mkdir("mkdir \"bin\" mode 0755 when need_bin\n");
-    auto &mk = std::get<MkdirStmt>(stmt->data);
+    auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_TRUE(mk.mode.has_value());
     EXPECT_EQ(*mk.mode, 0755);
     ASSERT_TRUE(mk.when_clause.has_value());
@@ -361,7 +362,7 @@ TEST(ParserTest, MkdirWithModeAndWhen) {
 
 TEST(ParserTest, MkdirAtEof) {
     auto stmt = parse_mkdir("mkdir \"src\"");
-    auto &mk = std::get<MkdirStmt>(stmt->data);
+    auto& mk = std::get<MkdirStmt>(stmt->data);
     EXPECT_EQ(mk.path, "src");
 }
 
@@ -373,47 +374,47 @@ TEST(ParserTest, MkdirMissingPath) {
 
 TEST(ParserTest, FileFromBasic) {
     auto stmt = parse_file("file \"out.txt\" from \"template.txt\"\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_EQ(file.path, "out.txt");
     EXPECT_FALSE(file.append);
-    auto &src = std::get<FileFromSource>(file.source);
+    auto& src = std::get<FileFromSource>(file.source);
     EXPECT_EQ(src.path, "template.txt");
     EXPECT_FALSE(src.verbatim);
 }
 
 TEST(ParserTest, FileFromVerbatim) {
     auto stmt = parse_file("file \"out.c\" from \"main.c\" verbatim\n");
-    auto &file = std::get<FileStmt>(stmt->data);
-    auto &src = std::get<FileFromSource>(file.source);
+    auto& file = std::get<FileStmt>(stmt->data);
+    auto& src = std::get<FileFromSource>(file.source);
     EXPECT_TRUE(src.verbatim);
 }
 
 TEST(ParserTest, FileContentExpression) {
     auto stmt = parse_file("file \"readme.md\" content \"# \" + name\n");
-    auto &file = std::get<FileStmt>(stmt->data);
-    auto &src = std::get<FileContentSource>(file.source);
-    auto &bin = std::get<BinaryExpr>(src.value->data);
+    auto& file = std::get<FileStmt>(stmt->data);
+    auto& src = std::get<FileContentSource>(file.source);
+    auto& bin = std::get<BinaryExpr>(src.value->data);
     EXPECT_EQ(bin.op, TokenType::PLUS);
 }
 
 TEST(ParserTest, FileWithMode) {
     auto stmt = parse_file("file \"run.sh\" from \"run.sh\" mode 0755\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0755);
 }
 
 TEST(ParserTest, FileWithWhen) {
     auto stmt = parse_file("file \"ci.yml\" from \"ci.yml\" when use_ci\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     ASSERT_TRUE(file.when_clause.has_value());
 }
 
 TEST(ParserTest, FileFromVerbatimModeWhen) {
-    auto stmt = parse_file(
-        "file \"main.c\" from \"main.c\" verbatim mode 0644 when need_c\n");
-    auto &file = std::get<FileStmt>(stmt->data);
-    auto &src = std::get<FileFromSource>(file.source);
+    auto stmt =
+        parse_file("file \"main.c\" from \"main.c\" verbatim mode 0644 when need_c\n");
+    auto& file = std::get<FileStmt>(stmt->data);
+    auto& src = std::get<FileFromSource>(file.source);
     EXPECT_TRUE(src.verbatim);
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0644);
@@ -422,15 +423,15 @@ TEST(ParserTest, FileFromVerbatimModeWhen) {
 
 TEST(ParserTest, FileContentWithMode) {
     auto stmt = parse_file("file \"x\" content \"data\" mode 0444\n");
-    auto &file = std::get<FileStmt>(stmt->data);
-    std::get<FileContentSource>(file.source); // NOLINT
+    auto& file = std::get<FileStmt>(stmt->data);
+    std::get<FileContentSource>(file.source);  // NOLINT
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0444);
 }
 
 TEST(ParserTest, FileAtEof) {
     auto stmt = parse_file("file \"out.txt\" from \"in.txt\"");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_EQ(file.path, "out.txt");
 }
 
@@ -450,37 +451,36 @@ TEST(ParserTest, FileFromMissingSourcePath) {
 
 TEST(ParserTest, FileAppendFrom) {
     auto stmt = parse_file("file \"log.txt\" append from \"entry.txt\"\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_EQ(file.path, "log.txt");
     EXPECT_TRUE(file.append);
-    auto &src = std::get<FileFromSource>(file.source);
+    auto& src = std::get<FileFromSource>(file.source);
     EXPECT_EQ(src.path, "entry.txt");
     EXPECT_FALSE(src.verbatim);
 }
 
 TEST(ParserTest, FileAppendContent) {
     auto stmt = parse_file("file \"log.txt\" append content \"new line\"\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_TRUE(file.append);
-    auto &src = std::get<FileContentSource>(file.source);
-    auto &lit = std::get<StringLiteralExpr>(src.value->data);
+    auto& src = std::get<FileContentSource>(file.source);
+    auto& lit = std::get<StringLiteralExpr>(src.value->data);
     EXPECT_EQ(lit.value, "new line");
 }
 
 TEST(ParserTest, FileAppendFromVerbatim) {
     auto stmt = parse_file("file \"out\" append from \"src\" verbatim\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_TRUE(file.append);
-    auto &src = std::get<FileFromSource>(file.source);
+    auto& src = std::get<FileFromSource>(file.source);
     EXPECT_TRUE(src.verbatim);
 }
 
 TEST(ParserTest, FileAppendFromModeWhen) {
-    auto stmt = parse_file(
-        "file \"out\" append from \"src\" mode 0644 when active\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto stmt = parse_file("file \"out\" append from \"src\" mode 0644 when active\n");
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_TRUE(file.append);
-    auto &src = std::get<FileFromSource>(file.source);
+    auto& src = std::get<FileFromSource>(file.source);
     EXPECT_EQ(src.path, "src");
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0644);
@@ -489,13 +489,13 @@ TEST(ParserTest, FileAppendFromModeWhen) {
 
 TEST(ParserTest, FileWithoutAppendDefaultsFalse) {
     auto stmt = parse_file("file \"out\" from \"src\"\n");
-    auto &file = std::get<FileStmt>(stmt->data);
+    auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_FALSE(file.append);
 }
 
 // --- Repeat and program parsing helpers ---
 
-static Program parse_program(const std::string &input) {
+static Program parse_program(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parse();
@@ -506,7 +506,7 @@ static Program parse_program(const std::string &input) {
 TEST(ParserTest, SingleStatementProgram) {
     auto program = parse_program("ask name \"Name?\" string\n");
     ASSERT_EQ(program.statements.size(), 1);
-    auto &ask = std::get<AskStmt>(program.statements[0]->data);
+    auto& ask = std::get<AskStmt>(program.statements[0]->data);
     EXPECT_EQ(ask.name, "name");
 }
 
@@ -534,7 +534,7 @@ TEST(ParserTest, RepeatBasic) {
         "  mkdir \"dir\"\n"
         "end\n");
     ASSERT_EQ(program.statements.size(), 1);
-    auto &rep = std::get<RepeatStmt>(program.statements[0]->data);
+    auto& rep = std::get<RepeatStmt>(program.statements[0]->data);
     EXPECT_EQ(rep.collection_var, "items");
     EXPECT_EQ(rep.iterator_var, "item");
     ASSERT_EQ(rep.body.size(), 1);
@@ -549,7 +549,7 @@ TEST(ParserTest, RepeatMultipleBodyStatements) {
         "  let x = 1\n"
         "end\n");
     ASSERT_EQ(program.statements.size(), 1);
-    auto &rep = std::get<RepeatStmt>(program.statements[0]->data);
+    auto& rep = std::get<RepeatStmt>(program.statements[0]->data);
     ASSERT_EQ(rep.body.size(), 3);
     std::get<MkdirStmt>(rep.body[0]->data);
     std::get<FileStmt>(rep.body[1]->data);
@@ -564,9 +564,9 @@ TEST(ParserTest, RepeatNested) {
         "  end\n"
         "end\n");
     ASSERT_EQ(program.statements.size(), 1);
-    auto &outer = std::get<RepeatStmt>(program.statements[0]->data);
+    auto& outer = std::get<RepeatStmt>(program.statements[0]->data);
     ASSERT_EQ(outer.body.size(), 1);
-    auto &inner = std::get<RepeatStmt>(outer.body[0]->data);
+    auto& inner = std::get<RepeatStmt>(outer.body[0]->data);
     EXPECT_EQ(inner.collection_var, "inner");
     EXPECT_EQ(inner.iterator_var, "i");
     ASSERT_EQ(inner.body.size(), 1);
@@ -604,16 +604,16 @@ TEST(ParserTest, FullSpudFile) {
     std::get<MkdirStmt>(program.statements[5]->data);
     std::get<FileStmt>(program.statements[6]->data);
     std::get<FileStmt>(program.statements[7]->data);
-    auto &rep = std::get<RepeatStmt>(program.statements[8]->data);
+    auto& rep = std::get<RepeatStmt>(program.statements[8]->data);
     ASSERT_EQ(rep.body.size(), 2);
 }
 
 // --- Error tests ---
 
 TEST(ParserTest, RepeatWithoutEnd) {
-    EXPECT_THROW(parse_program(
-        "repeat items as item\n"
-        "  mkdir \"dir\"\n"), ParseError);
+    EXPECT_THROW(parse_program("repeat items as item\n"
+                               "  mkdir \"dir\"\n"),
+                 ParseError);
 }
 
 TEST(ParserTest, UnexpectedTokenAtTopLevel) {


### PR DESCRIPTION
## Summary
Adds formatter and linter configs, applies them across the codebase and updates README.md 

## Changes
- Add .clang-format
- Add .clang-tidy
- Apply clang-format to all source files
- Fix all clang-tidy warnings
- Update README with slogan, badges, example, and development notice

## Test plan
- All 110 tests pass locally
- Zero clang-tidy warnings in source files