### PR TITLE
feat(parser): add copy and mkdir from source

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -67,10 +67,15 @@ let total_days = num_weeks * 7
 ### `mkdir` — Create a directory
 
 ```
-mkdir "<path>" [mode <octal>] [when <condition>]
+mkdir <path> [from <source> [verbatim]] [mode <octal>] [when <condition>] [as <name>]
 ```
 
-Creates a directory at the given path. The path may contain `{variable}` interpolation.
+Creates a directory at the given path. Intermediate directories are created as needed. The path may contain `{variable}` interpolation.
+
+- `from <source>` — creates the directory by copying the contents of the source directory. The source is embedded at compile time. `{var}` interpolation is applied at runtime unless `verbatim` is specified.
+- `mode <octal>` — sets the directory's permissions (e.g., `mode 0755`).
+- `when <condition>` — only creates the directory if the condition is true.
+- `as <name>` — binds the path to an alias that later statements can reuse.
 
 **Examples:**
 
@@ -78,6 +83,28 @@ Creates a directory at the given path. The path may contain `{variable}` interpo
 mkdir "{dir}/src"
 mkdir "{dir}/tests" when use_tests
 mkdir "{dir}/private" mode 0700
+mkdir templates from base_templates verbatim when use_templates as templatepath
+```
+
+---
+
+### `copy` — Copy a directory into an existing destination
+
+```
+copy <source> into <destination> [verbatim] [when <condition>]
+```
+
+Copies the contents of `<source>` into an already existing `<destination>` directory. Unlike `mkdir ... from`, which creates the destination, `copy into` requires the destination to exist — use it when merging several sources into one directory.
+
+- `verbatim` — suppress `{var}` interpolation when copying source file contents.
+- `when <condition>` — only perform the copy if the condition is true.
+
+**Examples:**
+
+```
+copy standard_templates into templatepath
+copy philosophy_templates into templatepath when use_philosophy
+copy assets into staticpath/assets verbatim
 ```
 
 ---

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -183,12 +183,17 @@ struct LetStmt {
 /**
  * @brief A `mkdir` statement — creates a directory.
  *
- * Example: `mkdir "{slug}/src" mode 0755`
+ * Example: `mkdir src/modules mode 0755`
+ *
+ * With a `from <source>` clause, the directory is created and populated from
+ * the source directory atomically. Without `from`, an empty directory is made.
  */
 struct MkdirStmt {
     PathExpr path;                         ///< Directory path expression.
     std::optional<std::string> alias;      ///< Optional `as <name>` binding; empty if no `as` clause.
     bool mkdir_p;                          ///< Always true — create intermediate directories.
+    std::optional<PathExpr> from_source;   ///< Optional source directory to populate from.
+    bool verbatim;                         ///< If true with from_source, suppress interpolation.
     std::optional<int> mode;               ///< Optional permission bits (e.g. 0755).
     std::optional<ExprPtr> when_clause;    ///< Optional condition guarding creation.
     int line;
@@ -234,8 +239,27 @@ struct RepeatStmt {
     int column;
 };
 
+/**
+ * @brief A `copy` statement — copies contents from a source directory into
+ * an existing destination directory.
+ *
+ * Example: `copy standard_templates/ into templatepath`
+ *
+ * Unlike `mkdir ... from`, the destination directory must already exist. Use
+ * `copy` to merge multiple sources into a single destination.
+ */
+struct CopyStmt {
+    PathExpr source;                     ///< Source directory path.
+    PathExpr destination;                ///< Existing destination directory path.
+    bool verbatim;                       ///< If true, suppress `{var}` interpolation.
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the copy.
+    int line;
+    int column;
+};
+
 /** @brief Discriminated union of all statement node types. */
-using StmtData = std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt>;
+using StmtData =
+    std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt, CopyStmt>;
 
 /** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -61,6 +61,8 @@ class Parser {
     StmtPtr parseFile();
     /** @brief Parses a `repeat` block. */
     StmtPtr parseRepeat();
+    /** @brief Parses a `copy` statement. */
+    StmtPtr parseCopy();
     /** @brief Dispatches to the appropriate statement parser based on the current token.
      */
     StmtPtr parseStatement();

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -23,6 +23,8 @@ enum class TokenType {
     AS,        ///< `as` — bind loop iterator variable in repeat
     DEFAULT,   ///< `default` — fallback value for an ask when the user skips it
     OPTIONS,   ///< `options` — restrict an ask to a bounded list of literals
+    COPY,      ///< `copy` — copy a source directory into an existing destination
+    INTO,      ///< `into` — destination marker used by `copy`
 
     // Logical operators (keywords)
     AND,  ///< `and` — logical AND
@@ -117,6 +119,10 @@ inline std::string tokenTypeToString(TokenType type) {
             return "DEFAULT";
         case TokenType::OPTIONS:
             return "OPTIONS";
+        case TokenType::COPY:
+            return "COPY";
+        case TokenType::INTO:
+            return "INTO";
         case TokenType::AND:
             return "AND";
         case TokenType::OR:

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -13,6 +13,7 @@ static const std::unordered_map<std::string, TokenType> keywords = {
     {"append", TokenType::APPEND},
     {"mode", TokenType::MODE},         {"as", TokenType::AS},
     {"default", TokenType::DEFAULT},   {"options", TokenType::OPTIONS},
+    {"copy", TokenType::COPY},         {"into", TokenType::INTO},
     {"and", TokenType::AND},           {"or", TokenType::OR},
     {"not", TokenType::NOT},           {"string", TokenType::STRING_TYPE},
     {"bool", TokenType::BOOL_TYPE},    {"int", TokenType::INT_TYPE},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -293,6 +293,8 @@ StmtPtr Parser::parseMkdir() {
     stmt->data = MkdirStmt{.path = std::move(path),
                             .alias = std::move(alias),
                             .mkdir_p = true,
+                            .from_source = std::nullopt,
+                            .verbatim = false,
                             .mode = mode,
                             .when_clause = std::move(when_clause),
                             .line = start.line,

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -277,6 +277,14 @@ StmtPtr Parser::parseLet() {
 StmtPtr Parser::parseMkdir() {
     Token start = expect(TokenType::MKDIR, "expected 'mkdir'");
     PathExpr path = parse_path_expr();
+
+    std::optional<PathExpr> from_source;
+    bool verbatim = false;
+    if (match(TokenType::FROM)) {
+        from_source = parse_path_expr();
+        verbatim = match(TokenType::VERBATIM);
+    }
+
     auto mode = parse_mode_clause();
     auto when_clause = parse_when_clause();
 
@@ -293,8 +301,8 @@ StmtPtr Parser::parseMkdir() {
     stmt->data = MkdirStmt{.path = std::move(path),
                             .alias = std::move(alias),
                             .mkdir_p = true,
-                            .from_source = std::nullopt,
-                            .verbatim = false,
+                            .from_source = std::move(from_source),
+                            .verbatim = verbatim,
                             .mode = mode,
                             .when_clause = std::move(when_clause),
                             .line = start.line,
@@ -340,6 +348,27 @@ StmtPtr Parser::parseFile() {
                           .source = std::move(source),
                           .append = append,
                           .mode = mode,
+                          .when_clause = std::move(when_clause),
+                          .line = start.line,
+                          .column = start.column};
+    return stmt;
+}
+
+// Copy statement parser
+
+StmtPtr Parser::parseCopy() {
+    Token start = expect(TokenType::COPY, "expected 'copy'");
+    PathExpr source = parse_path_expr();
+    expect(TokenType::INTO, "expected 'into' after copy source path");
+    PathExpr destination = parse_path_expr();
+    bool verbatim = match(TokenType::VERBATIM);
+    auto when_clause = parse_when_clause();
+    expect_newline("copy statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    stmt->data = CopyStmt{.source = std::move(source),
+                          .destination = std::move(destination),
+                          .verbatim = verbatim,
                           .when_clause = std::move(when_clause),
                           .line = start.line,
                           .column = start.column};
@@ -393,6 +422,9 @@ StmtPtr Parser::parseStatement() {
     }
     if (check(TokenType::REPEAT)) {
         return parseRepeat();
+    }
+    if (check(TokenType::COPY)) {
+        return parseCopy();
     }
     throw ParseError("unexpected token: " + current_.value, current_.line,
                      current_.column);

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -11,6 +11,7 @@ using spudplate::BoolLiteralExpr;
 using spudplate::ExprPtr;
 using spudplate::FileContentSource;
 using spudplate::FileFromSource;
+using spudplate::CopyStmt;
 using spudplate::FileStmt;
 using spudplate::FunctionCallExpr;
 using spudplate::IdentifierExpr;
@@ -735,6 +736,84 @@ TEST(ParserTest, MkdirAsWithNonIdentifier) {
 
 TEST(ParserTest, MkdirEmptyPath) {
     EXPECT_THROW(parse_mkdir("mkdir\n"), ParseError);
+}
+
+// --- Copy and mkdir-from tests ---
+
+static StmtPtr parse_copy(const std::string& input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseCopy();
+}
+
+TEST(ParserTest, CopyBasic) {
+    auto stmt = parse_copy("copy standard_templates into templatepath\n");
+    auto& cp = std::get<CopyStmt>(stmt->data);
+    ASSERT_EQ(cp.source.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(cp.source.segments[0]).value, "standard_templates");
+    ASSERT_EQ(cp.destination.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(cp.destination.segments[0]).value, "templatepath");
+    EXPECT_FALSE(cp.verbatim);
+    EXPECT_FALSE(cp.when_clause.has_value());
+}
+
+TEST(ParserTest, CopyWithWhen) {
+    auto stmt =
+        parse_copy("copy philosophy_templates into templatepath when use_philosophy\n");
+    auto& cp = std::get<CopyStmt>(stmt->data);
+    ASSERT_TRUE(cp.when_clause.has_value());
+    auto& cond = std::get<IdentifierExpr>((*cp.when_clause)->data);
+    EXPECT_EQ(cond.name, "use_philosophy");
+}
+
+TEST(ParserTest, CopyVerbatimWithNestedDestination) {
+    auto program = parse_program(
+        "mkdir static as staticpath\n"
+        "copy assets into staticpath/assets verbatim\n");
+    ASSERT_EQ(program.statements.size(), 2u);
+    auto& cp = std::get<CopyStmt>(program.statements[1]->data);
+    EXPECT_TRUE(cp.verbatim);
+    ASSERT_EQ(cp.destination.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathVar>(cp.destination.segments[0]).name, "staticpath");
+    EXPECT_EQ(std::get<PathLiteral>(cp.destination.segments[1]).value, "/assets");
+}
+
+TEST(ParserTest, CopyMissingInto) {
+    EXPECT_THROW(parse_copy("copy src dest\n"), ParseError);
+}
+
+TEST(ParserTest, CopyMissingSource) {
+    EXPECT_THROW(parse_copy("copy into dest\n"), ParseError);
+}
+
+TEST(ParserTest, CopyMissingDestination) {
+    EXPECT_THROW(parse_copy("copy src into\n"), ParseError);
+}
+
+TEST(ParserTest, MkdirFromBasic) {
+    auto stmt = parse_mkdir("mkdir templates from base_templates\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "templates");
+    ASSERT_TRUE(mk.from_source.has_value());
+    ASSERT_EQ(mk.from_source->segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.from_source->segments[0]).value, "base_templates");
+    EXPECT_FALSE(mk.verbatim);
+}
+
+TEST(ParserTest, MkdirFromVerbatimWhenAs) {
+    auto stmt = parse_mkdir(
+        "mkdir templates from base_templates verbatim when use_templates as templatepath\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_TRUE(mk.from_source.has_value());
+    EXPECT_TRUE(mk.verbatim);
+    ASSERT_TRUE(mk.when_clause.has_value());
+    ASSERT_TRUE(mk.alias.has_value());
+    EXPECT_EQ(*mk.alias, "templatepath");
+}
+
+TEST(ParserTest, MkdirFromMissingSourcePath) {
+    EXPECT_THROW(parse_mkdir("mkdir templates from\n"), ParseError);
 }
 
 // --- Program parsing tests ---


### PR DESCRIPTION
## Summary

Adds two related directory-copy features to spudlang. `copy <source> into <destination>` copies contents into an existing destination, and `mkdir <path> from <source>` creates a new destination populated from a source directory. This is the next branch in the roadmap at `.claude/todos/lang-spec-extensions.md`.

The two forms intentionally split: `mkdir from` is an atomic create-and-fill, while `copy into` is for merging several sources into one existing destination.

## Changes

- New copy statement in the syntax tree, carrying source and destination paths, a verbatim flag, and an optional when clause.
- `mkdir` gains an optional from-source and verbatim flag, parsed before mode and when.
- New `copy` and `into` keywords. Every path in both statements is a path expression, so aliases, interpolation, and quoted fallback all work.
- Verbatim on either form suppresses interpolation of embedded file contents at runtime.
- Docs updated with a copy section and a mkdir-from example.

## Test plan

- `cmake --build build && ctest --test-dir build --output-on-failure`
- 160 of 160 tests pass, including 9 new cases covering basic copy, copy with a when clause, verbatim into an aliased destination, mkdir with a source, mkdir with source plus verbatim plus when plus as, and error cases for missing into, source, destination, and mkdir-from source path.