### PR TITLE
feat(lexer): add backslash line continuation

### DIFF
--- a/include/spudplate/lexer.h
+++ b/include/spudplate/lexer.h
@@ -33,6 +33,7 @@ class Lexer {
     char advance();
     [[nodiscard]] bool isAtEnd() const;
     void skipWhitespace();
+    void skipLineContinuation();
     Token readIdentifierOrKeyword();
     Token readStringLiteral();
     Token readIntegerLiteral();

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -54,8 +54,8 @@ Token Lexer::readIdentifierOrKeyword() {
     int start_col = column_;
     std::string value;
 
-    while (!isAtEnd() &&
-           (std::isalnum(static_cast<unsigned char>(current())) != 0 || current() == '_')) {
+    while (!isAtEnd() && (std::isalnum(static_cast<unsigned char>(current())) != 0 ||
+                          current() == '_')) {
         value += advance();
     }
 
@@ -96,8 +96,26 @@ Token Lexer::readIntegerLiteral() {
     return Token(TokenType::INTEGER_LITERAL, value, start_line, start_col);
 }
 
+void Lexer::skipLineContinuation() {
+    while (!isAtEnd() && current() == '\\') {
+        std::size_t peek = pos_ + 1;
+        while (peek < source_.size() && (source_[peek] == ' ' || source_[peek] == '\t')) {
+            peek++;
+        }
+        if (peek < source_.size() && source_[peek] == '\n') {
+            while (pos_ <= peek) {
+                advance();
+            }
+            skipWhitespace();
+        } else {
+            break;
+        }
+    }
+}
+
 Token Lexer::nextToken() {
     skipWhitespace();
+    skipLineContinuation();
 
     if (isAtEnd()) {
         return Token(TokenType::EOF_TOKEN, "", line_, column_);

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -423,3 +423,78 @@ TEST(LexerTest, CommentDoesNotConsumeNewline) {
     Token tok3 = lexer.nextToken();
     EXPECT_EQ(tok3.type, TokenType::LET);
 }
+
+TEST(LexerTest, LineContinuationTwoLines) {
+    Lexer lexer("ask \\\nname");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::ASK);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok2.value, "name");
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::EOF_TOKEN);
+}
+
+TEST(LexerTest, LineContinuationThreeLines) {
+    Lexer lexer("ask \\\n\"prompt\" \\\nstring");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::ASK);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok2.value, "prompt");
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::STRING_TYPE);
+
+    Token tok4 = lexer.nextToken();
+    EXPECT_EQ(tok4.type, TokenType::EOF_TOKEN);
+}
+
+TEST(LexerTest, LineContinuationNoNewline) {
+    // Backslash not followed by newline is an error token
+    Lexer lexer("ask \\name");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::ASK);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::ERROR);
+    EXPECT_EQ(tok2.value, "\\");
+}
+
+TEST(LexerTest, LineContinuationTrailingWhitespace) {
+    // Trailing spaces/tabs between `\` and newline are silently ignored
+    Lexer lexer("ask \\  \t\nname");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::ASK);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok2.value, "name");
+}
+
+TEST(LexerTest, LineContinuationInsideStringIsNotContinuation) {
+    // A backslash inside a string literal is just a character, not continuation
+    Lexer lexer("\"hello\\nworld\"");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok.value, "hello\\nworld");
+}
+
+TEST(LexerTest, LineContinuationLineTracking) {
+    // After a continuation, tokens on the next physical line have correct line numbers
+    Lexer lexer("ask \\\nname \\\n\"prompt\"");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::ASK);
+    EXPECT_EQ(tok1.line, 1);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok2.line, 2);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::STRING_LITERAL);
+    EXPECT_EQ(tok3.line, 3);
+}


### PR DESCRIPTION
## Summary
Add backslash line continuation to the lexer so long statements can span multiple physical lines

## Changes
- Add `skipLineContinuation()` method to Lexer that consumes \, optional trailing whitespace and `\n` as a single continuation called after `skipWhitespace()` in `nextToken()`, with a loop to handle chained continuations
- `\` not followed by a newline falls through as an ERROR token
- 6 new lexer tests: two-line, three-line, no-newline (error), trailing whitespace, inside-string (not continuation), line tracking

## Test plan
- All 116 (6 new) tests pass locally
- Continuation across 2 and 3+ lines verified
- Edge cases: `\` without newline, `\` inside string literal, trailing whitespace between `\` and newline