### PR TITLE
feat(parser): parse include statements

### DIFF
--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -258,9 +258,24 @@ struct CopyStmt {
     int column;
 };
 
+/**
+ * @brief An `include` statement — runs another installed template as a subprocess.
+ *
+ * Example: `include claude_setup when use_claude`
+ *
+ * The named template is referenced by its installed name and runs in its own
+ * scope at runtime. The optional `when` clause skips the include if false.
+ */
+struct IncludeStmt {
+    std::string name;                    ///< Name of the installed template to run.
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the include.
+    int line;
+    int column;
+};
+
 /** @brief Discriminated union of all statement node types. */
-using StmtData =
-    std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt, CopyStmt>;
+using StmtData = std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt,
+                              CopyStmt, IncludeStmt>;
 
 /** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -63,6 +63,8 @@ class Parser {
     StmtPtr parseRepeat();
     /** @brief Parses a `copy` statement. */
     StmtPtr parseCopy();
+    /** @brief Parses an `include` statement. */
+    StmtPtr parseInclude();
     /** @brief Dispatches to the appropriate statement parser based on the current token.
      */
     StmtPtr parseStatement();

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -25,6 +25,7 @@ enum class TokenType {
     OPTIONS,   ///< `options` — restrict an ask to a bounded list of literals
     COPY,      ///< `copy` — copy a source directory into an existing destination
     INTO,      ///< `into` — destination marker used by `copy`
+    INCLUDE,   ///< `include` — run another installed template as a subprocess
 
     // Logical operators (keywords)
     AND,  ///< `and` — logical AND
@@ -123,6 +124,8 @@ inline std::string tokenTypeToString(TokenType type) {
             return "COPY";
         case TokenType::INTO:
             return "INTO";
+        case TokenType::INCLUDE:
+            return "INCLUDE";
         case TokenType::AND:
             return "AND";
         case TokenType::OR:

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -14,6 +14,7 @@ static const std::unordered_map<std::string, TokenType> keywords = {
     {"mode", TokenType::MODE},         {"as", TokenType::AS},
     {"default", TokenType::DEFAULT},   {"options", TokenType::OPTIONS},
     {"copy", TokenType::COPY},         {"into", TokenType::INTO},
+    {"include", TokenType::INCLUDE},
     {"and", TokenType::AND},           {"or", TokenType::OR},
     {"not", TokenType::NOT},           {"string", TokenType::STRING_TYPE},
     {"bool", TokenType::BOOL_TYPE},    {"int", TokenType::INT_TYPE},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -375,6 +375,23 @@ StmtPtr Parser::parseCopy() {
     return stmt;
 }
 
+// Include statement parser
+
+StmtPtr Parser::parseInclude() {
+    Token start = expect(TokenType::INCLUDE, "expected 'include'");
+    Token name =
+        expect(TokenType::IDENTIFIER, "expected template name after 'include'");
+    auto when_clause = parse_when_clause();
+    expect_newline("include statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    stmt->data = IncludeStmt{.name = name.value,
+                             .when_clause = std::move(when_clause),
+                             .line = start.line,
+                             .column = start.column};
+    return stmt;
+}
+
 // Repeat block parser
 
 StmtPtr Parser::parseRepeat() {
@@ -427,6 +444,9 @@ StmtPtr Parser::parseStatement() {
     }
     if (check(TokenType::COPY)) {
         return parseCopy();
+    }
+    if (check(TokenType::INCLUDE)) {
+        return parseInclude();
     }
     throw ParseError("unexpected token: " + current_.value, current_.line,
                      current_.column);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -275,6 +275,8 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
                 walk_path(s.source, scope, ctx, s.when_clause);
                 walk_path(s.destination, scope, ctx, s.when_clause);
                 walk_optional_expr(s.when_clause, scope);
+            } else if constexpr (std::is_same_v<T, IncludeStmt>) {
+                walk_optional_expr(s.when_clause, scope);
             } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                 check_reference(s.collection_var, s.line, s.column, scope);
                 walk_optional_expr(s.when_clause, scope);

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -15,6 +15,7 @@ using spudplate::CopyStmt;
 using spudplate::FileStmt;
 using spudplate::FunctionCallExpr;
 using spudplate::IdentifierExpr;
+using spudplate::IncludeStmt;
 using spudplate::IntegerLiteralExpr;
 using spudplate::LetStmt;
 using spudplate::Lexer;
@@ -976,6 +977,63 @@ TEST(ParserTest, RepeatWithoutEnd) {
     EXPECT_THROW(parse_program("repeat items as item\n"
                                "  mkdir \"dir\"\n"),
                  ParseError);
+}
+
+// --- Include statement tests ---
+
+static StmtPtr parse_include(const std::string& input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseInclude();
+}
+
+TEST(ParserTest, IncludeBasic) {
+    auto stmt = parse_include("include claude_setup\n");
+    auto& inc = std::get<IncludeStmt>(stmt->data);
+    EXPECT_EQ(inc.name, "claude_setup");
+    EXPECT_FALSE(inc.when_clause.has_value());
+    EXPECT_EQ(inc.line, 1);
+    EXPECT_EQ(inc.column, 1);
+}
+
+TEST(ParserTest, IncludeWithWhenIdentifier) {
+    auto stmt = parse_include("include claude_setup when use_claude\n");
+    auto& inc = std::get<IncludeStmt>(stmt->data);
+    EXPECT_EQ(inc.name, "claude_setup");
+    ASSERT_TRUE(inc.when_clause.has_value());
+    auto& cond = std::get<IdentifierExpr>((*inc.when_clause)->data);
+    EXPECT_EQ(cond.name, "use_claude");
+}
+
+TEST(ParserTest, IncludeWithWhenComparison) {
+    auto stmt = parse_include("include base when format == \"latex\"\n");
+    auto& inc = std::get<IncludeStmt>(stmt->data);
+    EXPECT_EQ(inc.name, "base");
+    ASSERT_TRUE(inc.when_clause.has_value());
+    auto& cond = std::get<BinaryExpr>((*inc.when_clause)->data);
+    EXPECT_EQ(cond.op, TokenType::EQUALS);
+}
+
+TEST(ParserTest, IncludeMissingName) {
+    EXPECT_THROW(parse_include("include\n"), ParseError);
+}
+
+TEST(ParserTest, IncludeStringLiteralAsNameRejected) {
+    EXPECT_THROW(parse_include("include \"claude_setup\"\n"), ParseError);
+}
+
+TEST(ParserTest, IncludeBareWhenRaisesError) {
+    EXPECT_THROW(parse_include("include claude_setup when\n"), ParseError);
+}
+
+TEST(ParserTest, IncludeAtTopLevelInProgram) {
+    auto program = parse_program(
+        "ask use_claude \"Use Claude?\" bool\n"
+        "include claude_setup when use_claude\n");
+    ASSERT_EQ(program.statements.size(), 2u);
+    auto& inc = std::get<IncludeStmt>(program.statements[1]->data);
+    EXPECT_EQ(inc.name, "claude_setup");
+    EXPECT_TRUE(inc.when_clause.has_value());
 }
 
 TEST(ParserTest, UnexpectedTokenAtTopLevel) {


### PR DESCRIPTION
## Summary
Parse the include statement so a template can run another installed template by name. At runtime the named template runs as an independent subprocess with its own questions and no shared scope; the optional when clause skips it if false.

## Changes
- New INCLUDE token and lexer keyword
- IncludeStmt AST node with name and optional when clause
- parseInclude in the parser, dispatched from parseStatement
- Validator walks the include's when clause for scope checks

## Test plan
- All 215 (7 new) tests pass locally
- New tests cover bare include, include with a bool when, include with a string comparison when, missing name, string literal in place of identifier, bare when, and an include used at program level