### PR TITLE
feat(validator): repeat when and semantic rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Library
-add_library(spudplate_lib src/lexer.cpp src/parser.cpp)
+add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 
 # Executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,8 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
-add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp)
+add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
+               tests/validator_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -232,9 +232,10 @@ using StmtPtr = std::unique_ptr<Stmt>;
  * @endcode
  */
 struct RepeatStmt {
-    std::string collection_var;  ///< Name of the int variable holding the count.
-    std::string iterator_var;    ///< Name of the loop index variable (0-based).
-    std::vector<StmtPtr> body;   ///< Statements inside the loop body.
+    std::string collection_var;          ///< Name of the int variable holding the count.
+    std::string iterator_var;            ///< Name of the loop index variable (0-based).
+    std::vector<StmtPtr> body;           ///< Statements inside the loop body.
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the whole loop.
     int line;
     int column;
 };

--- a/include/spudplate/validator.h
+++ b/include/spudplate/validator.h
@@ -3,10 +3,17 @@
 
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 
 #include "spudplate/ast.h"
 
 namespace spudplate {
+
+/**
+ * @brief Map from variable name to its declared type, built from `ask`
+ * statements seen so far. Drives bool equivalence in `normalize`.
+ */
+using TypeMap = std::unordered_map<std::string, VarType>;
 
 /**
  * @brief Exception thrown when the semantic validator finds a rule violation.
@@ -36,6 +43,29 @@ class SemanticError : public std::runtime_error {
  * program is valid.
  */
 void validate(const Program& program);
+
+/**
+ * @brief Deep-copy of an expression tree. Needed because `ExprPtr` is a
+ * `unique_ptr` and cannot be copied implicitly.
+ */
+ExprPtr clone_expr(const Expr& expr);
+
+/**
+ * @brief Normalizes bool equivalences in `expr` using `tm` as the type map.
+ *
+ * Returns a freshly-allocated tree. Rules are applied bottom-up to fixpoint:
+ * `x == true` ≡ `not not x` ≡ `x`; `not x` ≡ `x == false` ≡ `x != true`.
+ * Non-bool comparisons pass through structurally. Commutativity is NOT applied.
+ */
+ExprPtr normalize(const Expr& expr, const TypeMap& tm);
+
+/**
+ * @brief Structural recursive equality for expression trees.
+ *
+ * Ignores `line` and `column` on every node. Recurses into every `ExprPtr`
+ * child. For `FunctionCallExpr`, compares `name` then recurses into `argument`.
+ */
+bool exprs_equal(const Expr& a, const Expr& b);
 
 }  // namespace spudplate
 

