### PR TITLE
feat(interpreter): evaluate expressions

### DIFF
--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -114,6 +114,25 @@ void run(const Program& program, Prompter& prompter);
  */
 Environment run_for_tests(const Program& program, Prompter& prompter);
 
+/**
+ * @brief Evaluate an expression against an environment.
+ *
+ * Throws `RuntimeError` on type mismatch, unknown identifier, division by
+ * zero, integer overflow on division, or unknown function name. Arithmetic
+ * `+`, `-`, `*` use signed two's-complement wrap-around. Logical `and`/`or`
+ * short-circuit. Equality `==`/`!=` returns `false`/`true` for operands of
+ * differing variant alternatives.
+ */
+Value evaluate_expr(const Expr& expr, const Environment& env);
+
+/**
+ * @brief Render a `Value` for use in path interpolation or file content.
+ *
+ * Strings pass through; ints become decimal with no padding; bools become
+ * `"true"` or `"false"`.
+ */
+std::string value_to_string(const Value& value);
+
 }  // namespace spudplate
 
 #endif  // SPUDPLATE_INTERPRETER_H

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1,5 +1,10 @@
 #include "spudplate/interpreter.h"
 
+#include <algorithm>
+#include <cctype>
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -7,6 +12,7 @@
 #include <variant>
 
 #include "spudplate/ast.h"
