### PR TITLE
feat(parser): parse unquoted path expressions

### DIFF
--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -83,10 +83,51 @@ struct Expr {
 /** @brief The type of a variable declared by an `ask` statement. */
 enum class VarType { String, Bool, Int };
 
+// ---------------------------------------------------------------------------
+// Path expression types
+// ---------------------------------------------------------------------------
+
+/** @brief A literal component of a path expression, e.g. `src` or `README.md`. */
+struct PathLiteral {
+    std::string value;  ///< Literal text (identifiers, dots, slashes already joined).
+    int line;
+    int column;
+};
+
+/** @brief A reference to a previously-bound path alias, e.g. `staticpath` in `staticpath/notes`. */
+struct PathVar {
+    std::string name;  ///< The alias name.
+    int line;
+    int column;
+};
+
+/** @brief An inline `{expr}` interpolation inside a path, e.g. `week_{n}`. */
+struct PathInterp {
+    ExprPtr expression;  ///< The expression whose string value is substituted at runtime.
+    int line;
+    int column;
+};
+
+/** @brief Discriminated union of the three path segment kinds. */
+using PathSegment = std::variant<PathLiteral, PathVar, PathInterp>;
+
+/**
+ * @brief A path expression — an ordered sequence of segments.
+ *
+ * Used by `mkdir`, `file`, and `file ... from` for destination and source paths.
+ * Segments are concatenated at runtime, with literals inserted verbatim and
+ * interpolations/aliases resolved from the current scope.
+ */
+struct PathExpr {
+    std::vector<PathSegment> segments;  ///< Ordered path components.
+    int line;                           ///< Line of the first segment.
+    int column;                         ///< Column of the first segment.
+};
+
 /** @brief File source: content comes from an embedded source file. */
 struct FileFromSource {
-    std::string path;  ///< Path to the source file (resolved at compile time).
-    bool verbatim;     ///< If true, suppress `{var}` interpolation at runtime.
+    PathExpr path;  ///< Path to the source file (resolved at compile time).
+    bool verbatim;  ///< If true, suppress `{var}` interpolation at runtime.
 };
 
 /** @brief File source: content comes from an inline expression. */
@@ -134,9 +175,11 @@ struct LetStmt {
  * Example: `mkdir "{slug}/src" mode 0755`
  */
 struct MkdirStmt {
-    std::string path;         ///< Directory path (supports `{var}` interpolation).
-    std::optional<int> mode;  ///< Optional permission bits (e.g. 0755).
-    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding creation.
+    PathExpr path;                         ///< Directory path expression.
+    std::optional<std::string> alias;      ///< Optional `as <name>` binding; empty if no `as` clause.
+    bool mkdir_p;                          ///< Always true — create intermediate directories.
+    std::optional<int> mode;               ///< Optional permission bits (e.g. 0755).
+    std::optional<ExprPtr> when_clause;    ///< Optional condition guarding creation.
     int line;
     int column;
 };
@@ -147,11 +190,12 @@ struct MkdirStmt {
  * Example: `file "{slug}/README.md" content "# " + name`
  */
 struct FileStmt {
-    std::string path;                    ///< File path (supports `{var}` interpolation).
-    FileSource source;                   ///< Where the file content comes from.
-    bool append;                         ///< If true, append; otherwise create/overwrite.
-    std::optional<int> mode;             ///< Optional permission bits.
-    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding creation.
+    PathExpr path;                        ///< File path expression.
+    std::optional<std::string> alias;     ///< Optional `as <name>` binding; empty if no `as` clause.
+    FileSource source;                    ///< Where the file content comes from.
+    bool append;                          ///< If true, append; otherwise create/overwrite.
+    std::optional<int> mode;              ///< Optional permission bits.
+    std::optional<ExprPtr> when_clause;   ///< Optional condition guarding creation.
     int line;
     int column;
 };

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -3,6 +3,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 
 #include "spudplate/ast.h"
 #include "spudplate/lexer.h"
@@ -67,6 +68,7 @@ class Parser {
   private:
     Lexer lexer_;
     Token current_;
+    std::unordered_set<std::string> aliases_;  ///< Names bound by `as <name>` in prior statements.
 
     // Token consumption
     Token advance();
@@ -79,6 +81,7 @@ class Parser {
     VarType parse_var_type();
     std::optional<ExprPtr> parse_when_clause();
     std::optional<int> parse_mode_clause();
+    PathExpr parse_path_expr();
     void expect_newline(const std::string& context);
 
     // Expression precedence climbing

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -59,6 +59,9 @@ enum class TokenType {
     NEWLINE,  ///< Logical line break (newline or semicolon)
     LPAREN,   ///< `(`
     RPAREN,   ///< `)`
+    LBRACE,   ///< `{` — open inline interpolation in path expressions
+    RBRACE,   ///< `}` — close inline interpolation in path expressions
+    DOT,      ///< `.` — separator in path expressions (e.g. `README.md`)
 
     // Special
     EOF_TOKEN,  ///< End of input
@@ -155,6 +158,12 @@ inline std::string tokenTypeToString(TokenType type) {
             return "LPAREN";
         case TokenType::RPAREN:
             return "RPAREN";
+        case TokenType::LBRACE:
+            return "LBRACE";
+        case TokenType::RBRACE:
+            return "RBRACE";
+        case TokenType::DOT:
+            return "DOT";
         case TokenType::EOF_TOKEN:
             return "EOF_TOKEN";
         case TokenType::ERROR:

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -166,6 +166,12 @@ Token Lexer::nextToken() {
             return Token(TokenType::LPAREN, "(", start_line, start_col);
         case ')':
             return Token(TokenType::RPAREN, ")", start_line, start_col);
+        case '{':
+            return Token(TokenType::LBRACE, "{", start_line, start_col);
+        case '}':
+            return Token(TokenType::RBRACE, "}", start_line, start_col);
+        case '.':
+            return Token(TokenType::DOT, ".", start_line, start_col);
         case '=':
             if (!isAtEnd() && current() == '=') {
                 advance();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -75,6 +75,87 @@ void Parser::expect_newline(const std::string& context) {
     expect(TokenType::NEWLINE, "expected newline after " + context);
 }
 
+PathExpr Parser::parse_path_expr() {
+    PathExpr path;
+    path.line = current_.line;
+    path.column = current_.column;
+
+    // Quoted-string fallback for paths with spaces: `mkdir "my notes"`
+    if (check(TokenType::STRING_LITERAL)) {
+        Token tok = advance();
+        path.segments.push_back(
+            PathLiteral{.value = tok.value, .line = tok.line, .column = tok.column});
+        return path;
+    }
+
+    // Unquoted path: greedily consume IDENTIFIER / SLASH / DOT / INTEGER_LITERAL
+    // and `{expr}` interpolation blocks. Adjacent non-alias, non-interpolation
+    // tokens coalesce into a single PathLiteral via a text buffer.
+    std::string buffer;
+    int buf_line = 0;
+    int buf_col = 0;
+
+    auto flush_buffer = [&]() {
+        if (!buffer.empty()) {
+            path.segments.push_back(PathLiteral{
+                .value = std::move(buffer), .line = buf_line, .column = buf_col});
+            buffer.clear();
+        }
+    };
+
+    auto start_buffer = [&](int line, int col) {
+        if (buffer.empty()) {
+            buf_line = line;
+            buf_col = col;
+        }
+    };
+
+    while (true) {
+        if (check(TokenType::IDENTIFIER)) {
+            Token tok = advance();
+            if (aliases_.contains(tok.value)) {
+                flush_buffer();
+                path.segments.push_back(
+                    PathVar{.name = tok.value, .line = tok.line, .column = tok.column});
+            } else {
+                start_buffer(tok.line, tok.column);
+                buffer += tok.value;
+            }
+        } else if (check(TokenType::SLASH)) {
+            start_buffer(current_.line, current_.column);
+            buffer += '/';
+            advance();
+        } else if (check(TokenType::DOT)) {
+            start_buffer(current_.line, current_.column);
+            buffer += '.';
+            advance();
+        } else if (check(TokenType::INTEGER_LITERAL)) {
+            Token tok = advance();
+            start_buffer(tok.line, tok.column);
+            buffer += tok.value;
+        } else if (check(TokenType::LBRACE)) {
+            int line = current_.line;
+            int col = current_.column;
+            advance();
+            flush_buffer();
+            auto expr = parseExpression();
+            expect(TokenType::RBRACE, "expected '}' to close path interpolation");
+            path.segments.push_back(PathInterp{
+                .expression = std::move(expr), .line = line, .column = col});
+        } else {
+            break;
+        }
+    }
+
+    flush_buffer();
+
+    if (path.segments.empty()) {
+        throw ParseError("expected path expression", current_.line, current_.column);
+    }
+
+    return path;
+}
+
 // Statement parsers
 
 StmtPtr Parser::parseAsk() {
@@ -114,13 +195,23 @@ StmtPtr Parser::parseLet() {
 
 StmtPtr Parser::parseMkdir() {
     Token start = expect(TokenType::MKDIR, "expected 'mkdir'");
-    Token path = expect(TokenType::STRING_LITERAL, "expected path string after 'mkdir'");
+    PathExpr path = parse_path_expr();
     auto mode = parse_mode_clause();
     auto when_clause = parse_when_clause();
+
+    std::optional<std::string> alias;
+    if (match(TokenType::AS)) {
+        Token alias_tok = expect(TokenType::IDENTIFIER, "expected alias name after 'as'");
+        alias = alias_tok.value;
+        aliases_.insert(*alias);
+    }
+
     expect_newline("mkdir statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = MkdirStmt{.path = path.value,
+    stmt->data = MkdirStmt{.path = std::move(path),
+                            .alias = std::move(alias),
+                            .mkdir_p = true,
                             .mode = mode,
                             .when_clause = std::move(when_clause),
                             .line = start.line,
@@ -130,16 +221,15 @@ StmtPtr Parser::parseMkdir() {
 
 StmtPtr Parser::parseFile() {
     Token start = expect(TokenType::FILE, "expected 'file'");
-    Token path = expect(TokenType::STRING_LITERAL, "expected path string after 'file'");
+    PathExpr path = parse_path_expr();
 
     bool append = match(TokenType::APPEND);
 
     FileSource source = [&]() -> FileSource {
         if (match(TokenType::FROM)) {
-            Token src =
-                expect(TokenType::STRING_LITERAL, "expected source path after 'from'");
+            PathExpr src = parse_path_expr();
             bool verbatim = match(TokenType::VERBATIM);
-            return FileFromSource{.path = src.value, .verbatim = verbatim};
+            return FileFromSource{.path = std::move(src), .verbatim = verbatim};
         }
         if (match(TokenType::CONTENT)) {
             auto value = parseExpression();
@@ -151,10 +241,19 @@ StmtPtr Parser::parseFile() {
 
     auto mode = parse_mode_clause();
     auto when_clause = parse_when_clause();
+
+    std::optional<std::string> alias;
+    if (match(TokenType::AS)) {
+        Token alias_tok = expect(TokenType::IDENTIFIER, "expected alias name after 'as'");
+        alias = alias_tok.value;
+        aliases_.insert(*alias);
+    }
+
     expect_newline("file statement");
 
     auto stmt = std::make_unique<Stmt>();
-    stmt->data = FileStmt{.path = path.value,
+    stmt->data = FileStmt{.path = std::move(path),
+                          .alias = std::move(alias),
                           .source = std::move(source),
                           .append = append,
                           .mode = mode,

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -31,6 +31,9 @@ TEST(TokenTest, TypeToString) {
     EXPECT_EQ(tokenTypeToString(TokenType::ERROR), "ERROR");
     EXPECT_EQ(tokenTypeToString(TokenType::STRING_LITERAL), "STRING_LITERAL");
     EXPECT_EQ(tokenTypeToString(TokenType::ASSIGN), "ASSIGN");
+    EXPECT_EQ(tokenTypeToString(TokenType::DOT), "DOT");
+    EXPECT_EQ(tokenTypeToString(TokenType::LBRACE), "LBRACE");
+    EXPECT_EQ(tokenTypeToString(TokenType::RBRACE), "RBRACE");
 }
 
 TEST(LexerTest, EmptyInput) {
@@ -497,4 +500,143 @@ TEST(LexerTest, LineContinuationLineTracking) {
     Token tok3 = lexer.nextToken();
     EXPECT_EQ(tok3.type, TokenType::STRING_LITERAL);
     EXPECT_EQ(tok3.line, 3);
+}
+
+// --- DOT, LBRACE, RBRACE tokens ---
+
+TEST(LexerTest, DotToken) {
+    Lexer lexer(".");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::DOT);
+    EXPECT_EQ(tok.value, ".");
+    EXPECT_EQ(tok.line, 1);
+    EXPECT_EQ(tok.column, 1);
+}
+
+TEST(LexerTest, LbraceToken) {
+    Lexer lexer("{");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::LBRACE);
+    EXPECT_EQ(tok.value, "{");
+}
+
+TEST(LexerTest, RbraceToken) {
+    Lexer lexer("}");
+    Token tok = lexer.nextToken();
+    EXPECT_EQ(tok.type, TokenType::RBRACE);
+    EXPECT_EQ(tok.value, "}");
+}
+
+TEST(LexerTest, PathLikeSequence) {
+    // README.md → IDENTIFIER DOT IDENTIFIER
+    Lexer lexer("README.md");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok1.value, "README");
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::DOT);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok3.value, "md");
+
+    EXPECT_EQ(lexer.nextToken().type, TokenType::EOF_TOKEN);
+}
+
+TEST(LexerTest, PathWithSlashAndDot) {
+    // src/main.cpp → IDENTIFIER SLASH IDENTIFIER DOT IDENTIFIER
+    Lexer lexer("src/main.cpp");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok1.value, "src");
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::SLASH);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok3.value, "main");
+
+    Token tok4 = lexer.nextToken();
+    EXPECT_EQ(tok4.type, TokenType::DOT);
+
+    Token tok5 = lexer.nextToken();
+    EXPECT_EQ(tok5.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok5.value, "cpp");
+
+    EXPECT_EQ(lexer.nextToken().type, TokenType::EOF_TOKEN);
+}
+
+TEST(LexerTest, BraceInterpolation) {
+    // week_{n} → IDENTIFIER LBRACE IDENTIFIER RBRACE
+    Lexer lexer("week_{n}");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok1.value, "week_");
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::LBRACE);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok3.value, "n");
+
+    Token tok4 = lexer.nextToken();
+    EXPECT_EQ(tok4.type, TokenType::RBRACE);
+
+    EXPECT_EQ(lexer.nextToken().type, TokenType::EOF_TOKEN);
+}
+
+TEST(LexerTest, BraceInterpolationInPath) {
+    // {prefix}/README.md → LBRACE IDENTIFIER RBRACE SLASH IDENTIFIER DOT IDENTIFIER
+    Lexer lexer("{prefix}/README.md");
+    EXPECT_EQ(lexer.nextToken().type, TokenType::LBRACE);
+
+    Token id1 = lexer.nextToken();
+    EXPECT_EQ(id1.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(id1.value, "prefix");
+
+    EXPECT_EQ(lexer.nextToken().type, TokenType::RBRACE);
+    EXPECT_EQ(lexer.nextToken().type, TokenType::SLASH);
+
+    Token id2 = lexer.nextToken();
+    EXPECT_EQ(id2.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(id2.value, "README");
+
+    EXPECT_EQ(lexer.nextToken().type, TokenType::DOT);
+
+    Token id3 = lexer.nextToken();
+    EXPECT_EQ(id3.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(id3.value, "md");
+
+    EXPECT_EQ(lexer.nextToken().type, TokenType::EOF_TOKEN);
+}
+
+TEST(LexerTest, DotColumnTracking) {
+    Lexer lexer("a.b");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.column, 1);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::DOT);
+    EXPECT_EQ(tok2.column, 2);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.column, 3);
+}
+
+TEST(LexerTest, BraceColumnTracking) {
+    Lexer lexer("{x}");
+    Token tok1 = lexer.nextToken();
+    EXPECT_EQ(tok1.type, TokenType::LBRACE);
+    EXPECT_EQ(tok1.column, 1);
+
+    Token tok2 = lexer.nextToken();
+    EXPECT_EQ(tok2.type, TokenType::IDENTIFIER);
+    EXPECT_EQ(tok2.column, 2);
+
+    Token tok3 = lexer.nextToken();
+    EXPECT_EQ(tok3.type, TokenType::RBRACE);
+    EXPECT_EQ(tok3.column, 3);
 }

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -19,6 +19,8 @@ using spudplate::Lexer;
 using spudplate::MkdirStmt;
 using spudplate::ParseError;
 using spudplate::Parser;
+using spudplate::PathExpr;
+using spudplate::PathLiteral;
 using spudplate::Program;
 using spudplate::RepeatStmt;
 using spudplate::StmtPtr;
@@ -26,6 +28,14 @@ using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
 using spudplate::UnaryExpr;
 using spudplate::VarType;
+
+// Asserts a PathExpr is a single literal segment equal to the expected text.
+// Used by legacy tests that previously compared `.path` against a string.
+static void expect_simple_path(const PathExpr& path, const std::string& expected) {
+    ASSERT_EQ(path.segments.size(), 1u);
+    const auto& lit = std::get<PathLiteral>(path.segments[0]);
+    EXPECT_EQ(lit.value, expected);
+}
 
 static ExprPtr parse_expr(const std::string& input) {
     Lexer lexer(input);
@@ -331,7 +341,7 @@ TEST(ParserTest, LetMissingName) {
 TEST(ParserTest, MkdirBasic) {
     auto stmt = parse_mkdir("mkdir \"src\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
-    EXPECT_EQ(mk.path, "src");
+    expect_simple_path(mk.path, "src");
     EXPECT_FALSE(mk.mode.has_value());
     EXPECT_FALSE(mk.when_clause.has_value());
 }
@@ -339,7 +349,7 @@ TEST(ParserTest, MkdirBasic) {
 TEST(ParserTest, MkdirWithMode) {
     auto stmt = parse_mkdir("mkdir \"bin\" mode 0755\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
-    EXPECT_EQ(mk.path, "bin");
+    expect_simple_path(mk.path, "bin");
     ASSERT_TRUE(mk.mode.has_value());
     EXPECT_EQ(*mk.mode, 0755);
 }
@@ -363,7 +373,7 @@ TEST(ParserTest, MkdirWithModeAndWhen) {
 TEST(ParserTest, MkdirAtEof) {
     auto stmt = parse_mkdir("mkdir \"src\"");
     auto& mk = std::get<MkdirStmt>(stmt->data);
-    EXPECT_EQ(mk.path, "src");
+    expect_simple_path(mk.path, "src");
 }
 
 TEST(ParserTest, MkdirMissingPath) {
@@ -375,10 +385,10 @@ TEST(ParserTest, MkdirMissingPath) {
 TEST(ParserTest, FileFromBasic) {
     auto stmt = parse_file("file \"out.txt\" from \"template.txt\"\n");
     auto& file = std::get<FileStmt>(stmt->data);
-    EXPECT_EQ(file.path, "out.txt");
+    expect_simple_path(file.path, "out.txt");
     EXPECT_FALSE(file.append);
     auto& src = std::get<FileFromSource>(file.source);
-    EXPECT_EQ(src.path, "template.txt");
+    expect_simple_path(src.path, "template.txt");
     EXPECT_FALSE(src.verbatim);
 }
 
@@ -432,7 +442,7 @@ TEST(ParserTest, FileContentWithMode) {
 TEST(ParserTest, FileAtEof) {
     auto stmt = parse_file("file \"out.txt\" from \"in.txt\"");
     auto& file = std::get<FileStmt>(stmt->data);
-    EXPECT_EQ(file.path, "out.txt");
+    expect_simple_path(file.path, "out.txt");
 }
 
 TEST(ParserTest, FileMissingSource) {
@@ -452,10 +462,10 @@ TEST(ParserTest, FileFromMissingSourcePath) {
 TEST(ParserTest, FileAppendFrom) {
     auto stmt = parse_file("file \"log.txt\" append from \"entry.txt\"\n");
     auto& file = std::get<FileStmt>(stmt->data);
-    EXPECT_EQ(file.path, "log.txt");
+    expect_simple_path(file.path, "log.txt");
     EXPECT_TRUE(file.append);
     auto& src = std::get<FileFromSource>(file.source);
-    EXPECT_EQ(src.path, "entry.txt");
+    expect_simple_path(src.path, "entry.txt");
     EXPECT_FALSE(src.verbatim);
 }
 
@@ -481,7 +491,7 @@ TEST(ParserTest, FileAppendFromModeWhen) {
     auto& file = std::get<FileStmt>(stmt->data);
     EXPECT_TRUE(file.append);
     auto& src = std::get<FileFromSource>(file.source);
-    EXPECT_EQ(src.path, "src");
+    expect_simple_path(src.path, "src");
     ASSERT_TRUE(file.mode.has_value());
     EXPECT_EQ(*file.mode, 0644);
     ASSERT_TRUE(file.when_clause.has_value());

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -20,7 +20,9 @@ using spudplate::MkdirStmt;
 using spudplate::ParseError;
 using spudplate::Parser;
 using spudplate::PathExpr;
+using spudplate::PathInterp;
 using spudplate::PathLiteral;
+using spudplate::PathVar;
 using spudplate::Program;
 using spudplate::RepeatStmt;
 using spudplate::StmtPtr;
@@ -223,6 +225,12 @@ static StmtPtr parse_file(const std::string& input) {
     Lexer lexer(input);
     Parser parser(std::move(lexer));
     return parser.parseFile();
+}
+
+static Program parse_program(const std::string& input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parse();
 }
 
 // --- Ask statement tests ---
@@ -503,12 +511,151 @@ TEST(ParserTest, FileWithoutAppendDefaultsFalse) {
     EXPECT_FALSE(file.append);
 }
 
-// --- Repeat and program parsing helpers ---
+// --- Path expression tests ---
 
-static Program parse_program(const std::string& input) {
-    Lexer lexer(input);
-    Parser parser(std::move(lexer));
-    return parser.parse();
+TEST(ParserTest, MkdirUnquotedSimplePath) {
+    auto stmt = parse_mkdir("mkdir static\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static");
+    EXPECT_FALSE(mk.alias.has_value());
+    EXPECT_TRUE(mk.mkdir_p);
+}
+
+TEST(ParserTest, MkdirUnquotedSlashSeparated) {
+    auto stmt = parse_mkdir("mkdir static/notes\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static/notes");
+}
+
+TEST(ParserTest, MkdirWithAlias) {
+    auto stmt = parse_mkdir("mkdir static as staticpath\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static");
+    ASSERT_TRUE(mk.alias.has_value());
+    EXPECT_EQ(*mk.alias, "staticpath");
+}
+
+TEST(ParserTest, MkdirPathWithAlias) {
+    auto stmt = parse_mkdir("mkdir static/notes as notespath\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static/notes");
+    ASSERT_TRUE(mk.alias.has_value());
+    EXPECT_EQ(*mk.alias, "notespath");
+}
+
+TEST(ParserTest, MkdirAliasReferenceInLaterPath) {
+    auto program = parse_program(
+        "mkdir static as staticpath\n"
+        "mkdir staticpath/notes\n");
+    ASSERT_EQ(program.statements.size(), 2u);
+    auto& mk2 = std::get<MkdirStmt>(program.statements[1]->data);
+    ASSERT_EQ(mk2.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathVar>(mk2.path.segments[0]).name, "staticpath");
+    EXPECT_EQ(std::get<PathLiteral>(mk2.path.segments[1]).value, "/notes");
+}
+
+TEST(ParserTest, MkdirInterpolation) {
+    auto stmt = parse_mkdir("mkdir week_{n}\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "week_");
+    auto& interp = std::get<PathInterp>(mk.path.segments[1]);
+    EXPECT_EQ(std::get<IdentifierExpr>(interp.expression->data).name, "n");
+}
+
+TEST(ParserTest, MkdirAliasAndInterpolationInSamePath) {
+    auto program = parse_program(
+        "mkdir static as staticpath\n"
+        "mkdir notes as notespath\n"
+        "mkdir staticpath/notespath/week_{n}\n");
+    ASSERT_EQ(program.statements.size(), 3u);
+    auto& mk3 = std::get<MkdirStmt>(program.statements[2]->data);
+    ASSERT_EQ(mk3.path.segments.size(), 5u);
+    EXPECT_EQ(std::get<PathVar>(mk3.path.segments[0]).name, "staticpath");
+    EXPECT_EQ(std::get<PathLiteral>(mk3.path.segments[1]).value, "/");
+    EXPECT_EQ(std::get<PathVar>(mk3.path.segments[2]).name, "notespath");
+    EXPECT_EQ(std::get<PathLiteral>(mk3.path.segments[3]).value, "/week_");
+    auto& interp = std::get<PathInterp>(mk3.path.segments[4]);
+    EXPECT_EQ(std::get<IdentifierExpr>(interp.expression->data).name, "n");
+}
+
+TEST(ParserTest, MkdirQuotedPathWithSpaces) {
+    auto stmt = parse_mkdir("mkdir \"my notes\"\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "my notes");
+}
+
+TEST(ParserTest, MkdirAliasAfterWhenClause) {
+    auto stmt = parse_mkdir("mkdir static when use_static as staticpath\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_TRUE(mk.when_clause.has_value());
+    ASSERT_TRUE(mk.alias.has_value());
+    EXPECT_EQ(*mk.alias, "staticpath");
+}
+
+TEST(ParserTest, FileContentUnquotedPath) {
+    auto stmt = parse_file("file static/notes/README.md content \"\"\n");
+    auto& file = std::get<FileStmt>(stmt->data);
+    ASSERT_EQ(file.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[0]).value,
+              "static/notes/README.md");
+    std::get<FileContentSource>(file.source);  // NOLINT — just verifying variant
+}
+
+TEST(ParserTest, FileFromUnquotedPath) {
+    auto stmt = parse_file("file static/notes/README.md from base/README.md\n");
+    auto& file = std::get<FileStmt>(stmt->data);
+    ASSERT_EQ(file.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[0]).value,
+              "static/notes/README.md");
+    auto& src = std::get<FileFromSource>(file.source);
+    ASSERT_EQ(src.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(src.path.segments[0]).value, "base/README.md");
+}
+
+TEST(ParserTest, FileWithAlias) {
+    auto stmt = parse_file("file readme.md content \"# hi\" as readme\n");
+    auto& file = std::get<FileStmt>(stmt->data);
+    ASSERT_TRUE(file.alias.has_value());
+    EXPECT_EQ(*file.alias, "readme");
+}
+
+TEST(ParserTest, FileAppendViaAlias) {
+    auto program = parse_program(
+        "file project_dir/README.md content \"# Project\" as readme\n"
+        "file readme append content \"## Notes\" when use_notes\n"
+        "file readme append content \"## Testing\" when use_tests\n");
+    ASSERT_EQ(program.statements.size(), 3u);
+    auto& f1 = std::get<FileStmt>(program.statements[0]->data);
+    ASSERT_TRUE(f1.alias.has_value());
+    EXPECT_EQ(*f1.alias, "readme");
+
+    auto& f2 = std::get<FileStmt>(program.statements[1]->data);
+    ASSERT_EQ(f2.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathVar>(f2.path.segments[0]).name, "readme");
+    EXPECT_TRUE(f2.append);
+    ASSERT_TRUE(f2.when_clause.has_value());
+
+    auto& f3 = std::get<FileStmt>(program.statements[2]->data);
+    EXPECT_EQ(std::get<PathVar>(f3.path.segments[0]).name, "readme");
+    EXPECT_TRUE(f3.append);
+}
+
+TEST(ParserTest, MkdirAsMissingName) {
+    EXPECT_THROW(parse_mkdir("mkdir static as\n"), ParseError);
+}
+
+TEST(ParserTest, MkdirAsWithNonIdentifier) {
+    EXPECT_THROW(parse_mkdir("mkdir static as \"foo\"\n"), ParseError);
+}
+
+TEST(ParserTest, MkdirEmptyPath) {
+    EXPECT_THROW(parse_mkdir("mkdir\n"), ParseError);
 }
 
 // --- Program parsing tests ---


### PR DESCRIPTION
## Summary

Adds unquoted path expressions to spudlang so templates can write `mkdir static/notes` instead of `mkdir "static/notes"`. Also adds an `as name` clause for binding a path to a short alias, and `{expr}` inline interpolation inside paths. This is the second branch in the roadmap at `.claude/todos/lang-spec-extensions.md`.

## Changes

- New path expression type covering three segment kinds: literal text, alias reference, and inline expression.
- Path fields on `mkdir`, `file`, and `file from` use this type instead of a raw string.
- Added an optional `as name` clause on `mkdir` and `file` for binding an alias to the path.
- Parser consumes path tokens greedily, stopping at clause keywords or end of line. Quoted strings still work for paths containing spaces.
- Aliases declared earlier in the same program can appear as whole segments in later paths.
- `mkdir` now always creates intermediate directories.

## Test plan

- `cmake --build build && ctest --test-dir build --output-on-failure`
- 141 of 141 tests pass, including new coverage for unquoted paths, alias chains, inline interpolation, quoted fallback, and error cases.