--- a/include/spudplate/validator.h
+++ b/include/spudplate/validator.h
@@ -1,0 +1,42 @@
+#ifndef SPUDPLATE_VALIDATOR_H
+#define SPUDPLATE_VALIDATOR_H
+
+#include <stdexcept>
+#include <string>
+
+#include "spudplate/ast.h"
+
+namespace spudplate {
+
+/**
+ * @brief Exception thrown when the semantic validator finds a rule violation.
+ *
+ * Mirrors ParseError in shape: carries the source line and column of the
+ * offending node alongside a bare message string.
+ */
+class SemanticError : public std::runtime_error {
+  public:
+    SemanticError(const std::string& message, int line, int column)
+        : std::runtime_error(message), line_(line), column_(column) {}
+
+    /** @brief 1-based line number of the offending statement or expression. */
+    [[nodiscard]] int line() const { return line_; }
+    /** @brief 1-based column number of the offending statement or expression. */
+    [[nodiscard]] int column() const { return column_; }
+
+  private:
+    int line_;
+    int column_;
+};
+
+/**
+ * @brief Walks a parsed Program and enforces spudlang semantic rules.
+ *
+ * Throws SemanticError on the first rule violation. Returns normally if the
+ * program is valid.
+ */
+void validate(const Program& program);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_VALIDATOR_H

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -384,6 +384,7 @@ StmtPtr Parser::parseRepeat() {
     expect(TokenType::AS, "expected 'as' after collection variable");
     Token iterator =
         expect(TokenType::IDENTIFIER, "expected iterator variable after 'as'");
+    auto when_clause = parse_when_clause();
     expect_newline("repeat header");
 
     std::vector<StmtPtr> body;
@@ -400,6 +401,7 @@ StmtPtr Parser::parseRepeat() {
     stmt->data = RepeatStmt{.collection_var = collection.value,
                              .iterator_var = iterator.value,
                              .body = std::move(body),
+                             .when_clause = std::move(when_clause),
                              .line = start.line,
                              .column = start.column};
     return stmt;

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -1,14 +1,81 @@
 #include "spudplate/validator.h"
 
+#include <memory>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
+#include <utility>
 #include <variant>
 #include <vector>
 
 namespace spudplate {
 
 namespace {
+
+ExprPtr make_expr(ExprData data) {
+    auto expr = std::make_unique<Expr>();
+    expr->data = std::move(data);
+    return expr;
+}
+
+bool is_bool_id(const Expr& e, const TypeMap& tm) {
+    if (const auto* id = std::get_if<IdentifierExpr>(&e.data); id != nullptr) {
+        auto it = tm.find(id->name);
+        return it != tm.end() && it->second == VarType::Bool;
+    }
+    return false;
+}
+
+// Apply a single top-level normalization rule. Sets `fired` if a rule matched.
+// Children are assumed already normalized.
+ExprPtr apply_rule_once(const Expr& expr, const TypeMap& tm, bool& fired) {
+    // Rule: `not not X` -> X
+    if (const auto* un = std::get_if<UnaryExpr>(&expr.data);
+        un != nullptr && un->op == TokenType::NOT) {
+        if (const auto* inner = std::get_if<UnaryExpr>(&un->operand->data);
+            inner != nullptr && inner->op == TokenType::NOT) {
+            fired = true;
+            return clone_expr(*inner->operand);
+        }
+    }
+
+    // Rules: `x == true` / `x == false` / `x != true` / `x != false` where x is bool.
+    // Symmetric: `true == x` etc. are also recognised.
+    if (const auto* bin = std::get_if<BinaryExpr>(&expr.data);
+        bin != nullptr &&
+        (bin->op == TokenType::EQUALS || bin->op == TokenType::NOT_EQUALS)) {
+        const Expr* id_side = nullptr;
+        const BoolLiteralExpr* lit = nullptr;
+        if (is_bool_id(*bin->left, tm)) {
+            if (const auto* l = std::get_if<BoolLiteralExpr>(&bin->right->data);
+                l != nullptr) {
+                id_side = bin->left.get();
+                lit = l;
+            }
+        }
+        if (id_side == nullptr && is_bool_id(*bin->right, tm)) {
+            if (const auto* l = std::get_if<BoolLiteralExpr>(&bin->left->data);
+                l != nullptr) {
+                id_side = bin->right.get();
+                lit = l;
+            }
+        }
+        if (id_side != nullptr && lit != nullptr) {
+            const bool positive = (bin->op == TokenType::EQUALS && lit->value) ||
+                                  (bin->op == TokenType::NOT_EQUALS && !lit->value);
+            fired = true;
+            if (positive) {
+                return clone_expr(*id_side);
+            }
+            return make_expr(UnaryExpr{.op = TokenType::NOT,
+                                       .operand = clone_expr(*id_side),
+                                       .line = bin->line,
+                                       .column = bin->column});
+        }
+    }
+
+    return clone_expr(expr);
+}
 
 // Scope stack. frames[0] is the program-level scope and is never popped. Each
 // `repeat` body pushes a new frame on entry and pops it on exit. Names that
@@ -171,6 +238,110 @@ void validate_stmt(const Stmt& stmt, Scope& scope) {
 }
 
 }  // namespace
+
+ExprPtr clone_expr(const Expr& expr) {
+    return std::visit(
+        [](const auto& n) -> ExprPtr {
+            using T = std::decay_t<decltype(n)>;
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                return make_expr(StringLiteralExpr{
+                    .value = n.value, .line = n.line, .column = n.column});
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                return make_expr(IntegerLiteralExpr{
+                    .value = n.value, .line = n.line, .column = n.column});
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                return make_expr(BoolLiteralExpr{
+                    .value = n.value, .line = n.line, .column = n.column});
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                return make_expr(
+                    IdentifierExpr{.name = n.name, .line = n.line, .column = n.column});
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                return make_expr(UnaryExpr{.op = n.op,
+                                           .operand = clone_expr(*n.operand),
+                                           .line = n.line,
+                                           .column = n.column});
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                return make_expr(BinaryExpr{.op = n.op,
+                                            .left = clone_expr(*n.left),
+                                            .right = clone_expr(*n.right),
+                                            .line = n.line,
+                                            .column = n.column});
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                return make_expr(FunctionCallExpr{.name = n.name,
+                                                  .argument = clone_expr(*n.argument),
+                                                  .line = n.line,
+                                                  .column = n.column});
+            }
+        },
+        expr.data);
+}
+
+ExprPtr normalize(const Expr& expr, const TypeMap& tm) {
+    // Step 1: deep-clone and normalize children bottom-up.
+    ExprPtr out;
+    std::visit(
+        [&](const auto& n) {
+            using T = std::decay_t<decltype(n)>;
+            if constexpr (std::is_same_v<T, UnaryExpr>) {
+                out = make_expr(UnaryExpr{.op = n.op,
+                                          .operand = normalize(*n.operand, tm),
+                                          .line = n.line,
+                                          .column = n.column});
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                out = make_expr(BinaryExpr{.op = n.op,
+                                           .left = normalize(*n.left, tm),
+                                           .right = normalize(*n.right, tm),
+                                           .line = n.line,
+                                           .column = n.column});
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                out = make_expr(FunctionCallExpr{.name = n.name,
+                                                 .argument = normalize(*n.argument, tm),
+                                                 .line = n.line,
+                                                 .column = n.column});
+            } else {
+                out = clone_expr(expr);
+            }
+        },
+        expr.data);
+
+    // Step 2: apply top-level rules to fixpoint.
+    while (true) {
+        bool fired = false;
+        out = apply_rule_once(*out, tm, fired);
+        if (!fired) {
+            break;
+        }
+    }
+    return out;
+}
+
+bool exprs_equal(const Expr& a, const Expr& b) {
+    if (a.data.index() != b.data.index()) {
+        return false;
+    }
+    return std::visit(
+        [&](const auto& ax) -> bool {
+            using T = std::decay_t<decltype(ax)>;
+            const auto& bx = std::get<T>(b.data);
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                return ax.value == bx.value;
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                return ax.value == bx.value;
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                return ax.value == bx.value;
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                return ax.name == bx.name;
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                return ax.op == bx.op && exprs_equal(*ax.operand, *bx.operand);
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                return ax.op == bx.op && exprs_equal(*ax.left, *bx.left) &&
+                       exprs_equal(*ax.right, *bx.right);
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                return ax.name == bx.name && exprs_equal(*ax.argument, *bx.argument);
+            }
+        },
+        a.data);
+}
 
 void validate(const Program& program) {
     Scope scope;

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -1,0 +1,46 @@
+#include "spudplate/validator.h"
+
+#include <variant>
+
+namespace spudplate {
+
+namespace {
+
+// Forward declaration so the visitor below can recurse into nested repeat bodies.
+void validate_stmt(const Stmt& stmt, bool inside_repeat);
+
+struct StmtVisitor {
+    bool inside_repeat;
+
+    void operator()(const AskStmt& ask) const {
+        if (inside_repeat) {
+            throw SemanticError("'ask' not allowed inside 'repeat'", ask.line,
+                                ask.column);
+        }
+    }
+
+    void operator()(const LetStmt&) const {}
+    void operator()(const MkdirStmt&) const {}
+    void operator()(const FileStmt&) const {}
+    void operator()(const CopyStmt&) const {}
+
+    void operator()(const RepeatStmt& rep) const {
+        for (const auto& inner : rep.body) {
+            validate_stmt(*inner, true);
+        }
+    }
+};
+
+void validate_stmt(const Stmt& stmt, bool inside_repeat) {
+    std::visit(StmtVisitor{inside_repeat}, stmt.data);
+}
+
+}  // namespace
+
+void validate(const Program& program) {
+    for (const auto& stmt : program.statements) {
+        validate_stmt(*stmt, false);
+    }
+}
+
+}  // namespace spudplate

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -111,15 +111,48 @@ struct Scope {
     [[nodiscard]] bool inside_repeat() const { return frames.size() > 1; }
 };
 
+// AliasCtx carries state that accumulates as the walker moves through the
+// program: the alias registry (populated for mkdir/file aliases declared
+// outside any repeat, Part E) and the type map used to normalize when clauses
+// (Part D).
+struct AliasCtx {
+    std::unordered_map<std::string, std::optional<ExprPtr>> registry;
+    TypeMap type_map;
+};
+
 void walk_expr(const Expr& expr, const Scope& scope);
-void walk_path(const PathExpr& path, const Scope& scope);
-void validate_stmt(const Stmt& stmt, Scope& scope);
+void walk_path(const PathExpr& path, const Scope& scope, const AliasCtx& ctx,
+               const std::optional<ExprPtr>& current_when);
+void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx);
 
 void check_reference(const std::string& name, int line, int column,
                      const Scope& scope) {
     if (scope.out_of_scope(name)) {
         throw SemanticError("reference to out-of-scope name '" + name + "'", line,
                             column);
+    }
+}
+
+void check_alias(const PathVar& pv, const std::optional<ExprPtr>& current_when,
+                 const AliasCtx& ctx) {
+    auto it = ctx.registry.find(pv.name);
+    if (it == ctx.registry.end()) {
+        return;  // Not a registered alias (for example one rejected by Part C).
+    }
+    const auto& stored = it->second;
+    if (!stored.has_value()) {
+        return;  // Unconditional binding — references are unrestricted.
+    }
+    if (!current_when.has_value()) {
+        throw SemanticError("alias '" + pv.name +
+                                "' is conditional; reference requires a matching when clause",
+                            pv.line, pv.column);
+    }
+    auto normalized_current = normalize(**current_when, ctx.type_map);
+    if (!exprs_equal(**stored, *normalized_current)) {
+        throw SemanticError(
+            "alias '" + pv.name + "' referenced under a different condition than its binding",
+            pv.line, pv.column);
     }
 }
 
@@ -142,13 +175,15 @@ void walk_expr(const Expr& expr, const Scope& scope) {
         expr.data);
 }
 
-void walk_path(const PathExpr& path, const Scope& scope) {
+void walk_path(const PathExpr& path, const Scope& scope, const AliasCtx& ctx,
+               const std::optional<ExprPtr>& current_when) {
     for (const auto& seg : path.segments) {
         std::visit(
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, PathVar>) {
                     check_reference(s.name, s.line, s.column, scope);
+                    check_alias(s, current_when, ctx);
                 } else if constexpr (std::is_same_v<T, PathInterp>) {
                     walk_expr(*s.expression, scope);
                 }
@@ -171,7 +206,22 @@ void check_shadowing(const std::string& name, int line, int column,
     }
 }
 
-void validate_stmt(const Stmt& stmt, Scope& scope) {
+// Called by mkdir/file to record an alias binding in the registry if the
+// binding is outside any repeat body.
+void register_alias_binding(const std::string& name,
+                            const std::optional<ExprPtr>& when_clause,
+                            const Scope& scope, AliasCtx& ctx) {
+    if (scope.inside_repeat()) {
+        return;  // Part C already rejects out-of-repeat references to these.
+    }
+    std::optional<ExprPtr> stored;
+    if (when_clause.has_value()) {
+        stored = normalize(**when_clause, ctx.type_map);
+    }
+    ctx.registry[name] = std::move(stored);
+}
+
+void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
     std::visit(
         [&](const auto& s) {
             using T = std::decay_t<decltype(s)>;
@@ -187,27 +237,29 @@ void validate_stmt(const Stmt& stmt, Scope& scope) {
                     walk_expr(*opt, scope);
                 }
                 walk_optional_expr(s.when_clause, scope);
+                ctx.type_map[s.name] = s.var_type;
             } else if constexpr (std::is_same_v<T, LetStmt>) {
                 walk_expr(*s.value, scope);
                 check_shadowing(s.name, s.line, s.column, scope);
                 scope.declare(s.name);
             } else if constexpr (std::is_same_v<T, MkdirStmt>) {
-                walk_path(s.path, scope);
+                walk_path(s.path, scope, ctx, s.when_clause);
                 if (s.from_source.has_value()) {
-                    walk_path(*s.from_source, scope);
+                    walk_path(*s.from_source, scope, ctx, s.when_clause);
                 }
                 walk_optional_expr(s.when_clause, scope);
                 if (s.alias.has_value()) {
                     check_shadowing(*s.alias, s.line, s.column, scope);
                     scope.declare(*s.alias);
+                    register_alias_binding(*s.alias, s.when_clause, scope, ctx);
                 }
             } else if constexpr (std::is_same_v<T, FileStmt>) {
-                walk_path(s.path, scope);
+                walk_path(s.path, scope, ctx, s.when_clause);
                 std::visit(
                     [&](const auto& src) {
                         using ST = std::decay_t<decltype(src)>;
                         if constexpr (std::is_same_v<ST, FileFromSource>) {
-                            walk_path(src.path, scope);
+                            walk_path(src.path, scope, ctx, s.when_clause);
                         } else if constexpr (std::is_same_v<ST, FileContentSource>) {
                             walk_expr(*src.value, scope);
                         }
@@ -217,10 +269,11 @@ void validate_stmt(const Stmt& stmt, Scope& scope) {
                 if (s.alias.has_value()) {
                     check_shadowing(*s.alias, s.line, s.column, scope);
                     scope.declare(*s.alias);
+                    register_alias_binding(*s.alias, s.when_clause, scope, ctx);
                 }
             } else if constexpr (std::is_same_v<T, CopyStmt>) {
-                walk_path(s.source, scope);
-                walk_path(s.destination, scope);
+                walk_path(s.source, scope, ctx, s.when_clause);
+                walk_path(s.destination, scope, ctx, s.when_clause);
                 walk_optional_expr(s.when_clause, scope);
             } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                 check_reference(s.collection_var, s.line, s.column, scope);
@@ -229,7 +282,7 @@ void validate_stmt(const Stmt& stmt, Scope& scope) {
                 scope.push();
                 scope.declare(s.iterator_var);
                 for (const auto& inner : s.body) {
-                    validate_stmt(*inner, scope);
+                    validate_stmt(*inner, scope, ctx);
                 }
                 scope.pop();
             }
@@ -346,8 +399,9 @@ bool exprs_equal(const Expr& a, const Expr& b) {
 void validate(const Program& program) {
     Scope scope;
     scope.push();  // program-level frame, never popped.
+    AliasCtx ctx;
     for (const auto& stmt : program.statements) {
-        validate_stmt(*stmt, scope);
+        validate_stmt(*stmt, scope, ctx);
     }
 }
 

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -1,45 +1,182 @@
 #include "spudplate/validator.h"
 
+#include <string>
+#include <type_traits>
+#include <unordered_set>
 #include <variant>
+#include <vector>
 
 namespace spudplate {
 
 namespace {
 
-// Forward declaration so the visitor below can recurse into nested repeat bodies.
-void validate_stmt(const Stmt& stmt, bool inside_repeat);
+// Scope stack. frames[0] is the program-level scope and is never popped. Each
+// `repeat` body pushes a new frame on entry and pops it on exit. Names that
+// leave a popped frame go into `popped` so we can reject later references.
+struct Scope {
+    std::vector<std::unordered_set<std::string>> frames;
+    std::unordered_set<std::string> popped;
 
-struct StmtVisitor {
-    bool inside_repeat;
+    void push() { frames.emplace_back(); }
 
-    void operator()(const AskStmt& ask) const {
-        if (inside_repeat) {
-            throw SemanticError("'ask' not allowed inside 'repeat'", ask.line,
-                                ask.column);
+    void pop() {
+        for (const auto& n : frames.back()) {
+            popped.insert(n);
         }
+        frames.pop_back();
     }
 
-    void operator()(const LetStmt&) const {}
-    void operator()(const MkdirStmt&) const {}
-    void operator()(const FileStmt&) const {}
-    void operator()(const CopyStmt&) const {}
-
-    void operator()(const RepeatStmt& rep) const {
-        for (const auto& inner : rep.body) {
-            validate_stmt(*inner, true);
+    [[nodiscard]] bool visible(const std::string& name) const {
+        for (const auto& f : frames) {
+            if (f.count(name) != 0U) {
+                return true;
+            }
         }
+        return false;
     }
+
+    [[nodiscard]] bool out_of_scope(const std::string& name) const {
+        return popped.count(name) != 0U && !visible(name);
+    }
+
+    void declare(const std::string& name) { frames.back().insert(name); }
+
+    [[nodiscard]] bool inside_repeat() const { return frames.size() > 1; }
 };
 
-void validate_stmt(const Stmt& stmt, bool inside_repeat) {
-    std::visit(StmtVisitor{inside_repeat}, stmt.data);
+void walk_expr(const Expr& expr, const Scope& scope);
+void walk_path(const PathExpr& path, const Scope& scope);
+void validate_stmt(const Stmt& stmt, Scope& scope);
+
+void check_reference(const std::string& name, int line, int column,
+                     const Scope& scope) {
+    if (scope.out_of_scope(name)) {
+        throw SemanticError("reference to out-of-scope name '" + name + "'", line,
+                            column);
+    }
+}
+
+void walk_expr(const Expr& expr, const Scope& scope) {
+    std::visit(
+        [&](const auto& e) {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                check_reference(e.name, e.line, e.column, scope);
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                walk_expr(*e.operand, scope);
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                walk_expr(*e.left, scope);
+                walk_expr(*e.right, scope);
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                walk_expr(*e.argument, scope);
+            }
+            // String, Integer, Bool literals have no children.
+        },
+        expr.data);
+}
+
+void walk_path(const PathExpr& path, const Scope& scope) {
+    for (const auto& seg : path.segments) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, PathVar>) {
+                    check_reference(s.name, s.line, s.column, scope);
+                } else if constexpr (std::is_same_v<T, PathInterp>) {
+                    walk_expr(*s.expression, scope);
+                }
+                // PathLiteral has no children.
+            },
+            seg);
+    }
+}
+
+void walk_optional_expr(const std::optional<ExprPtr>& opt, const Scope& scope) {
+    if (opt.has_value()) {
+        walk_expr(**opt, scope);
+    }
+}
+
+void check_shadowing(const std::string& name, int line, int column,
+                     const Scope& scope) {
+    if (scope.visible(name)) {
+        throw SemanticError("shadowing of visible name '" + name + "'", line, column);
+    }
+}
+
+void validate_stmt(const Stmt& stmt, Scope& scope) {
+    std::visit(
+        [&](const auto& s) {
+            using T = std::decay_t<decltype(s)>;
+            if constexpr (std::is_same_v<T, AskStmt>) {
+                if (scope.inside_repeat()) {
+                    throw SemanticError("'ask' not allowed inside 'repeat'", s.line,
+                                        s.column);
+                }
+                if (s.default_value.has_value()) {
+                    walk_expr(**s.default_value, scope);
+                }
+                for (const auto& opt : s.options) {
+                    walk_expr(*opt, scope);
+                }
+                walk_optional_expr(s.when_clause, scope);
+            } else if constexpr (std::is_same_v<T, LetStmt>) {
+                walk_expr(*s.value, scope);
+                check_shadowing(s.name, s.line, s.column, scope);
+                scope.declare(s.name);
+            } else if constexpr (std::is_same_v<T, MkdirStmt>) {
+                walk_path(s.path, scope);
+                if (s.from_source.has_value()) {
+                    walk_path(*s.from_source, scope);
+                }
+                walk_optional_expr(s.when_clause, scope);
+                if (s.alias.has_value()) {
+                    check_shadowing(*s.alias, s.line, s.column, scope);
+                    scope.declare(*s.alias);
+                }
+            } else if constexpr (std::is_same_v<T, FileStmt>) {
+                walk_path(s.path, scope);
+                std::visit(
+                    [&](const auto& src) {
+                        using ST = std::decay_t<decltype(src)>;
+                        if constexpr (std::is_same_v<ST, FileFromSource>) {
+                            walk_path(src.path, scope);
+                        } else if constexpr (std::is_same_v<ST, FileContentSource>) {
+                            walk_expr(*src.value, scope);
+                        }
+                    },
+                    s.source);
+                walk_optional_expr(s.when_clause, scope);
+                if (s.alias.has_value()) {
+                    check_shadowing(*s.alias, s.line, s.column, scope);
+                    scope.declare(*s.alias);
+                }
+            } else if constexpr (std::is_same_v<T, CopyStmt>) {
+                walk_path(s.source, scope);
+                walk_path(s.destination, scope);
+                walk_optional_expr(s.when_clause, scope);
+            } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                check_reference(s.collection_var, s.line, s.column, scope);
+                walk_optional_expr(s.when_clause, scope);
+                check_shadowing(s.iterator_var, s.line, s.column, scope);
+                scope.push();
+                scope.declare(s.iterator_var);
+                for (const auto& inner : s.body) {
+                    validate_stmt(*inner, scope);
+                }
+                scope.pop();
+            }
+        },
+        stmt.data);
 }
 
 }  // namespace
 
 void validate(const Program& program) {
+    Scope scope;
+    scope.push();  // program-level frame, never popped.
     for (const auto& stmt : program.statements) {
-        validate_stmt(*stmt, false);
+        validate_stmt(*stmt, scope);
     }
 }
 

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -888,6 +888,53 @@ TEST(ParserTest, RepeatNested) {
     std::get<MkdirStmt>(inner.body[0]->data);
 }
 
+TEST(ParserTest, RepeatWithWhenClause) {
+    auto program = parse_program(
+        "repeat n as i when use_weeks\n"
+        "  mkdir \"week_{i}\"\n"
+        "end\n");
+    ASSERT_EQ(program.statements.size(), 1);
+    auto& rep = std::get<RepeatStmt>(program.statements[0]->data);
+    ASSERT_TRUE(rep.when_clause.has_value());
+    auto& cond = std::get<IdentifierExpr>((*rep.when_clause)->data);
+    EXPECT_EQ(cond.name, "use_weeks");
+    ASSERT_EQ(rep.body.size(), 1);
+}
+
+TEST(ParserTest, RepeatHeaderWhenWithBodyStatementWhen) {
+    // Proves the header when binds to repeat and the body statement's when
+    // binds to the body statement — no lexical collision.
+    auto program = parse_program(
+        "repeat n as i when outer\n"
+        "  mkdir \"x\" when inner\n"
+        "end\n");
+    auto& rep = std::get<RepeatStmt>(program.statements[0]->data);
+    ASSERT_TRUE(rep.when_clause.has_value());
+    EXPECT_EQ(std::get<IdentifierExpr>((*rep.when_clause)->data).name, "outer");
+    ASSERT_EQ(rep.body.size(), 1);
+    auto& mk = std::get<MkdirStmt>(rep.body[0]->data);
+    ASSERT_TRUE(mk.when_clause.has_value());
+    EXPECT_EQ(std::get<IdentifierExpr>((*mk.when_clause)->data).name, "inner");
+}
+
+TEST(ParserTest, RepeatWithoutWhenClauseHasEmptyOptional) {
+    auto program = parse_program(
+        "repeat n as i\n"
+        "  mkdir \"x\"\n"
+        "end\n");
+    auto& rep = std::get<RepeatStmt>(program.statements[0]->data);
+    EXPECT_FALSE(rep.when_clause.has_value());
+}
+
+TEST(ParserTest, RepeatBareWhenRaisesError) {
+    // `repeat n as i when\n ... end` — bare when with no expression.
+    // parseExpression sees NEWLINE and throws.
+    EXPECT_THROW(parse_program("repeat n as i when\n"
+                               "  mkdir \"x\"\n"
+                               "end\n"),
+                 ParseError);
+}
+
 // --- Full integration test ---
 
 TEST(ParserTest, FullSpudFile) {

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -87,3 +87,110 @@ TEST(ValidatorTest, RepeatBodyWithNonAskStatementsValidates) {
         "end\n");
     EXPECT_NO_THROW(validate(program));
 }
+
+// --- Scope stack tests ---
+
+TEST(ValidatorTest, LetInsideRepeatReferencedOutsideIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  let x = i\n"
+        "end\n"
+        "let y = x\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, IteratorVarReferencedOutsideIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "end\n"
+        "let y = i\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AliasBoundInsideRepeatReferencedOutsideIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  mkdir \"foo\" as bar\n"
+        "end\n"
+        "mkdir bar/sub\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, NestedRepeatsIsolateInnerScope) {
+    // Inner-declared `x` must not be visible to the outer body after inner pops.
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  repeat n as j\n"
+        "    let x = 1\n"
+        "  end\n"
+        "  let y = x\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, OuterNamesVisibleFromInsideNestedRepeat) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "let base = 5\n"
+        "repeat n as i\n"
+        "  repeat n as j\n"
+        "    let x = base + i + j\n"
+        "  end\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, SameScopeReferencesInsideRepeatAreValid) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  let x = i\n"
+        "  let y = x\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, ShadowingTopLevelLetFromInsideRepeatIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "let x = 1\n"
+        "repeat n as i\n"
+        "  let x = i\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, WhenClauseReferencingPoppedBindingIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  let x = 1\n"
+        "end\n"
+        "mkdir stuff when x\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, PathInterpReferencingPoppedIteratorIsError) {
+    // Unquoted path so `{i}` is parsed as a PathInterp segment.
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "end\n"
+        "mkdir week_{i}\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, CollectionVarReferencingPoppedNameIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as k\n"
+        "  let x = 1\n"
+        "end\n"
+        "repeat x as j\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -2,14 +2,87 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+#include <utility>
+
+#include "spudplate/ast.h"
 #include "spudplate/lexer.h"
 #include "spudplate/parser.h"
+#include "spudplate/token.h"
 
+using spudplate::BinaryExpr;
+using spudplate::BoolLiteralExpr;
+using spudplate::clone_expr;
+using spudplate::Expr;
+using spudplate::ExprData;
+using spudplate::ExprPtr;
+using spudplate::exprs_equal;
+using spudplate::FunctionCallExpr;
+using spudplate::IdentifierExpr;
+using spudplate::IntegerLiteralExpr;
 using spudplate::Lexer;
+using spudplate::normalize;
 using spudplate::Parser;
 using spudplate::Program;
 using spudplate::SemanticError;
+using spudplate::StringLiteralExpr;
+using spudplate::TokenType;
+using spudplate::TypeMap;
+using spudplate::UnaryExpr;
 using spudplate::validate;
+using spudplate::VarType;
+
+// AST builder helpers used by the normalization tests.
+static ExprPtr wrap(ExprData data, int line = 1, int column = 1) {
+    auto e = std::make_unique<Expr>();
+    e->data = std::move(data);
+    (void)line;
+    (void)column;
+    return e;
+}
+
+static ExprPtr id(const std::string& name, int line = 1, int column = 1) {
+    return wrap(IdentifierExpr{.name = name, .line = line, .column = column});
+}
+
+static ExprPtr bool_lit(bool value, int line = 1, int column = 1) {
+    return wrap(BoolLiteralExpr{.value = value, .line = line, .column = column});
+}
+
+static ExprPtr int_lit(int value, int line = 1, int column = 1) {
+    return wrap(IntegerLiteralExpr{.value = value, .line = line, .column = column});
+}
+
+static ExprPtr str_lit(const std::string& value, int line = 1, int column = 1) {
+    return wrap(StringLiteralExpr{.value = value, .line = line, .column = column});
+}
+
+static ExprPtr not_of(ExprPtr operand) {
+    return wrap(UnaryExpr{.op = TokenType::NOT,
+                          .operand = std::move(operand),
+                          .line = 1,
+                          .column = 1});
+}
+
+static ExprPtr bin(TokenType op, ExprPtr left, ExprPtr right) {
+    return wrap(BinaryExpr{.op = op,
+                           .left = std::move(left),
+                           .right = std::move(right),
+                           .line = 1,
+                           .column = 1});
+}
+
+static ExprPtr call(const std::string& name, ExprPtr arg) {
+    return wrap(FunctionCallExpr{
+        .name = name, .argument = std::move(arg), .line = 1, .column = 1});
+}
+
+// Equivalent under the given type map iff normalized forms compare equal.
+static bool equivalent(const Expr& a, const Expr& b, const TypeMap& tm) {
+    auto na = normalize(a, tm);
+    auto nb = normalize(b, tm);
+    return exprs_equal(*na, *nb);
+}
 
 static Program parse(const std::string& input) {
     Lexer lexer(input);
@@ -193,4 +266,101 @@ TEST(ValidatorTest, CollectionVarReferencingPoppedNameIsError) {
         "repeat x as j\n"
         "end\n");
     EXPECT_THROW(validate(program), SemanticError);
+}
+
+// --- Expression normalization tests ---
+
+TEST(NormalizeTest, BoolIdEqualsTrueCollapsesToId) {
+    TypeMap tm{{"x", VarType::Bool}};
+    auto a = id("x");
+    auto b = bin(TokenType::EQUALS, id("x"), bool_lit(true));
+    EXPECT_TRUE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, NotBoolIdEqualsXEqualsFalse) {
+    TypeMap tm{{"x", VarType::Bool}};
+    auto a = not_of(id("x"));
+    auto b = bin(TokenType::EQUALS, id("x"), bool_lit(false));
+    EXPECT_TRUE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, NotBoolIdEqualsXNotEqualsTrue) {
+    TypeMap tm{{"x", VarType::Bool}};
+    auto a = not_of(id("x"));
+    auto b = bin(TokenType::NOT_EQUALS, id("x"), bool_lit(true));
+    EXPECT_TRUE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, NotNotBoolIdCollapsesToId) {
+    TypeMap tm{{"x", VarType::Bool}};
+    auto a = id("x");
+    auto b = not_of(not_of(id("x")));
+    EXPECT_TRUE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, ArbitraryDepthNotNormalizes) {
+    TypeMap tm{{"x", VarType::Bool}};
+    auto a = not_of(id("x"));  // canonical negative
+    auto b = not_of(not_of(not_of(id("x"))));  // three nots collapses to one
+    EXPECT_TRUE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, RecursesUnderFunctionAndComparison) {
+    TypeMap tm{{"x", VarType::Bool}};
+    // lower(not not x) == "y"   vs   lower(x) == "y"
+    auto a = bin(TokenType::EQUALS,
+                 call("lower", not_of(not_of(id("x")))), str_lit("y"));
+    auto b = bin(TokenType::EQUALS, call("lower", id("x")), str_lit("y"));
+    EXPECT_TRUE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, LineColumnIgnoredInEquality) {
+    // Two identifiers with the same name at wildly different positions.
+    auto a = id("x", 1, 1);
+    auto b = id("x", 42, 7);
+    EXPECT_TRUE(exprs_equal(*a, *b));
+}
+
+TEST(NormalizeTest, FunctionCallRecursiveEquality) {
+    auto a = call("lower", id("a"));
+    auto b = call("lower", id("a"));
+    EXPECT_TRUE(exprs_equal(*a, *b));
+}
+
+TEST(NormalizeTest, DifferentIdentifiersNotEqual) {
+    TypeMap tm{{"x", VarType::Bool}, {"y", VarType::Bool}};
+    auto a = id("x");
+    auto b = id("y");
+    EXPECT_FALSE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, PositiveAndNegativeBoolNotEqual) {
+    TypeMap tm{{"x", VarType::Bool}};
+    auto a = id("x");
+    auto b = not_of(id("x"));
+    EXPECT_FALSE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, CommutativityNotApplied) {
+    // `a and b` vs `b and a` — known limitation per TODO.
+    TypeMap tm{{"a", VarType::Bool}, {"b", VarType::Bool}};
+    auto left = bin(TokenType::AND, id("a"), id("b"));
+    auto right = bin(TokenType::AND, id("b"), id("a"));
+    EXPECT_FALSE(equivalent(*left, *right, tm));
+}
+
+TEST(NormalizeTest, UnknownIdentifierKeepsStructuralForm) {
+    // `x` is NOT in the type map — bool simplification skipped.
+    // `x == true` stays as the binary form; `x` stays as the identifier.
+    TypeMap tm;  // empty
+    auto a = id("x");
+    auto b = bin(TokenType::EQUALS, id("x"), bool_lit(true));
+    EXPECT_FALSE(equivalent(*a, *b, tm));
+}
+
+TEST(NormalizeTest, IntComparisonDiffersFromBoolComparison) {
+    TypeMap tm{{"x", VarType::Bool}, {"n", VarType::Int}};
+    auto a = bin(TokenType::EQUALS, id("n"), int_lit(1));
+    auto b = bin(TokenType::EQUALS, id("x"), bool_lit(true));
+    EXPECT_FALSE(equivalent(*a, *b, tm));
 }

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -1,0 +1,89 @@
+#include "spudplate/validator.h"
+
+#include <gtest/gtest.h>
+
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+
+using spudplate::Lexer;
+using spudplate::Parser;
+using spudplate::Program;
+using spudplate::SemanticError;
+using spudplate::validate;
+
+static Program parse(const std::string& input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parse();
+}
+
+// --- Validator skeleton tests ---
+
+TEST(ValidatorTest, EmptyProgramValidatesCleanly) {
+    Program empty;
+    EXPECT_NO_THROW(validate(empty));
+}
+
+TEST(ValidatorTest, AskAtTopLevelThenRepeatValidates) {
+    auto program = parse(
+        "ask name \"Name?\" string\n"
+        "repeat n as i\n"
+        "  mkdir \"m_{i}\"\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, EmptyRepeatBodyValidates) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, AskInsideSingleRepeatIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  ask use_extra \"Extra?\" bool\n"
+        "end\n");
+    try {
+        validate(program);
+        FAIL() << "expected SemanticError";
+    } catch (const SemanticError& e) {
+        // The offending ask is on line 3 (ask n ... is line 1, repeat is line 2).
+        EXPECT_EQ(e.line(), 3);
+    }
+}
+
+TEST(ValidatorTest, AskInsideNestedRepeatPointsAtAskLine) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"       // line 1
+        "ask m \"Count?\" int\n"       // line 2
+        "repeat n as i\n"              // line 3 (outer)
+        "  repeat m as j\n"            // line 4 (inner)
+        "    ask bad \"bad?\" bool\n"  // line 5 — the offender
+        "  end\n"
+        "end\n");
+    try {
+        validate(program);
+        FAIL() << "expected SemanticError";
+    } catch (const SemanticError& e) {
+        EXPECT_EQ(e.line(), 5);
+    }
+}
+
+TEST(ValidatorTest, RepeatBodyWithNonAskStatementsValidates) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "mkdir base\n"
+        "repeat n as i\n"
+        "  mkdir \"m_{i}\"\n"
+        "  file \"m_{i}/README.md\" content \"hi\"\n"
+        "  let x = i + 1\n"
+        "  repeat n as j\n"
+        "    mkdir \"inner_{j}\"\n"
+        "  end\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -364,3 +364,145 @@ TEST(NormalizeTest, IntComparisonDiffersFromBoolComparison) {
     auto b = bin(TokenType::EQUALS, id("x"), bool_lit(true));
     EXPECT_FALSE(equivalent(*a, *b, tm));
 }
+
+// --- Conditional alias scoping tests ---
+
+TEST(ValidatorTest, AliasBoundWhenXReferencedWhenXValid) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir bar/sub when x\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, AliasBoundWhenXReferencedWhenXEqualsTrueValid) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir bar/sub when x == true\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, AliasBoundWhenXEqualsTrueReferencedWhenXValid) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x == true as bar\n"
+        "mkdir bar/sub when x\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, AliasBoundWhenXReferencedWhenXEqualsFalseIsError) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir bar/sub when x == false\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AliasBoundWhenXReferencedWhenNotXIsError) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir bar/sub when not x\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AliasBoundWhenAAndBReferencedWhenBAndAIsError) {
+    // Commutativity is a known limitation of normalization.
+    auto program = parse(
+        "ask a \"a?\" bool\n"
+        "ask b \"b?\" bool\n"
+        "mkdir foo when a and b as bar\n"
+        "mkdir bar/sub when b and a\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AliasBoundWhenXReferencedWithNoWhenIsError) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir bar/sub\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, UnconditionalAliasReferencedWhenXValid) {
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo as bar\n"
+        "mkdir bar/sub when x\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, UnconditionalAliasReferencedUnconditionallyValid) {
+    auto program = parse(
+        "mkdir foo as bar\n"
+        "mkdir bar/sub\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, ConditionalAliasReferenceInFilePath) {
+    // Exercises the file.path reference site.
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "file bar/readme content \"hi\" when x\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, ConditionalAliasReferenceInCopySource) {
+    // Exercises the copy.source reference site.
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir dest\n"
+        "copy bar into dest when x\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, ConditionalAliasReferenceInCopyDestinationMismatch) {
+    // Exercises copy.destination + mismatched condition.
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir src\n"
+        "copy src into bar when not x\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, ConditionalAliasReferenceInMkdirFromSource) {
+    // Exercises mkdir.from_source reference site.
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "mkdir foo when x as bar\n"
+        "mkdir new from bar when x\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, RepeatWhenNotFoldedIntoAliasCondition) {
+    // The enclosing repeat's when clause is NOT silently combined with the
+    // inner statement's condition. An inner statement without its own when
+    // still mismatches a conditional alias, even if the repeat's own when
+    // matches the alias's binding condition.
+    auto program = parse(
+        "ask x \"x?\" bool\n"
+        "ask n \"n?\" int\n"
+        "mkdir foo when x as bar\n"
+        "repeat n as i when x\n"
+        "  mkdir bar/dup_{i}\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, ComposedRulesEndToEnd) {
+    // Exercises Part A (repeat when), Part B (no ask-in-repeat — valid case),
+    // Part C (nested let scoping), and Part E (bool-equivalent alias when).
+    auto program = parse(
+        "ask use_ci \"use ci?\" bool\n"
+        "ask n \"n?\" int\n"
+        "mkdir ci_dir when use_ci as ci_path\n"
+        "repeat n as i when use_ci\n"
+        "  let j = i + 1\n"
+        "end\n"
+        "mkdir ci_path/out when use_ci == true\n");
+    EXPECT_NO_THROW(validate(program));
+}


### PR DESCRIPTION
## Summary

Adds the first semantic validation pass, plus an optional `when` clause on `repeat`. `validate()` runs after parsing and throws `SemanticError` on rule violations.

## Changes

- `repeat` accepts `when <cond>` between the iterator name and the newline.
- New validator module: `SemanticError` class and a single `validate(Program&)` entry point.
- Rules enforced:
  - `ask` inside `repeat` is rejected.
  - Names declared inside a repeat body go out of scope when it ends; later references are rejected. Inner names that shadow a visible outer name are rejected.
  - Path aliases bound under `when` can only be referenced under an equivalent condition. Bool identifiers normalize: `x` ≡ `x == true` ≡ `not not x`; `not x` ≡ `x == false` ≡ `x != true`. Commutativity of `and` and `or` is not applied (documented limitation).
  - A repeat's own `when` is not folded into conditions on inner statements.

## Test plan

- `cmake --build build && ctest --test-dir build --output-on-failure`
- 208 of 208 pass, including 48 new tests covering every rule above and every path-expression reference site.