+#include "spudplate/token.h"
 
 namespace spudplate {
 
@@ -37,6 +43,180 @@ void unsupported(const std::string& stmt_name, int line, int column) {
     throw RuntimeError("statement '" + stmt_name +
                            "' not yet supported in this build",
                        line, column);
+}
+
+// Names a Value's variant alternative for error messages.
+const char* type_name(const Value& v) {
+    if (std::holds_alternative<std::string>(v)) {
+        return "string";
+    }
+    if (std::holds_alternative<std::int64_t>(v)) {
+        return "int";
+    }
+    return "bool";
+}
+
+[[noreturn]] void type_error(const std::string& msg, int line, int column) {
+    throw RuntimeError(msg, line, column);
+}
+
+// Wrap-around helpers — signed overflow is UB in C++, so route arithmetic
+// through unsigned and cast the bit pattern back.
+std::int64_t wrap_add(std::int64_t a, std::int64_t b) {
+    return static_cast<std::int64_t>(static_cast<std::uint64_t>(a) +
+                                     static_cast<std::uint64_t>(b));
+}
+std::int64_t wrap_sub(std::int64_t a, std::int64_t b) {
+    return static_cast<std::int64_t>(static_cast<std::uint64_t>(a) -
+                                     static_cast<std::uint64_t>(b));
+}
+std::int64_t wrap_mul(std::int64_t a, std::int64_t b) {
+    return static_cast<std::int64_t>(static_cast<std::uint64_t>(a) *
+                                     static_cast<std::uint64_t>(b));
+}
+
+Value eval_unary(const UnaryExpr& un, const Environment& env) {
+    Value operand = evaluate_expr(*un.operand, env);
+    if (un.op != TokenType::NOT) {
+        type_error("unsupported unary operator", un.line, un.column);
+    }
+    if (!std::holds_alternative<bool>(operand)) {
+        type_error(std::string{"'not' requires bool, got "} + type_name(operand),
+                   un.line, un.column);
+    }
+    return Value{!std::get<bool>(operand)};
+}
+
+bool int_compare(TokenType op, std::int64_t a, std::int64_t b) {
+    switch (op) {
+        case TokenType::GREATER:
+            return a > b;
+        case TokenType::LESS:
+            return a < b;
+        case TokenType::GREATER_EQUAL:
+            return a >= b;
+        case TokenType::LESS_EQUAL:
+            return a <= b;
+        default:
+            return false;  // unreachable — caller restricts the op set
+    }
+}
+
+Value eval_binary(const BinaryExpr& bin, const Environment& env) {
+    // Short-circuit logical ops handled before evaluating the right side.
+    if (bin.op == TokenType::AND || bin.op == TokenType::OR) {
+        Value left = evaluate_expr(*bin.left, env);
+        if (!std::holds_alternative<bool>(left)) {
+            type_error(std::string{"logical operator requires bool, got "} +
+                           type_name(left),
+                       bin.line, bin.column);
+        }
+        bool lv = std::get<bool>(left);
+        if (bin.op == TokenType::AND && !lv) {
+            return Value{false};
+        }
+        if (bin.op == TokenType::OR && lv) {
+            return Value{true};
+        }
+        Value right = evaluate_expr(*bin.right, env);
+        if (!std::holds_alternative<bool>(right)) {
+            type_error(std::string{"logical operator requires bool, got "} +
+                           type_name(right),
+                       bin.line, bin.column);
+        }
+        return Value{std::get<bool>(right)};
+    }
+
+    Value left = evaluate_expr(*bin.left, env);
+    Value right = evaluate_expr(*bin.right, env);
+
+    // Equality and inequality accept any operand types per docs/syntax.md.
+    if (bin.op == TokenType::EQUALS || bin.op == TokenType::NOT_EQUALS) {
+        bool eq = (left.index() == right.index()) && (left == right);
+        return Value{bin.op == TokenType::EQUALS ? eq : !eq};
+    }
+
+    // Ordering comparisons require ints.
+    if (bin.op == TokenType::GREATER || bin.op == TokenType::LESS ||
+        bin.op == TokenType::GREATER_EQUAL || bin.op == TokenType::LESS_EQUAL) {
+        if (!std::holds_alternative<std::int64_t>(left) ||
+            !std::holds_alternative<std::int64_t>(right)) {
+            type_error("ordering comparison requires int operands", bin.line,
+                       bin.column);
+        }
+        return Value{int_compare(bin.op, std::get<std::int64_t>(left),
+                                 std::get<std::int64_t>(right))};
+    }
+
+    // Arithmetic — `+` accepts both int+int and string+string; the others
+    // are int-only.
+    if (bin.op == TokenType::PLUS && std::holds_alternative<std::string>(left) &&
+        std::holds_alternative<std::string>(right)) {
+        return Value{std::get<std::string>(left) + std::get<std::string>(right)};
+    }
+    if (!std::holds_alternative<std::int64_t>(left) ||
+        !std::holds_alternative<std::int64_t>(right)) {
+        type_error("arithmetic requires matching int (or string for '+') operands",
+                   bin.line, bin.column);
+    }
+    auto a = std::get<std::int64_t>(left);
+    auto b = std::get<std::int64_t>(right);
+    switch (bin.op) {
+        case TokenType::PLUS:
+            return Value{wrap_add(a, b)};
+        case TokenType::MINUS:
+            return Value{wrap_sub(a, b)};
+        case TokenType::STAR:
+            return Value{wrap_mul(a, b)};
+        case TokenType::SLASH:
+            if (b == 0) {
+                type_error("division by zero", bin.line, bin.column);
+            }
+            if (a == INT64_MIN && b == -1) {
+                type_error("integer overflow in division", bin.line, bin.column);
+            }
+            return Value{a / b};
+        default:
+            type_error("unsupported binary operator", bin.line, bin.column);
+    }
+}
+
+Value eval_call(const FunctionCallExpr& fc, const Environment& env) {
+    Value arg = evaluate_expr(*fc.argument, env);
+    if (!std::holds_alternative<std::string>(arg)) {
+        type_error(std::string{"function '"} + fc.name +
+                       "' requires string argument, got " + type_name(arg),
+                   fc.line, fc.column);
+    }
+    const std::string& s = std::get<std::string>(arg);
+    if (fc.name == "lower") {
+        std::string out;
+        out.reserve(s.size());
+        for (char c : s) {
+            out.push_back(static_cast<char>(
+                std::tolower(static_cast<unsigned char>(c))));
+        }
+        return Value{out};
+    }
+    if (fc.name == "upper") {
+        std::string out;
+        out.reserve(s.size());
+        for (char c : s) {
+            out.push_back(static_cast<char>(
+                std::toupper(static_cast<unsigned char>(c))));
+        }
+        return Value{out};
+    }
+    if (fc.name == "trim") {
+        auto start = std::find_if_not(s.begin(), s.end(), [](unsigned char c) {
+            return std::isspace(c) != 0;
+        });
+        auto end = std::find_if_not(s.rbegin(), s.rend(), [](unsigned char c) {
+                       return std::isspace(c) != 0;
+                   }).base();
+        return Value{(start < end) ? std::string{start, end} : std::string{}};
+    }
+    type_error("unknown function '" + fc.name + "'", fc.line, fc.column);
 }
 
 class Interpreter {
@@ -78,6 +258,49 @@ void run_program(const Program& program, Prompter& /*prompter*/,
 }
 
 }  // namespace
+
+Value evaluate_expr(const Expr& expr, const Environment& env) {
+    return std::visit(
+        [&](const auto& e) -> Value {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                return Value{e.value};
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                return Value{static_cast<std::int64_t>(e.value)};
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                return Value{e.value};
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                auto v = env.lookup(e.name);
+                if (!v.has_value()) {
+                    throw RuntimeError("undefined variable '" + e.name + "'",
+                                       e.line, e.column);
+                }
+                return *v;
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                return eval_unary(e, env);
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                return eval_binary(e, env);
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                return eval_call(e, env);
+            }
+        },
+        expr.data);
+}
+
+std::string value_to_string(const Value& value) {
+    return std::visit(
+        [](const auto& v) -> std::string {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, std::string>) {
+                return v;
+            } else if constexpr (std::is_same_v<T, std::int64_t>) {
+                return std::to_string(v);
+            } else {
+                return v ? "true" : "false";
+            }
+        },
+        value);
+}
 
 void run(const Program& program, Prompter& prompter) {
     Interpreter interp;

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -2,7 +2,9 @@
 
 #include <gtest/gtest.h>
 
+#include <climits>
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -10,8 +12,18 @@
 #include "spudplate/ast.h"
 #include "spudplate/lexer.h"
 #include "spudplate/parser.h"
+#include "spudplate/token.h"
 
+using spudplate::BinaryExpr;
+using spudplate::BoolLiteralExpr;
 using spudplate::Environment;
+using spudplate::evaluate_expr;
+using spudplate::Expr;
+using spudplate::ExprData;
+using spudplate::ExprPtr;
+using spudplate::FunctionCallExpr;
+using spudplate::IdentifierExpr;
+using spudplate::IntegerLiteralExpr;
 using spudplate::Lexer;
 using spudplate::Parser;
 using spudplate::Program;
@@ -19,7 +31,11 @@ using spudplate::Prompter;
 using spudplate::run;
 using spudplate::run_for_tests;
 using spudplate::RuntimeError;
+using spudplate::StringLiteralExpr;
+using spudplate::TokenType;
+using spudplate::UnaryExpr;
 using spudplate::Value;
+using spudplate::value_to_string;
 using spudplate::VarType;
 
 namespace {
@@ -38,6 +54,44 @@ Program parse(const std::string& source) {
     Lexer lexer(source);
     Parser parser(std::move(lexer));
     return parser.parse();
+}
+
+// AST builder helpers for expression-level tests.
+ExprPtr wrap(ExprData data) {
+    auto e = std::make_unique<Expr>();
+    e->data = std::move(data);
+    return e;
+}
+ExprPtr str_lit(const std::string& v) {
+    return wrap(StringLiteralExpr{.value = v, .line = 1, .column = 1});
+}
+ExprPtr int_lit(int v) {
+    return wrap(IntegerLiteralExpr{.value = v, .line = 1, .column = 1});
+}
+ExprPtr bool_lit(bool v) {
+    return wrap(BoolLiteralExpr{.value = v, .line = 1, .column = 1});
+}
+ExprPtr ident(const std::string& name) {
+    return wrap(IdentifierExpr{.name = name, .line = 1, .column = 1});
+}
+ExprPtr unary_not(ExprPtr operand) {
+    return wrap(UnaryExpr{.op = TokenType::NOT,
+                          .operand = std::move(operand),
+                          .line = 1,
+                          .column = 1});
+}
+ExprPtr binop(TokenType op, ExprPtr left, ExprPtr right) {
+    return wrap(BinaryExpr{.op = op,
+                           .left = std::move(left),
+                           .right = std::move(right),
+                           .line = 1,
+                           .column = 1});
+}
+ExprPtr fn(const std::string& name, ExprPtr arg) {
+    return wrap(FunctionCallExpr{.name = name,
+                                 .argument = std::move(arg),
+                                 .line = 1,
+                                 .column = 1});
 }
 
 }  // namespace
@@ -207,4 +261,223 @@ TEST(InterpreterTest, RunForTestsReturnsEnvironmentOnEmptyProgram) {
     NullPrompter prompter;
     Environment env = run_for_tests(empty, prompter);
     EXPECT_FALSE(env.lookup("anything").has_value());
+}
+
+// --- Expression evaluator: literals ---
+
+TEST(EvalExprTest, StringLiteral) {
+    Environment env;
+    auto e = str_lit("hi");
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "hi");
+}
+
+TEST(EvalExprTest, IntegerLiteralCastsToInt64) {
+    Environment env;
+    auto e = int_lit(42);
+    EXPECT_EQ(std::get<std::int64_t>(evaluate_expr(*e, env)), 42);
+}
+
+TEST(EvalExprTest, BoolLiteral) {
+    Environment env;
+    auto e = bool_lit(true);
+    EXPECT_TRUE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+// --- Identifier resolution ---
+
+TEST(EvalExprTest, IdentifierLooksUpEnv) {
+    Environment env;
+    env.declare("x", Value{std::int64_t{7}});
+    auto e = ident("x");
+    EXPECT_EQ(std::get<std::int64_t>(evaluate_expr(*e, env)), 7);
+}
+
+TEST(EvalExprTest, IdentifierMissingThrows) {
+    Environment env;
+    auto e = wrap(IdentifierExpr{.name = "missing", .line = 4, .column = 9});
+    try {
+        evaluate_expr(*e, env);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& ex) {
+        EXPECT_EQ(ex.line(), 4);
+        EXPECT_EQ(ex.column(), 9);
+    }
+}
+
+// --- Unary NOT ---
+
+TEST(EvalExprTest, NotTrueIsFalse) {
+    Environment env;
+    auto e = unary_not(bool_lit(true));
+    EXPECT_FALSE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, NotNotTrueIsTrue) {
+    Environment env;
+    auto e = unary_not(unary_not(bool_lit(true)));
+    EXPECT_TRUE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, NotIntThrows) {
+    Environment env;
+    auto e = unary_not(int_lit(1));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+// --- Arithmetic ---
+
+TEST(EvalExprTest, Addition) {
+    Environment env;
+    auto e = binop(TokenType::PLUS, int_lit(2), int_lit(3));
+    EXPECT_EQ(std::get<std::int64_t>(evaluate_expr(*e, env)), 5);
+}
+
+TEST(EvalExprTest, IntegerDivisionTruncates) {
+    Environment env;
+    auto e = binop(TokenType::SLASH, int_lit(10), int_lit(3));
+    EXPECT_EQ(std::get<std::int64_t>(evaluate_expr(*e, env)), 3);
+}
+
+TEST(EvalExprTest, DivisionByZeroThrows) {
+    Environment env;
+    auto e = binop(TokenType::SLASH, int_lit(10), int_lit(0));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+TEST(EvalExprTest, IntMinDivByMinusOneThrows) {
+    Environment env;
+    env.declare("a", Value{std::int64_t{INT64_MIN}});
+    env.declare("b", Value{std::int64_t{-1}});
+    auto e = binop(TokenType::SLASH, ident("a"), ident("b"));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+TEST(EvalExprTest, AdditionOverflowWrapsAround) {
+    Environment env;
+    env.declare("a", Value{std::int64_t{INT64_MAX}});
+    auto e = binop(TokenType::PLUS, ident("a"), int_lit(1));
+    EXPECT_EQ(std::get<std::int64_t>(evaluate_expr(*e, env)), INT64_MIN);
+}
+
+// --- String concat ---
+
+TEST(EvalExprTest, StringConcat) {
+    Environment env;
+    auto e = binop(TokenType::PLUS, str_lit("foo"), str_lit("bar"));
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "foobar");
+}
+
+TEST(EvalExprTest, StringPlusIntThrows) {
+    Environment env;
+    auto e = binop(TokenType::PLUS, str_lit("a"), int_lit(1));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+// --- Comparison ---
+
+TEST(EvalExprTest, EqualityTrue) {
+    Environment env;
+    auto e = binop(TokenType::EQUALS, int_lit(1), int_lit(1));
+    EXPECT_TRUE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, EqualityFalse) {
+    Environment env;
+    auto e = binop(TokenType::EQUALS, int_lit(1), int_lit(2));
+    EXPECT_FALSE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, EqualityMixedVariantReturnsFalse) {
+    Environment env;
+    auto e = binop(TokenType::EQUALS, int_lit(1), str_lit("1"));
+    EXPECT_FALSE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, OrderingOnStringsThrows) {
+    Environment env;
+    auto e = binop(TokenType::LESS, str_lit("a"), str_lit("b"));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+TEST(EvalExprTest, OrderingOnInts) {
+    Environment env;
+    auto e = binop(TokenType::LESS, int_lit(1), int_lit(2));
+    EXPECT_TRUE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+// --- Logical and short-circuit ---
+
+TEST(EvalExprTest, AndFalse) {
+    Environment env;
+    auto e = binop(TokenType::AND, bool_lit(true), bool_lit(false));
+    EXPECT_FALSE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, AndShortCircuitsOnFalse) {
+    Environment env;
+    // false and (1/0) — must not evaluate the right side
+    auto e = binop(TokenType::AND, bool_lit(false),
+                   binop(TokenType::SLASH, int_lit(1), int_lit(0)));
+    EXPECT_FALSE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+TEST(EvalExprTest, OrShortCircuitsOnTrue) {
+    Environment env;
+    auto e = binop(TokenType::OR, bool_lit(true),
+                   binop(TokenType::SLASH, int_lit(1), int_lit(0)));
+    EXPECT_TRUE(std::get<bool>(evaluate_expr(*e, env)));
+}
+
+// --- Functions ---
+
+TEST(EvalExprTest, LowerString) {
+    Environment env;
+    auto e = fn("lower", str_lit("HI"));
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "hi");
+}
+
+TEST(EvalExprTest, UpperString) {
+    Environment env;
+    auto e = fn("upper", str_lit("hi"));
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "HI");
+}
+
+TEST(EvalExprTest, TrimString) {
+    Environment env;
+    auto e = fn("trim", str_lit("  x  "));
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "x");
+}
+
+TEST(EvalExprTest, FunctionTypeMismatchThrows) {
+    Environment env;
+    auto e = fn("lower", int_lit(42));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+TEST(EvalExprTest, UnknownFunctionThrows) {
+    Environment env;
+    auto e = fn("frobnicate", str_lit("x"));
+    EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
+}
+
+// --- value_to_string ---
+
+TEST(ValueToStringTest, StringPassesThrough) {
+    EXPECT_EQ(value_to_string(Value{std::string{"hello"}}), "hello");
+}
+
+TEST(ValueToStringTest, IntZero) {
+    EXPECT_EQ(value_to_string(Value{std::int64_t{0}}), "0");
+}
+
+TEST(ValueToStringTest, IntNegative) {
+    EXPECT_EQ(value_to_string(Value{std::int64_t{-7}}), "-7");
+}
+
+TEST(ValueToStringTest, BoolTrue) {
+    EXPECT_EQ(value_to_string(Value{true}), "true");
+}
+
+TEST(ValueToStringTest, BoolFalse) {
+    EXPECT_EQ(value_to_string(Value{false}), "false");
 }


### PR DESCRIPTION
## Summary
Adds the expression evaluator and value-to-string helper. Pure code, no side effects. Handles literals, identifiers, the `not` operator, arithmetic with wrap-around, string concatenation, mixed-variant equality per the spec, ordering on ints, short-circuit `and` and `or`, and the `lower`/`upper`/`trim` functions.

## Changes
- New `evaluate_expr` and `value_to_string` exposed from the interpreter header
- Type errors, unknown identifiers, division by zero, and unknown function names all throw a runtime error with the offending node's line and column
- Arithmetic on signed ints uses two's-complement wrap-around through unsigned to avoid undefined behaviour
- Equality and inequality accept any operand types and return false or true on differing variants, matching the language docs
- Ordering comparisons are int-only and reject other types

## Test plan
- All 265 (33 new) tests pass locally
- New tests cover every literal kind, identifier lookup and missing-identifier failure, unary `not` on bool and on int, arithmetic including overflow wrap and the int-min over minus-one corner case, string concatenation, mixed-variant equality, ordering rejection on strings, short-circuit observation via division by zero on the dead branch, function happy paths, function type mismatch, and unknown function name. value-to-string has exact-string assertions for each variant