### PR TITLE
feat(interpreter): foundation skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Library
-add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp)
+add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
+                          src/interpreter.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 
 # Executable
@@ -25,7 +26,7 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
-               tests/validator_test.cpp)
+               tests/validator_test.cpp tests/interpreter_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -1,0 +1,119 @@
+#ifndef SPUDPLATE_INTERPRETER_H
+#define SPUDPLATE_INTERPRETER_H
+
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+#include "spudplate/ast.h"
+
+namespace spudplate {
+
+/**
+ * @brief Exception thrown when the interpreter encounters a runtime failure.
+ *
+ * Mirrors ParseError and SemanticError in shape: carries the source line and
+ * column of the offending node alongside a bare message string.
+ */
+class RuntimeError : public std::runtime_error {
+  public:
+    RuntimeError(const std::string& message, int line, int column)
+        : std::runtime_error(message), line_(line), column_(column) {}
+
+    /** @brief 1-based line number of the offending statement or expression. */
+    [[nodiscard]] int line() const { return line_; }
+    /** @brief 1-based column number of the offending statement or expression. */
+    [[nodiscard]] int column() const { return column_; }
+
+  private:
+    int line_;
+    int column_;
+};
+
+/**
+ * @brief A runtime value carried in the interpreter's environment.
+ *
+ * Matches the three spudlang types: string, int, bool. The integer alternative
+ * is `int64_t` to give arithmetic enough headroom; literals from
+ * `IntegerLiteralExpr` are cast on entry.
+ */
+using Value = std::variant<std::string, std::int64_t, bool>;
+
+/**
+ * @brief Variable storage for a running interpreter.
+ *
+ * Frame stack mirroring the validator's `Scope` shape (see
+ * `src/validator.cpp`). frames[0] is the program-level scope. Each `repeat`
+ * body pushes a new frame on entry and pops it on exit.
+ *
+ * Exposed in the public header solely so tests can observe the final
+ * environment after a run; production code should not depend on this type.
+ */
+class Environment {
+  public:
+    Environment() { push(); }
+
+    void push() { frames_.emplace_back(); }
+    void pop() { frames_.pop_back(); }
+
+    /**
+     * @brief Bind `name` to `value` in the innermost frame.
+     *
+     * Throws `std::logic_error` if `name` is already visible in any frame —
+     * the language never silently shadows.
+     */
+    void declare(const std::string& name, Value value);
+
+    /** @brief Find `name` in any frame, innermost first. */
+    [[nodiscard]] std::optional<Value> lookup(const std::string& name) const;
+
+  private:
+    std::vector<std::unordered_map<std::string, Value>> frames_;
+};
+
+/**
+ * @brief Abstract source of user input for `ask` statements.
+ *
+ * Concrete subclasses (`StdinPrompter` for production, `ScriptedPrompter` for
+ * tests) are added when `ask` execution lands. The base interface is exposed
+ * now so callers can pass any subclass to `run`.
+ */
+class Prompter {
+  public:
+    virtual ~Prompter() = default;
+
+    /**
+     * @brief Display `message` and obtain the user's raw answer string.
+     *
+     * The interpreter parses the returned string into a `Value` according to
+     * the question's `type`. Implementations may re-prompt internally if the
+     * caller signals invalid input by ignoring the return value, but normally
+     * the loop lives in the interpreter, not here.
+     */
+    virtual std::string prompt(const std::string& message, VarType type) = 0;
+};
+
+/**
+ * @brief Run a validated program.
+ *
+ * Walks `program.statements` top-to-bottom, prompting through `prompter` for
+ * `ask` statements and queueing filesystem operations to be flushed at the
+ * end of the run. Throws `RuntimeError` on the first failure.
+ */
+void run(const Program& program, Prompter& prompter);
+
+/**
+ * @brief Test-only entry point: like `run`, but returns the final environment.
+ *
+ * Production callers should use `run`; this is exposed so tests can assert
+ * on bindings without relying on filesystem side effects.
+ */
+Environment run_for_tests(const Program& program, Prompter& prompter);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_INTERPRETER_H

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1,0 +1,93 @@
+#include "spudplate/interpreter.h"
+
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "spudplate/ast.h"
+
+namespace spudplate {
+
+void Environment::declare(const std::string& name, Value value) {
+    if (lookup(name).has_value()) {
+        throw std::logic_error("environment already has a binding for '" + name +
+                               "'");
+    }
+    frames_.back().emplace(name, std::move(value));
+}
+
+std::optional<Value> Environment::lookup(const std::string& name) const {
+    for (auto it = frames_.rbegin(); it != frames_.rend(); ++it) {
+        auto found = it->find(name);
+        if (found != it->end()) {
+            return found->second;
+        }
+    }
+    return std::nullopt;
+}
+
+namespace {
+
+// Until Part 4 lands, the Prompter forward-declared in the header has no
+// concrete implementation. The skeleton interpreter never reaches a code
+// path that calls it (every statement throws "not yet supported" first).
+void unsupported(const std::string& stmt_name, int line, int column) {
+    throw RuntimeError("statement '" + stmt_name +
+                           "' not yet supported in this build",
+                       line, column);
+}
+
+class Interpreter {
+  public:
+    void execute(const Stmt& stmt) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, AskStmt>) {
+                    unsupported("ask", s.line, s.column);
+                } else if constexpr (std::is_same_v<T, LetStmt>) {
+                    unsupported("let", s.line, s.column);
+                } else if constexpr (std::is_same_v<T, MkdirStmt>) {
+                    unsupported("mkdir", s.line, s.column);
+                } else if constexpr (std::is_same_v<T, FileStmt>) {
+                    unsupported("file", s.line, s.column);
+                } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                    unsupported("repeat", s.line, s.column);
+                } else if constexpr (std::is_same_v<T, CopyStmt>) {
+                    unsupported("copy", s.line, s.column);
+                } else if constexpr (std::is_same_v<T, IncludeStmt>) {
+                    unsupported("include", s.line, s.column);
+                }
+            },
+            stmt.data);
+    }
+
+    [[nodiscard]] Environment& env() { return env_; }
+
+  private:
+    Environment env_;
+};
+
+void run_program(const Program& program, Prompter& /*prompter*/,
+                 Interpreter& interp) {
+    for (const auto& stmt : program.statements) {
+        interp.execute(*stmt);
+    }
+}
+
+}  // namespace
+
+void run(const Program& program, Prompter& prompter) {
+    Interpreter interp;
+    run_program(program, prompter, interp);
+}
+
+Environment run_for_tests(const Program& program, Prompter& prompter) {
+    Interpreter interp;
+    run_program(program, prompter, interp);
+    return std::move(interp.env());
+}
+
+}  // namespace spudplate

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1,0 +1,210 @@
+#include "spudplate/interpreter.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "spudplate/ast.h"
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+
+using spudplate::Environment;
+using spudplate::Lexer;
+using spudplate::Parser;
+using spudplate::Program;
+using spudplate::Prompter;
+using spudplate::run;
+using spudplate::run_for_tests;
+using spudplate::RuntimeError;
+using spudplate::Value;
+using spudplate::VarType;
+
+namespace {
+
+// Test stub — never asked, never answered. Used in Part 1 where every
+// statement throws "not yet supported" before the prompter is reached.
+class NullPrompter : public Prompter {
+  public:
+    std::string prompt(const std::string& /*message*/,
+                       VarType /*type*/) override {
+        throw std::logic_error("NullPrompter should not be called");
+    }
+};
+
+Program parse(const std::string& source) {
+    Lexer lexer(source);
+    Parser parser(std::move(lexer));
+    return parser.parse();
+}
+
+}  // namespace
+
+// --- RuntimeError shape ---
+
+TEST(RuntimeErrorTest, RoundTripsMessageAndPosition) {
+    RuntimeError e("boom", 3, 7);
+    EXPECT_STREQ(e.what(), "boom");
+    EXPECT_EQ(e.line(), 3);
+    EXPECT_EQ(e.column(), 7);
+}
+
+// --- Environment primitives ---
+
+TEST(EnvironmentTest, DeclareAndLookupString) {
+    Environment env;
+    env.declare("name", Value{std::string{"hello"}});
+    auto v = env.lookup("name");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(std::get<std::string>(*v), "hello");
+}
+
+TEST(EnvironmentTest, DeclareAndLookupInt) {
+    Environment env;
+    env.declare("n", Value{std::int64_t{42}});
+    auto v = env.lookup("n");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(std::get<std::int64_t>(*v), 42);
+}
+
+TEST(EnvironmentTest, DeclareAndLookupBool) {
+    Environment env;
+    env.declare("flag", Value{true});
+    auto v = env.lookup("flag");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(std::get<bool>(*v), true);
+}
+
+TEST(EnvironmentTest, LookupReturnsNulloptForUnknown) {
+    Environment env;
+    EXPECT_FALSE(env.lookup("missing").has_value());
+}
+
+TEST(EnvironmentTest, DeclareRejectsShadow) {
+    Environment env;
+    env.declare("x", Value{std::int64_t{1}});
+    EXPECT_THROW(env.declare("x", Value{std::int64_t{2}}), std::logic_error);
+}
+
+TEST(EnvironmentTest, NestedFrameSeesOuterBinding) {
+    Environment env;
+    env.declare("outer", Value{std::int64_t{1}});
+    env.push();
+    auto v = env.lookup("outer");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(std::get<std::int64_t>(*v), 1);
+}
+
+TEST(EnvironmentTest, PoppedFrameLosesItsBindings) {
+    Environment env;
+    env.push();
+    env.declare("inner", Value{std::int64_t{1}});
+    env.pop();
+    EXPECT_FALSE(env.lookup("inner").has_value());
+}
+
+// --- run() on empty program ---
+
+TEST(InterpreterTest, EmptyProgramRunsCleanly) {
+    Program empty;
+    NullPrompter prompter;
+    EXPECT_NO_THROW(run(empty, prompter));
+}
+
+// --- Every statement type throws "not yet supported" ---
+
+TEST(InterpreterTest, AskThrowsNotYetSupported) {
+    auto program = parse(R"(ask name "Project name?" string
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("ask"), std::string::npos);
+    }
+}
+
+TEST(InterpreterTest, LetThrowsNotYetSupported) {
+    auto program = parse(R"(let x = 1
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("let"), std::string::npos);
+    }
+}
+
+TEST(InterpreterTest, MkdirThrowsNotYetSupported) {
+    auto program = parse(R"(mkdir foo
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("mkdir"), std::string::npos);
+    }
+}
+
+TEST(InterpreterTest, FileThrowsNotYetSupported) {
+    auto program = parse(R"(file foo.txt content "hi"
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("file"), std::string::npos);
+    }
+}
+
+TEST(InterpreterTest, RepeatThrowsNotYetSupported) {
+    auto program = parse(R"(repeat n as i
+end
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("repeat"), std::string::npos);
+    }
+}
+
+TEST(InterpreterTest, CopyThrowsNotYetSupported) {
+    auto program = parse(R"(copy src into dst
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("copy"), std::string::npos);
+    }
+}
+
+TEST(InterpreterTest, IncludeThrowsNotYetSupported) {
+    auto program = parse(R"(include claude_setup
+)");
+    NullPrompter prompter;
+    try {
+        run(program, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("include"), std::string::npos);
+    }
+}
+
+// --- run_for_tests returns the interpreter's environment ---
+
+TEST(InterpreterTest, RunForTestsReturnsEnvironmentOnEmptyProgram) {
+    Program empty;
+    NullPrompter prompter;
+    Environment env = run_for_tests(empty, prompter);
+    EXPECT_FALSE(env.lookup("anything").has_value());
+}


### PR DESCRIPTION
## Summary
Lays the interpreter shell. No statement actually runs yet, every visited statement throws a clear "not yet supported" runtime error. Subsequent PRs replace each arm with a real implementation.

## Changes
- New header `include/spudplate/interpreter.h` exposing the runtime value type, environment, runtime exception, prompter interface, and the `run` entry point
- New translation unit `src/interpreter.cpp` with the dispatching shell
- CMakeLists wiring for the new library source and test file
- Test-only `run_for_tests` helper that returns the final environment so later parts can assert on bindings without filesystem effects

## Test plan
- All 232 (13 new) tests pass locally
- New tests cover the runtime error shape, environment declare and lookup across scope frames, the shadow rejection rule, and confirm every statement variant hits its dispatch arm