### PR TITLE
feat(interpreter): resolve path expressions

### DIFF
--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -133,6 +133,28 @@ Value evaluate_expr(const Expr& expr, const Environment& env);
  */
 std::string value_to_string(const Value& value);
 
+/**
+ * @brief Resolved bindings for path aliases declared by `as` clauses.
+ *
+ * Maps the alias name to the already-resolved destination path string. The
+ * parser guarantees that `PathVar` segments only ever name a registered alias,
+ * so the evaluator never falls back to an environment lookup for them.
+ */
+using AliasMap = std::unordered_map<std::string, std::string>;
+
+/**
+ * @brief Evaluate a path expression to a flat string.
+ *
+ * Concatenates segment outputs verbatim (the parser already embeds `/` and
+ * `.` inside `PathLiteral.value`, so no separator insertion is needed).
+ * `PathInterp` segments evaluate their inner expression and stringify the
+ * result via `value_to_string`. `PathVar` segments look up the alias name in
+ * `aliases`; an unbound alias is a defensive runtime error since the
+ * validator already guarantees presence in well-formed programs.
+ */
+std::string evaluate_path(const PathExpr& path, const Environment& env,
+                          const AliasMap& aliases);
+
 }  // namespace spudplate
 
 #endif  // SPUDPLATE_INTERPRETER_H

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -36,6 +36,27 @@ std::optional<Value> Environment::lookup(const std::string& name) const {
 
 namespace {
 
+// Deferred-write queue entries. The interpreter never touches the filesystem
+// during statement execution; mkdir and file statements push one of these and
+// the flush step at the end of a run executes them in order.
+struct PendingMkdir {
+    std::string path;
+    std::optional<int> mode;
+    int line;
+    int column;
+};
+
+struct PendingFile {
+    std::string path;
+    std::string content;
+    bool append;
+    std::optional<int> mode;
+    int line;
+    int column;
+};
+
+using PendingOp = std::variant<PendingMkdir, PendingFile>;
+
 // Until Part 4 lands, the Prompter forward-declared in the header has no
 // concrete implementation. The skeleton interpreter never reaches a code
 // path that calls it (every statement throws "not yet supported" first).
@@ -248,6 +269,7 @@ class Interpreter {
 
   private:
     Environment env_;
+    std::vector<PendingOp> pending_;
 };
 
 void run_program(const Program& program, Prompter& /*prompter*/,
@@ -285,6 +307,32 @@ Value evaluate_expr(const Expr& expr, const Environment& env) {
             }
         },
         expr.data);
+}
+
+std::string evaluate_path(const PathExpr& path, const Environment& env,
+                          const AliasMap& aliases) {
+    std::string out;
+    for (const auto& seg : path.segments) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, PathLiteral>) {
+                    out += s.value;
+                } else if constexpr (std::is_same_v<T, PathVar>) {
+                    auto it = aliases.find(s.name);
+                    if (it == aliases.end()) {
+                        throw RuntimeError(
+                            "internal error: unbound path alias '" + s.name + "'",
+                            s.line, s.column);
+                    }
+                    out += it->second;
+                } else if constexpr (std::is_same_v<T, PathInterp>) {
+                    out += value_to_string(evaluate_expr(*s.expression, env));
+                }
+            },
+            seg);
+    }
+    return out;
 }
 
 std::string value_to_string(const Value& value) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -14,10 +14,17 @@
 #include "spudplate/parser.h"
 #include "spudplate/token.h"
 
+using spudplate::AliasMap;
 using spudplate::BinaryExpr;
 using spudplate::BoolLiteralExpr;
 using spudplate::Environment;
 using spudplate::evaluate_expr;
+using spudplate::evaluate_path;
+using spudplate::PathExpr;
+using spudplate::PathInterp;
+using spudplate::PathLiteral;
+using spudplate::PathSegment;
+using spudplate::PathVar;
 using spudplate::Expr;
 using spudplate::ExprData;
 using spudplate::ExprPtr;
@@ -92,6 +99,20 @@ ExprPtr fn(const std::string& name, ExprPtr arg) {
                                  .argument = std::move(arg),
                                  .line = 1,
                                  .column = 1});
