### PR TITLE
feat(interpreter): run mkdir and flush

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -6,10 +6,12 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 
@@ -380,7 +382,7 @@ class Interpreter {
                     Value v = evaluate_expr(*s.value, env_);
                     env_.declare(s.name, std::move(v));
                 } else if constexpr (std::is_same_v<T, MkdirStmt>) {
-                    unsupported("mkdir", s.line, s.column);
+                    execute_mkdir(s);
                 } else if constexpr (std::is_same_v<T, FileStmt>) {
                     unsupported("file", s.line, s.column);
                 } else if constexpr (std::is_same_v<T, RepeatStmt>) {
@@ -396,16 +398,71 @@ class Interpreter {
 
     [[nodiscard]] Environment& env() { return env_; }
 
+    void flush() {
+        for (const auto& op : pending_) {
+            std::visit([&](const auto& o) { run_op(o); }, op);
+        }
+    }
+
   private:
+    void execute_mkdir(const MkdirStmt& s) {
+        if (!when_passes(s.when_clause, env_)) {
+            return;
+        }
+        if (s.from_source.has_value() || s.verbatim) {
+            throw RuntimeError(
+                "'mkdir from' / 'verbatim' not yet supported in this build",
+                s.line, s.column);
+        }
+        std::string path_str = evaluate_path(s.path, env_, alias_map_);
+        if (s.alias.has_value()) {
+            alias_map_[*s.alias] = path_str;
+        }
+        pending_.push_back(PendingMkdir{.path = std::move(path_str),
+                                        .mode = s.mode,
+                                        .line = s.line,
+                                        .column = s.column});
+    }
+
+    void check_pre_existing(const std::string& path, int line, int col) {
+        // Snapshot is taken at flush time, not run start; valid only because
+        // v1 does not write before flush. If a side-effecting statement is
+        // added before flush (e.g. `run`), revisit.
+        if (created_during_run_.find(path) == created_during_run_.end() &&
+            std::filesystem::exists(path)) {
+            throw RuntimeError("refusing to write to pre-existing path '" + path +
+                                   "'",
+                               line, col);
+        }
+    }
+
+    void run_op(const PendingMkdir& op) {
+        check_pre_existing(op.path, op.line, op.column);
+        std::filesystem::create_directories(op.path);
+        if (op.mode.has_value()) {
+            std::filesystem::permissions(
+                op.path, static_cast<std::filesystem::perms>(*op.mode),
+                std::filesystem::perm_options::replace);
+        }
+        created_during_run_.insert(op.path);
+    }
+
+    void run_op(const PendingFile& /*op*/) {
+        // PendingFile lands in Part 6.
+    }
+
     Environment env_;
     Prompter& prompter_;
+    AliasMap alias_map_;
     std::vector<PendingOp> pending_;
+    std::unordered_set<std::string> created_during_run_;
 };
 
 void run_program(const Program& program, Interpreter& interp) {
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }
+    interp.flush();
 }
 
 }  // namespace

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -4,7 +4,10 @@
 
 #include <climits>
 #include <cstdint>
+#include <filesystem>
 #include <memory>
+#include <random>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -116,6 +119,36 @@ PathExpr path(std::vector<PathSegment> segs) {
     return PathExpr{.segments = std::move(segs), .line = 1, .column = 1};
 }
 
+// Per-test scratch directory. Created on construction with a randomised name
+// under the system temp dir; the previous working directory is restored and
+// the directory is wiped on destruction. Tests that touch the filesystem
+// `chdir` into one of these so `mkdir foo` etc. resolve under it.
+class TmpDir {
+  public:
+    TmpDir() {
+        prev_ = std::filesystem::current_path();
+        std::random_device rd;
+        std::stringstream ss;
+        ss << "spudplate-test-" << std::hex << rd() << rd();
+        path_ = std::filesystem::temp_directory_path() / ss.str();
+        std::filesystem::create_directories(path_);
+        std::filesystem::current_path(path_);
+    }
+    TmpDir(const TmpDir&) = delete;
+    TmpDir& operator=(const TmpDir&) = delete;
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::current_path(prev_, ec);
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const { return path_; }
+
+  private:
+    std::filesystem::path path_;
+    std::filesystem::path prev_;
+};
+
 }  // namespace
 
 // --- RuntimeError shape ---
@@ -190,18 +223,6 @@ TEST(InterpreterTest, EmptyProgramRunsCleanly) {
 }
 
 // --- Every statement type throws "not yet supported" ---
