### PR TITLE
feat(interpreter): run ask and let statements

### DIFF
--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -77,10 +77,6 @@ class Environment {
 
 /**
  * @brief Abstract source of user input for `ask` statements.
- *
- * Concrete subclasses (`StdinPrompter` for production, `ScriptedPrompter` for
- * tests) are added when `ask` execution lands. The base interface is exposed
- * now so callers can pass any subclass to `run`.
  */
 class Prompter {
   public:
@@ -90,11 +86,37 @@ class Prompter {
      * @brief Display `message` and obtain the user's raw answer string.
      *
      * The interpreter parses the returned string into a `Value` according to
-     * the question's `type`. Implementations may re-prompt internally if the
-     * caller signals invalid input by ignoring the return value, but normally
-     * the loop lives in the interpreter, not here.
+     * the question's `type` and re-prompts on invalid input — implementations
+     * just deliver one raw line per call.
      */
     virtual std::string prompt(const std::string& message, VarType type) = 0;
+};
+
+/**
+ * @brief Production prompter: writes to stdout and reads a line from stdin.
+ */
+class StdinPrompter : public Prompter {
+  public:
+    std::string prompt(const std::string& message, VarType type) override;
+};
+
+/**
+ * @brief Test prompter: replays a fixed sequence of canned answers.
+ *
+ * Constructed with a vector of strings; each call to `prompt` consumes the
+ * next answer. Calling `prompt` after the queue is exhausted throws
+ * `std::logic_error`, so test retry-loop bugs cannot hang.
+ */
+class ScriptedPrompter : public Prompter {
+  public:
+    explicit ScriptedPrompter(std::vector<std::string> answers)
+        : answers_(std::move(answers)) {}
+
+    std::string prompt(const std::string& message, VarType type) override;
+
+  private:
+    std::vector<std::string> answers_;
+    std::size_t index_{0};
 };
 
 /**

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -3,8 +3,10 @@
 #include <algorithm>
 #include <cctype>
 #include <climits>
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -64,6 +66,36 @@ void unsupported(const std::string& stmt_name, int line, int column) {
     throw RuntimeError("statement '" + stmt_name +
                            "' not yet supported in this build",
                        line, column);
+}
+
+// Lower-case ASCII copy used for case-insensitive bool parsing.
+std::string ascii_lower(std::string s) {
+    for (auto& c : s) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return s;
+}
+
+// Evaluate an optional `when` clause; returns true if it passes (clause
+// absent or evaluates to true). Throws if the clause's value is non-bool.
+bool when_passes(const std::optional<ExprPtr>& clause, const Environment& env) {
+    if (!clause.has_value()) {
+        return true;
+    }
+    Value v = evaluate_expr(**clause, env);
+    if (!std::holds_alternative<bool>(v)) {
+        const auto& expr = **clause;
+        int line = 0;
+        int col = 0;
+        std::visit(
+            [&](const auto& e) {
+                line = e.line;
+                col = e.column;
+            },
+            expr.data);
+        throw RuntimeError("'when' condition must be bool", line, col);
+    }
+    return std::get<bool>(v);
 }
 
 // Names a Value's variant alternative for error messages.
@@ -202,6 +234,100 @@ Value eval_binary(const BinaryExpr& bin, const Environment& env) {
     }
 }
 
+// Parse a raw answer string into a Value of the requested type.
+// Returns nullopt when the input is invalid (caller re-prompts).
+std::optional<Value> parse_answer(const std::string& raw, VarType type) {
+    if (type == VarType::String) {
+        return Value{raw};
+    }
+    if (type == VarType::Bool) {
+        std::string lc = ascii_lower(raw);
+        if (lc == "true") {
+            return Value{true};
+        }
+        if (lc == "false") {
+            return Value{false};
+        }
+        return std::nullopt;
+    }
+    // VarType::Int
+    try {
+        std::size_t consumed = 0;
+        long long v = std::stoll(raw, &consumed);
+        // Reject if any non-whitespace remains after the number.
+        for (std::size_t i = consumed; i < raw.size(); ++i) {
+            if (std::isspace(static_cast<unsigned char>(raw[i])) == 0) {
+                return std::nullopt;
+            }
+        }
+        return Value{static_cast<std::int64_t>(v)};
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter) {
+    if (!when_passes(stmt.when_clause, env)) {
+        return;
+    }
+
+    std::optional<Value> default_value;
+    if (stmt.default_value.has_value()) {
+        default_value = evaluate_expr(**stmt.default_value, env);
+    }
+
+    std::vector<std::string> option_strings;
+    option_strings.reserve(stmt.options.size());
+    for (const auto& opt : stmt.options) {
+        option_strings.push_back(value_to_string(evaluate_expr(*opt, env)));
+    }
+
+    std::string message = stmt.prompt;
+    if (!option_strings.empty()) {
+        message += " [";
+        for (std::size_t i = 0; i < option_strings.size(); ++i) {
+            if (i != 0) {
+                message += ", ";
+            }
+            message += option_strings[i];
+        }
+        message += "]";
+    }
+    if (default_value.has_value()) {
+        message += " (default: " + value_to_string(*default_value) + ")";
+    }
+
+    while (true) {
+        std::string raw = prompter.prompt(message, stmt.var_type);
+        if (raw.empty()) {
+            if (default_value.has_value()) {
+                env.declare(stmt.name, *default_value);
+                return;
+            }
+            continue;  // required question, re-prompt
+        }
+        auto parsed = parse_answer(raw, stmt.var_type);
+        if (!parsed.has_value()) {
+            continue;
+        }
+        if (!option_strings.empty()) {
+            std::string parsed_str = value_to_string(*parsed);
+            bool match = false;
+            for (const auto& s : option_strings) {
+                if (s == parsed_str) {
+                    match = true;
+                    break;
+                }
+            }
+            if (!match) {
+                continue;
+            }
+        }
+        env.declare(stmt.name, std::move(*parsed));
+        return;
+    }
+}
+
 Value eval_call(const FunctionCallExpr& fc, const Environment& env) {
     Value arg = evaluate_expr(*fc.argument, env);
     if (!std::holds_alternative<std::string>(arg)) {
@@ -242,14 +368,17 @@ Value eval_call(const FunctionCallExpr& fc, const Environment& env) {
 
 class Interpreter {
   public:
+    explicit Interpreter(Prompter& prompter) : prompter_(prompter) {}
+
     void execute(const Stmt& stmt) {
         std::visit(
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, AskStmt>) {
-                    unsupported("ask", s.line, s.column);
+                    execute_ask(s, env_, prompter_);
                 } else if constexpr (std::is_same_v<T, LetStmt>) {
-                    unsupported("let", s.line, s.column);
+                    Value v = evaluate_expr(*s.value, env_);
+                    env_.declare(s.name, std::move(v));
                 } else if constexpr (std::is_same_v<T, MkdirStmt>) {
                     unsupported("mkdir", s.line, s.column);
                 } else if constexpr (std::is_same_v<T, FileStmt>) {
@@ -269,17 +398,33 @@ class Interpreter {
 
   private:
     Environment env_;
+    Prompter& prompter_;
     std::vector<PendingOp> pending_;
 };
 
-void run_program(const Program& program, Prompter& /*prompter*/,
-                 Interpreter& interp) {
+void run_program(const Program& program, Interpreter& interp) {
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }
 }
 
 }  // namespace
