### PR TITLE
feat(interpreter): execute repeat loops

### DIFF
--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -388,7 +388,7 @@ class Interpreter {
                 } else if constexpr (std::is_same_v<T, FileStmt>) {
                     execute_file(s);
                 } else if constexpr (std::is_same_v<T, RepeatStmt>) {
-                    unsupported("repeat", s.line, s.column);
+                    execute_repeat(s);
                 } else if constexpr (std::is_same_v<T, CopyStmt>) {
                     unsupported("copy", s.line, s.column);
                 } else if constexpr (std::is_same_v<T, IncludeStmt>) {
@@ -407,6 +407,63 @@ class Interpreter {
     }
 
   private:
+    void execute_repeat(const RepeatStmt& s) {
+        if (!when_passes(s.when_clause, env_)) {
+            return;
+        }
+        auto count_v = env_.lookup(s.collection_var);
+        if (!count_v.has_value()) {
+            throw RuntimeError("undefined variable '" + s.collection_var + "'",
+                               s.line, s.column);
+        }
+        if (!std::holds_alternative<std::int64_t>(*count_v)) {
+            throw RuntimeError("'repeat' count must be int", s.line, s.column);
+        }
+        std::int64_t count = std::get<std::int64_t>(*count_v);
+        if (count < 0) {
+            return;  // matches n == 0 — empty loop, no throw
+        }
+
+        for (std::int64_t i = 0; i < count; ++i) {
+            // Snapshot which alias names existed before the iteration so we
+            // can drop anything the body adds. Aliases declared in the body
+            // do not leak across iterations or out of the loop.
+            std::unordered_set<std::string> outer_aliases;
+            outer_aliases.reserve(alias_map_.size());
+            for (const auto& kv : alias_map_) {
+                outer_aliases.insert(kv.first);
+            }
+
+            env_.push();
+            env_.declare(s.iterator_var, Value{i});
+            try {
+                for (const auto& stmt : s.body) {
+                    execute(*stmt);
+                }
+            } catch (...) {
+                // Restore scope before propagating; aliases stay restored too.
+                for (auto it = alias_map_.begin(); it != alias_map_.end();) {
+                    if (outer_aliases.find(it->first) == outer_aliases.end()) {
+                        it = alias_map_.erase(it);
+                    } else {
+                        ++it;
+                    }
+                }
+                env_.pop();
+                throw;
+            }
+
+            for (auto it = alias_map_.begin(); it != alias_map_.end();) {
+                if (outer_aliases.find(it->first) == outer_aliases.end()) {
+                    it = alias_map_.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            env_.pop();
+        }
+    }
+
     void execute_mkdir(const MkdirStmt& s) {
         if (!when_passes(s.when_clause, env_)) {
             return;

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -225,19 +225,6 @@ TEST(InterpreterTest, EmptyProgramRunsCleanly) {
 
 // --- Every statement type throws "not yet supported" ---
 
-TEST(InterpreterTest, RepeatThrowsNotYetSupported) {
-    auto program = parse(R"(repeat n as i
-end
-)");
-    NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("repeat"), std::string::npos);
-    }
-}
-
 TEST(InterpreterTest, CopyThrowsNotYetSupported) {
     auto program = parse(R"(copy src into dst
 )");
@@ -944,4 +931,114 @@ file foo.txt content "hi" when use_f
     ScriptedPrompter prompter({"false"});
     run(p, prompter);
     EXPECT_FALSE(std::filesystem::exists(td.path() / "foo.txt"));
+}
+
+// --- Repeat (Part 7) ---
+
+TEST(RepeatTest, ZeroCountBodyNeverRuns) {
+    TmpDir td;
+    auto p = parse(R"(let n = 0
+repeat n as i
+    mkdir x_{i}
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_empty(td.path()));
+}
+
+TEST(RepeatTest, ThreeIterationsCreateThreeDirs) {
+    TmpDir td;
+    auto p = parse(R"(let n = 3
+repeat n as i
+    mkdir week_{i}
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_0"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_1"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_2"));
+}
+
+TEST(RepeatTest, WhenFalseSkipsLoop) {
+    TmpDir td;
+    auto p = parse(R"(ask use_loop "Use loop?" bool
+let n = 3
+repeat n as i when use_loop
+    mkdir week_{i}
+end
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "week_0"));
+}
+
+TEST(RepeatTest, NegativeCountIsZeroIterations) {
+    TmpDir td;
+    auto p = parse(R"(let n = 0 - 5
+repeat n as i
+    mkdir x_{i}
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_empty(td.path()));
+}
+
+TEST(RepeatTest, InnerLetReferencesIterator) {
+    TmpDir td;
+    // `let doubled = i + i` reads the iterator inside the body and binds a
+    // new value; `mkdir d_{doubled}` proves it was both bound and visible.
+    auto p = parse(R"(let n = 3
+repeat n as i
+    let doubled = i + i
+    mkdir d_{doubled}
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "d_0"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "d_2"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "d_4"));
+}
+
+TEST(RepeatTest, NestedRepeatsCreateGrid) {
+    TmpDir td;
+    auto p = parse(R"(let n = 2
+let m = 2
+repeat n as i
+    repeat m as j
+        mkdir x_{i}_{j}
+    end
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "x_0_0"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "x_0_1"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "x_1_0"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "x_1_1"));
+}
+
+TEST(RepeatTest, InnerAliasDoesNotLeak) {
+    TmpDir td;
+    // `wk` is rebound each iteration to that iteration's `week_{i}` path;
+    // the inner `mkdir wk/sub_{i}` resolves through the per-iteration alias.
+    // Each iteration must see only its own binding — no bleed across
+    // iterations and no escape after the loop.
+    auto p = parse(R"(let n = 2
+repeat n as i
+    mkdir week_{i} as wk
+    mkdir wk/sub_{i}
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_0" / "sub_0"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_1" / "sub_1"));
+    // Crucially, week_0/sub_1 and week_1/sub_0 must NOT exist — they would
+    // if the alias from iteration 0 leaked into iteration 1 or vice versa.
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "week_0" / "sub_1"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "week_1" / "sub_0"));
 }


### PR DESCRIPTION
## Summary
`repeat <count_var> as <iter>` now actually loops. Stacked on top of #28 (file content) since the loop tests use `mkdir` and `file` to observe what each iteration did.

## Changes
- `RepeatStmt` arm: skips on a false `when`, looks up `collection_var` and rejects non-int defensively, treats a negative count as zero iterations (matches `n=0` semantics, no throw)
- Each iteration pushes a new environment frame, declares the iterator variable, runs the body via the same dispatcher used at the top level, then pops the frame
- Per-iteration alias overlay: snapshot the alias map's existing keys on entry, drop any keys the body added on exit. Aliases declared inside the body do not leak across iterations or out of the loop. Cleanup happens on both success and exception paths
- `ask` inside `repeat` is rejected by the validator already; the interpreter assumes validated input and adds no runtime guard. v1 also does not cap iteration count, so pathological inputs may exhaust memory by queueing pending ops — listed as a follow-up

## Test plan
- All 310 (7 new) tests pass locally
- New tests cover zero count (body never runs), three iterations creating three directories, `when false` skipping the loop, negative count treated as zero, an inner `let` reading the iterator and feeding into a path, nested repeats forming a 2x2 grid, and per-iteration `as` alias not leaking across iterations