-
-TEST(InterpreterTest, MkdirThrowsNotYetSupported) {
-    auto program = parse(R"(mkdir foo
-)");
-    NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("mkdir"), std::string::npos);
-    }
-}
 
 TEST(InterpreterTest, FileThrowsNotYetSupported) {
     auto program = parse(R"(file foo.txt content "hi"
@@ -659,6 +680,120 @@ TEST(ScriptedPrompterTest, ExhaustionThrowsLogicError) {
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run_for_tests(p, prompter), std::logic_error);
+}
+
+// --- Mkdir + flush + safety (Part 5) ---
+
+TEST(MkdirTest, CreatesDirectory) {
+    TmpDir td;
+    auto p = parse(R"(mkdir my_project
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "my_project"));
+}
+
+TEST(MkdirTest, MkdirP) {
+    TmpDir td;
+    auto p = parse(R"(mkdir a/b/c
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "a" / "b" / "c"));
+}
+
+TEST(MkdirTest, WhenFalseSkips) {
+    TmpDir td;
+    auto p = parse(R"(ask use_foo "Use foo?" bool
+mkdir foo when use_foo
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
+}
+
+TEST(MkdirTest, WhenTrueCreates) {
+    TmpDir td;
+    auto p = parse(R"(ask use_foo "Use foo?" bool
+mkdir foo when use_foo
+)");
+    ScriptedPrompter prompter({"true"});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "foo"));
+}
+
+TEST(MkdirTest, ModeApplied) {
+    TmpDir td;
+    auto p = parse(R"(mkdir bar mode 0700
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    auto perms = std::filesystem::status(td.path() / "bar").permissions();
+    EXPECT_EQ(perms, static_cast<std::filesystem::perms>(0700));
+}
+
+TEST(MkdirTest, AliasResolvesInLaterPath) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo as project
+mkdir project/sub
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "foo" / "sub"));
+}
+
+TEST(MkdirTest, RejectsPreExistingPath) {
+    TmpDir td;
+    std::filesystem::create_directory(td.path() / "exists");
+    auto p = parse(R"(mkdir exists
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+}
+
+TEST(MkdirTest, FromIsNotYetSupported) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo from base
+)");
+    ScriptedPrompter prompter({});
+    try {
+        run(p, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("not yet supported"),
+                  std::string::npos);
+    }
+    // The `from` rejection happens during execution, before flush — nothing
+    // was written.
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
+}
+
+TEST(MkdirTest, DeferredWriteAtomicityOnPreFlushFailure) {
+    TmpDir td;
+    // First mkdir queues; second throws on `from` before any flush runs.
+    auto p = parse(R"(mkdir a
+mkdir b from base
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "a"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "b"));
+}
+
+TEST(MkdirTest, SkippedConditionalAliasNotBound) {
+    TmpDir td;
+    // Producer is skipped (`use_x=false`); consumer guarded by the same when
+    // is also skipped — neither directory is created and the alias is never
+    // looked up. This proves the runtime does not bind aliases on skipped
+    // statements.
+    auto p = parse(R"(ask use_x "Use x?" bool
+mkdir foo when use_x as project
+mkdir project/sub when use_x
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "project"));
 }
 
 TEST(EvalPathTest, MixedSegments) {


### PR DESCRIPTION
## Summary
First filesystem side effect. `mkdir` statements queue a `PendingMkdir` during execution; the queue is flushed at the end of the run, with a pre-existing-path check that refuses to overwrite anything that was on disk before the run started. `mkdir from` and `verbatim` raise a clear "not yet supported" error since the embedder is not in this branch.

## Changes
- `MkdirStmt` arm: skips on a false `when`, rejects `from` and `verbatim` before any alias binding, evaluates the path against the alias map, records the alias if `as` was given, and pushes a `PendingMkdir` onto the queue
- New `flush()` step at end of run executes each `PendingMkdir` via `std::filesystem::create_directories`, applies `mode` via `std::filesystem::permissions` with `perm_options::replace`, and tracks created paths so they are not later mistaken for pre-existing
- Pre-existing-path safety throws `RuntimeError` if a queued path was not created earlier in the same run yet already exists on disk; the snapshot is taken at flush time, valid only because v1 does not write before flush
- Tests gain a `TmpDir` RAII fixture that creates a unique scratch directory under the system temp dir, `chdir`s into it, and cleans up on destruction

## Test plan
- All 292 (10 new) tests pass locally
- New tests cover a plain `mkdir`, `mkdir -p` semantics, `when` skipping and creating, `mode` application, `as` alias resolution in a later path, pre-existing path rejection, `mkdir from` rejection, deferred-write atomicity (a queued op leaves no trace on disk when a later statement throws before flush), and a skipped conditional alias not being bound