### PR TITLE
feat(interpreter): write files from content

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
+#include <ios>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -384,7 +386,7 @@ class Interpreter {
                 } else if constexpr (std::is_same_v<T, MkdirStmt>) {
                     execute_mkdir(s);
                 } else if constexpr (std::is_same_v<T, FileStmt>) {
-                    unsupported("file", s.line, s.column);
+                    execute_file(s);
                 } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                     unsupported("repeat", s.line, s.column);
                 } else if constexpr (std::is_same_v<T, CopyStmt>) {
@@ -447,8 +449,58 @@ class Interpreter {
         created_during_run_.insert(op.path);
     }
 
-    void run_op(const PendingFile& /*op*/) {
-        // PendingFile lands in Part 6.
+    void execute_file(const FileStmt& s) {
+        if (!when_passes(s.when_clause, env_)) {
+            return;
+        }
+        // Reject `from` first so a thrown statement leaves no stale alias.
+        if (std::holds_alternative<FileFromSource>(s.source)) {
+            throw RuntimeError("'file from' not yet supported in this build",
+                               s.line, s.column);
+        }
+        const auto& content_src = std::get<FileContentSource>(s.source);
+        std::string content =
+            value_to_string(evaluate_expr(*content_src.value, env_));
+
+        std::string path_str = evaluate_path(s.path, env_, alias_map_);
+        if (s.alias.has_value()) {
+            alias_map_[*s.alias] = path_str;
+        }
+
+        pending_.push_back(PendingFile{.path = std::move(path_str),
+                                       .content = std::move(content),
+                                       .append = s.append,
+                                       .mode = s.mode,
+                                       .line = s.line,
+                                       .column = s.column});
+    }
+
+    void run_op(const PendingFile& op) {
+        // For non-append, the path may have been written earlier in this run
+        // (a prior `PendingFile` to the same path) — that's an in-run
+        // overwrite, allowed. The pre-existing check only fires for paths
+        // that existed before the run started.
+        check_pre_existing(op.path, op.line, op.column);
+        std::ios::openmode mode = std::ios::out;
+        if (op.append) {
+            mode |= std::ios::app;
+        } else {
+            mode |= std::ios::trunc;
+        }
+        {
+            std::ofstream out(op.path, mode);
+            if (!out) {
+                throw RuntimeError("cannot open '" + op.path + "' for writing",
+                                   op.line, op.column);
+            }
+            out << op.content;
+        }
+        if (op.mode.has_value()) {
+            std::filesystem::permissions(
+                op.path, static_cast<std::filesystem::perms>(*op.mode),
+                std::filesystem::perm_options::replace);
+        }
+        created_during_run_.insert(op.path);
     }
 
     Environment env_;

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -5,6 +5,7 @@
 #include <climits>
 #include <cstdint>
 #include <filesystem>
+#include <fstream>
 #include <memory>
 #include <random>
 #include <sstream>
@@ -223,18 +224,6 @@ TEST(InterpreterTest, EmptyProgramRunsCleanly) {
 }
 
 // --- Every statement type throws "not yet supported" ---
-
-TEST(InterpreterTest, FileThrowsNotYetSupported) {
-    auto program = parse(R"(file foo.txt content "hi"
-)");
-    NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("file"), std::string::npos);
-    }
-}
 
 TEST(InterpreterTest, RepeatThrowsNotYetSupported) {
     auto program = parse(R"(repeat n as i
@@ -807,4 +796,152 @@ TEST(EvalPathTest, MixedSegments) {
     segs.push_back(plit("/notes.md"));
     auto pe = path(std::move(segs));
     EXPECT_EQ(evaluate_path(pe, env, aliases), "my-app/week_2/notes.md");
+}
+
+// --- File content + flush (Part 6) ---
+
+namespace {
+
+std::string read_file(const std::filesystem::path& p) {
+    std::ifstream in(p);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+}  // namespace
+
+TEST(FileTest, ContentLiteral) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt content "hello"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "hello");
+}
+
+TEST(FileTest, ContentInterpolatedFromLet) {
+    TmpDir td;
+    auto p = parse(R"(let name = "world"
+file foo.txt content "hello, " + name
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "hello, world");
+}
+
+TEST(FileTest, FileInsideQueuedDirectory) {
+    TmpDir td;
+    auto p = parse(R"(mkdir x
+file x/foo.txt content "hi"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "x" / "foo.txt"), "hi");
+}
+
+TEST(FileTest, AppendAfterContent) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt content "first"
+file foo.txt append content "second"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "firstsecond");
+}
+
+TEST(FileTest, SamePathTwiceWithoutAppendOverwrites) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt content "A"
+file foo.txt content "B"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "B");
+}
+
+TEST(FileTest, EmptyContent) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt content ""
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "foo.txt"));
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "");
+}
+
+TEST(FileTest, IntContentCoercedToString) {
+    TmpDir td;
+    auto p = parse(R"(let n = 42
+file count.txt content n
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "count.txt"), "42");
+}
+
+TEST(FileTest, BoolContentCoercedToString) {
+    TmpDir td;
+    auto p = parse(R"(file flag.txt content true
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "flag.txt"), "true");
+}
+
+TEST(FileTest, AppendViaAlias) {
+    TmpDir td;
+    auto p = parse(R"(file foo content "A" as f
+file f append content "B"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo"), "AB");
+}
+
+TEST(FileTest, ModeApplied) {
+    TmpDir td;
+    auto p = parse(R"(file run.sh content "echo hi" mode 0755
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    auto perms = std::filesystem::status(td.path() / "run.sh").permissions();
+    EXPECT_EQ(perms, static_cast<std::filesystem::perms>(0755));
+}
+
+TEST(FileTest, RejectsPreExistingFile) {
+    TmpDir td;
+    {
+        std::ofstream out(td.path() / "exists.txt");
+        out << "old";
+    }
+    auto p = parse(R"(file exists.txt content "new"
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+}
+
+TEST(FileTest, FromIsNotYetSupported) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt from src
+)");
+    ScriptedPrompter prompter({});
+    try {
+        run(p, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("not yet supported"),
+                  std::string::npos);
+    }
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo.txt"));
+}
+
+TEST(FileTest, WhenFalseSkips) {
+    TmpDir td;
+    auto p = parse(R"(ask use_f "Use file?" bool
+file foo.txt content "hi" when use_f
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo.txt"));
 }


### PR DESCRIPTION
## Summary
`file <path> content <expr>` now actually writes to disk, with `append`, `mode`, and `as` aliases all supported. `file from` raises a clear "not yet supported" error since the embedder is not in this branch.

## Changes
- `FileStmt` arm: skips on a false `when`, rejects `from` and `verbatim` before any alias binding, evaluates the content expression and stringifies via `value_to_string` (so int and bool content work too), evaluates the path against the alias map, records the alias if `as` was given, and pushes a `PendingFile` onto the queue
- `flush()` extends with a `PendingFile` arm: opens with `std::ios::trunc` for normal writes (so a same-path re-write within a run overwrites the prior queued content) and `std::ios::app` for `append`, then applies `mode` via `std::filesystem::permissions` with `perm_options::replace`
- Pre-existing-path safety still applies — appending to a file that existed on disk before the run is rejected, but appending to a file created earlier in the same run is fine
- Conditional-append via alias works naturally: `file foo content "A" as f` then `file f append content "B"` resolves the second statement's `PathVar` against the alias map populated by the first

## Test plan
- All 304 (12 new) tests pass locally
- New tests cover a literal content write, an interpolated content from a `let`, a file inside a queued-and-flushed directory, append after content, same-path re-write without append (last write wins), empty content, int and bool content coercion to string, append via alias, `mode` permissions, pre-existing file rejection, `file from` rejection, and `when false` skipping the file