+
+std::string StdinPrompter::prompt(const std::string& message,
+                                  VarType /*type*/) {
+    std::cout << message << ": " << std::flush;
+    std::string line;
+    std::getline(std::cin, line);
+    return line;
+}
+
+std::string ScriptedPrompter::prompt(const std::string& /*message*/,
+                                     VarType /*type*/) {
+    if (index_ >= answers_.size()) {
+        throw std::logic_error("ScriptedPrompter exhausted");
+    }
+    return answers_[index_++];
+}
 
 Value evaluate_expr(const Expr& expr, const Environment& env) {
     return std::visit(
@@ -351,13 +496,13 @@ std::string value_to_string(const Value& value) {
 }
 
 void run(const Program& program, Prompter& prompter) {
-    Interpreter interp;
-    run_program(program, prompter, interp);
+    Interpreter interp(prompter);
+    run_program(program, interp);
 }
 
 Environment run_for_tests(const Program& program, Prompter& prompter) {
-    Interpreter interp;
-    run_program(program, prompter, interp);
+    Interpreter interp(prompter);
+    run_program(program, interp);
     return std::move(interp.env());
 }
 

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -38,6 +38,7 @@ using spudplate::Prompter;
 using spudplate::run;
 using spudplate::run_for_tests;
 using spudplate::RuntimeError;
+using spudplate::ScriptedPrompter;
 using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
 using spudplate::UnaryExpr;
@@ -189,30 +190,6 @@ TEST(InterpreterTest, EmptyProgramRunsCleanly) {
 }
 
 // --- Every statement type throws "not yet supported" ---
-
-TEST(InterpreterTest, AskThrowsNotYetSupported) {
-    auto program = parse(R"(ask name "Project name?" string
-)");
-    NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("ask"), std::string::npos);
-    }
-}
-
-TEST(InterpreterTest, LetThrowsNotYetSupported) {
-    auto program = parse(R"(let x = 1
-)");
-    NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("let"), std::string::npos);
-    }
-}
 
 TEST(InterpreterTest, MkdirThrowsNotYetSupported) {
     auto program = parse(R"(mkdir foo
@@ -571,6 +548,117 @@ TEST(EvalPathTest, UnboundAliasThrows) {
         EXPECT_EQ(ex.line(), 5);
         EXPECT_EQ(ex.column(), 9);
     }
+}
+
+// --- Ask + Let execution (Part 4) ---
+
+TEST(AskTest, StringAnswerIsBound) {
+    auto p = parse(R"(ask name "Project name?" string
+)");
+    ScriptedPrompter prompter({"my-project"});
+    Environment env = run_for_tests(p, prompter);
+    auto v = env.lookup("name");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(std::get<std::string>(*v), "my-project");
+}
+
+TEST(AskTest, BoolAnswerCaseInsensitive) {
+    auto p = parse(R"(ask flag "Enable?" bool
+)");
+    ScriptedPrompter t({"true"});
+    EXPECT_TRUE(std::get<bool>(*run_for_tests(p, t).lookup("flag")));
+    ScriptedPrompter f({"FALSE"});
+    EXPECT_FALSE(std::get<bool>(*run_for_tests(p, f).lookup("flag")));
+}
+
+TEST(AskTest, IntAnswer) {
+    auto p = parse(R"(ask n "How many?" int
+)");
+    ScriptedPrompter prompter({"42"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("n")), 42);
+}
+
+TEST(AskTest, EmptyInputUsesDefault) {
+    auto p = parse(R"(ask license "License?" string default "MIT"
+)");
+    ScriptedPrompter prompter({""});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("license")), "MIT");
+}
+
+TEST(AskTest, EmptyInputWithoutDefaultRePrompts) {
+    auto p = parse(R"(ask name "Name?" string
+)");
+    ScriptedPrompter prompter({"", "MyProj"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("name")), "MyProj");
+}
+
+TEST(AskTest, StringOptionsRetryUntilValid) {
+    auto p = parse(R"(ask format "Format?" string options "pdf" "html"
+)");
+    ScriptedPrompter prompter({"foo", "pdf"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("format")), "pdf");
+}
+
+TEST(AskTest, IntOptionsAcceptNumericMatch) {
+    auto p = parse(R"(ask v "Version?" int options 15 16 17
+)");
+    ScriptedPrompter prompter({"15"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("v")), 15);
+}
+
+TEST(AskTest, WhenSkipsAsk) {
+    auto p = parse(R"(ask use_x "Use X?" bool
+ask name "Name?" string when use_x
+)");
+    ScriptedPrompter prompter({"false"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_FALSE(env.lookup("name").has_value());
+}
+
+TEST(AskTest, BadBoolRetries) {
+    auto p = parse(R"(ask flag "Enable?" bool
+)");
+    ScriptedPrompter prompter({"maybe", "true"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_TRUE(std::get<bool>(*env.lookup("flag")));
+}
+
+TEST(AskTest, BadIntRetries) {
+    auto p = parse(R"(ask n "How many?" int
+)");
+    ScriptedPrompter prompter({"abc", "7"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("n")), 7);
+}
+
+TEST(LetTest, ArithmeticOverPriorAsk) {
+    auto p = parse(R"(ask n "n?" int
+let m = n + 1
+)");
+    ScriptedPrompter prompter({"10"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("m")), 11);
+}
+
+TEST(LetTest, StringFunctionsCompose) {
+    auto p = parse(R"(ask project_name "Name?" string
+let slug = lower(trim(project_name))
+)");
+    ScriptedPrompter prompter({"  My Project  "});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("slug")), "my project");
+}
+
+TEST(ScriptedPrompterTest, ExhaustionThrowsLogicError) {
+    auto p = parse(R"(ask name "Name?" string
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run_for_tests(p, prompter), std::logic_error);
 }
 
 TEST(EvalPathTest, MixedSegments) {


### PR DESCRIPTION
## Summary
First statements that actually execute. Adds the prompter interface with stdin and scripted implementations, runs `ask` with default values, options, type parsing, re-prompt on bad input, and an optional `when` guard, and runs `let` by evaluating the expression and binding the result.

## Changes
- New `StdinPrompter` and `ScriptedPrompter` on the public header
- `when_passes` helper used by `ask` now and reused by every later statement
- `ask` parses string, bool (case-insensitive `true` and `false` only), and int answers; empty input falls back to a `default` if present, otherwise re-prompts; `options` match by stringified value so int and string options work uniformly; a false `when` clause skips the prompt entirely
- `let` evaluates the value and declares the binding
- Test-only `run_for_tests` now produces a usable environment from a real run since `ask` and `let` actually populate it

## Test plan
- All 283 (13 new) tests pass locally
- New tests cover string and bool and int answers, empty input with and without default, string options retry, int options accepted, `when` skips `ask`, bad bool retries, bad int retries, `let` arithmetic over a prior `ask`, `let` string-fn composition, and `ScriptedPrompter` throwing on exhaustion