+}
+
+// Path-segment builders.
+PathSegment plit(const std::string& v) {
+    return PathLiteral{.value = v, .line = 1, .column = 1};
+}
+PathSegment pvar(const std::string& name) {
+    return PathVar{.name = name, .line = 1, .column = 1};
+}
+PathSegment pinterp(ExprPtr e) {
+    return PathInterp{.expression = std::move(e), .line = 1, .column = 1};
+}
+PathExpr path(std::vector<PathSegment> segs) {
+    return PathExpr{.segments = std::move(segs), .line = 1, .column = 1};
 }
 
 }  // namespace
@@ -480,4 +501,87 @@ TEST(ValueToStringTest, BoolTrue) {
 
 TEST(ValueToStringTest, BoolFalse) {
     EXPECT_EQ(value_to_string(Value{false}), "false");
+}
+
+// --- Path evaluator ---
+
+TEST(EvalPathTest, PureLiteralPath) {
+    Environment env;
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(plit("static/notes/README.md"));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "static/notes/README.md");
+}
+
+TEST(EvalPathTest, PathVarFromAliasMap) {
+    Environment env;
+    AliasMap aliases{{"project", "my-project"}};
+    std::vector<PathSegment> segs;
+    segs.push_back(pvar("project"));
+    segs.push_back(plit("/src"));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "my-project/src");
+}
+
+TEST(EvalPathTest, PathInterpAgainstEnvString) {
+    Environment env;
+    env.declare("prefix", Value{std::string{"x"}});
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(pinterp(ident("prefix")));
+    segs.push_back(plit("/sub"));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "x/sub");
+}
+
+TEST(EvalPathTest, PathInterpWithArithmetic) {
+    Environment env;
+    env.declare("n", Value{std::int64_t{3}});
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(plit("week_"));
+    segs.push_back(pinterp(binop(TokenType::PLUS, ident("n"), int_lit(1))));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "week_4");
+}
+
+TEST(EvalPathTest, PathInterpStringifiesBool) {
+    Environment env;
+    env.declare("use_x", Value{true});
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(plit("flag_"));
+    segs.push_back(pinterp(ident("use_x")));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "flag_true");
+}
+
+TEST(EvalPathTest, UnboundAliasThrows) {
+    Environment env;
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(PathVar{.name = "ghost", .line = 5, .column = 9});
+    auto pe = path(std::move(segs));
+    try {
+        evaluate_path(pe, env, aliases);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& ex) {
+        EXPECT_NE(std::string(ex.what()).find("ghost"), std::string::npos);
+        EXPECT_EQ(ex.line(), 5);
+        EXPECT_EQ(ex.column(), 9);
+    }
+}
+
+TEST(EvalPathTest, MixedSegments) {
+    Environment env;
+    env.declare("i", Value{std::int64_t{2}});
+    AliasMap aliases{{"project", "my-app"}};
+    std::vector<PathSegment> segs;
+    segs.push_back(pvar("project"));
+    segs.push_back(plit("/week_"));
+    segs.push_back(pinterp(ident("i")));
+    segs.push_back(plit("/notes.md"));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "my-app/week_2/notes.md");
 }


### PR DESCRIPTION
## Summary
Adds the path expression evaluator and the deferred-write queue types. No filesystem effects yet.

## Changes
- New `evaluate_path` and `AliasMap` exposed from the interpreter header
- Path segments concatenate verbatim: the parser already embeds slashes and dots inside literal segments, so the evaluator inserts no separators
- `PathInterp` segments evaluate their inner expression and stringify with the helper from the previous PR
- `PathVar` segments look up the alias name in the supplied alias map and throw a runtime error if missing, since the validator guarantees presence in well-formed programs
- Internal pending-op types defined for use by the upcoming mkdir and file work

## Test plan
- All 272 (7 new) tests pass locally
- New tests cover a pure literal path, a path-var resolved from the alias map, an interpolation against an environment string, an interpolation with arithmetic, an interpolation that stringifies a bool, an unbound alias surfacing line and column, and a mix of all three segment kinds