### PR TITLE
feat(interpreter): wire spudplate run cli

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
-                          src/interpreter.cpp)
+                          src/interpreter.cpp src/cli.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 
 # Executable
@@ -26,7 +26,8 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
-               tests/validator_test.cpp tests/interpreter_test.cpp)
+               tests/validator_test.cpp tests/interpreter_test.cpp
+               tests/cli_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Spudlang supports questions with defaults and option lists, derived variables, c
 
 ## Build
 
-> **Note:** spudplate is currently in active development. The lexer, parser, and semantic validator are complete, but the interpreter and CLI are not yet functional, so installed templates cannot be run end-to-end.
-
 Requires CMake and a C++20 compiler.
 
 ```bash

--- a/include/spudplate/cli.h
+++ b/include/spudplate/cli.h
@@ -1,0 +1,31 @@
+#ifndef SPUDPLATE_CLI_H
+#define SPUDPLATE_CLI_H
+
+#include <ostream>
+
+#include "spudplate/interpreter.h"
+
+namespace spudplate {
+
+/**
+ * @brief Command-line entry point factored out of `main` for testability.
+ *
+ * Recognised invocations:
+ *   spudplate run <file.spud>     run a template (exit codes below)
+ *
+ * Exit codes:
+ *   0 — success
+ *   1 — unrecognised invocation (usage printed to `err`)
+ *   2 — parse error
+ *   3 — semantic error
+ *   4 — runtime error
+ *   5 — file not found or unreadable
+ *
+ * Errors are formatted as `<file>:<line>:<col>: <kind>: <message>` on `err`.
+ */
+int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
+             Prompter& prompter);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_CLI_H

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,0 +1,82 @@
+#include "spudplate/cli.h"
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "spudplate/interpreter.h"
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+#include "spudplate/validator.h"
+
+namespace spudplate {
+
+namespace {
+
+void print_usage(std::ostream& err) {
+    err << "usage: spudplate run <file.spud>\n";
+}
+
+void print_error(std::ostream& err, const std::string& file, const char* kind,
+                 int line, int column, const char* message) {
+    err << file << ":" << line << ":" << column << ": " << kind << ": "
+        << message << "\n";
+}
+
+}  // namespace
+
+int cli_main(int argc, char* argv[], std::ostream& /*out*/, std::ostream& err,
+             Prompter& prompter) {
+    if (argc < 2) {
+        print_usage(err);
+        return 1;
+    }
+    std::string subcommand{argv[1]};
+    if (subcommand != "run" || argc != 3) {
+        print_usage(err);
+        return 1;
+    }
+
+    std::string file_path{argv[2]};
+    std::ifstream in(file_path);
+    if (!in) {
+        err << file_path << ": cannot open: " << std::strerror(errno) << "\n";
+        return 5;
+    }
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    std::string source = buffer.str();
+
+    Program program;
+    try {
+        Lexer lexer(source);
+        Parser parser(std::move(lexer));
+        program = parser.parse();
+    } catch (const ParseError& e) {
+        print_error(err, file_path, "parse error", e.line(), e.column(),
+                    e.what());
+        return 2;
+    }
+
+    try {
+        validate(program);
+    } catch (const SemanticError& e) {
+        print_error(err, file_path, "semantic error", e.line(), e.column(),
+                    e.what());
+        return 3;
+    }
+
+    try {
+        run(program, prompter);
+    } catch (const RuntimeError& e) {
+        print_error(err, file_path, "runtime error", e.line(), e.column(),
+                    e.what());
+        return 4;
+    }
+
+    return 0;
+}
+
+}  // namespace spudplate

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,9 @@
 #include <iostream>
 
-int main(int argc, char* argv[]) {
-    if (argc < 2) {
-        std::cerr << "Usage: spudplate <file.spud>" << '\n';
-        return 1;
-    }
+#include "spudplate/cli.h"
+#include "spudplate/interpreter.h"
 
-    std::cout << "spudplate: " << argv[1] << '\n';
-    return 0;
+int main(int argc, char* argv[]) {
+    spudplate::StdinPrompter prompter;
+    return spudplate::cli_main(argc, argv, std::cout, std::cerr, prompter);
 }

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -1,0 +1,157 @@
+#include "spudplate/cli.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "spudplate/interpreter.h"
+
+using spudplate::cli_main;
+using spudplate::Prompter;
+using spudplate::ScriptedPrompter;
+using spudplate::VarType;
+
+namespace {
+
+class TmpDir {
+  public:
+    TmpDir() {
+        prev_ = std::filesystem::current_path();
+        std::random_device rd;
+        std::stringstream ss;
+        ss << "spudplate-cli-" << std::hex << rd() << rd();
+        path_ = std::filesystem::temp_directory_path() / ss.str();
+        std::filesystem::create_directories(path_);
+        std::filesystem::current_path(path_);
+    }
+    TmpDir(const TmpDir&) = delete;
+    TmpDir& operator=(const TmpDir&) = delete;
+    ~TmpDir() {
+        std::error_code ec;
+        std::filesystem::current_path(prev_, ec);
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] const std::filesystem::path& path() const { return path_; }
+
+  private:
+    std::filesystem::path path_;
+    std::filesystem::path prev_;
+};
+
+void write_file(const std::filesystem::path& p, const std::string& content) {
+    std::ofstream out(p);
+    out << content;
+}
+
+// Build an argv array suitable for cli_main from a vector of arguments.
+class Argv {
+  public:
+    explicit Argv(std::vector<std::string> args) : args_(std::move(args)) {
+        for (auto& s : args_) {
+            ptrs_.push_back(s.data());
+        }
+    }
+    [[nodiscard]] int argc() const { return static_cast<int>(ptrs_.size()); }
+    [[nodiscard]] char** argv() { return ptrs_.data(); }
+
+  private:
+    std::vector<std::string> args_;
+    std::vector<char*> ptrs_;
+};
+
+}  // namespace
+
+TEST(CliTest, RunSuccessExitsZero) {
+    TmpDir td;
+    auto file = td.path() / "ok.spud";
+    write_file(file, "ask name \"Project name?\" string\nmkdir {name}\n");
+    Argv args({"spudplate", "run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({"my_project"});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_EQ(err.str(), "");
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "my_project"));
+}
+
+TEST(CliTest, ParseErrorExitsTwo) {
+    TmpDir td;
+    auto file = td.path() / "broken.spud";
+    write_file(file, "ask\n");
+    Argv args({"spudplate", "run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 2);
+    EXPECT_NE(err.str().find("parse error"), std::string::npos);
+}
+
+TEST(CliTest, SemanticErrorExitsThree) {
+    TmpDir td;
+    auto file = td.path() / "bad.spud";
+    // `ask` inside `repeat` is a semantic error, not a parse error.
+    write_file(file, "let n = 1\nrepeat n as i\n  ask x \"X?\" string\nend\n");
+    Argv args({"spudplate", "run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 3);
+    EXPECT_NE(err.str().find("semantic error"), std::string::npos);
+}
+
+TEST(CliTest, RuntimeErrorExitsFour) {
+    TmpDir td;
+    auto file = td.path() / "runtime.spud";
+    // `mkdir from` is rejected at runtime as not yet supported.
+    write_file(file, "mkdir foo from base\n");
+    Argv args({"spudplate", "run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 4);
+    EXPECT_NE(err.str().find("runtime error"), std::string::npos);
+}
+
+TEST(CliTest, UnknownSubcommandExitsOne) {
+    TmpDir td;
+    Argv args({"spudplate", "frobnicate"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("usage"), std::string::npos);
+}
+
+TEST(CliTest, NoArgumentsExitsOne) {
+    Argv args({"spudplate"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("usage"), std::string::npos);
+}
+
+TEST(CliTest, MissingFileExitsFive) {
+    TmpDir td;
+    auto file = td.path() / "absent.spud";
+    Argv args({"spudplate", "run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+    EXPECT_NE(err.str().find("cannot open"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
End of the interpreter branch. `spudplate run <file.spud>` is now a real command, it reads the file, lexes, parses, validates, and runs the program with a `StdinPrompter`. Stacked on #29 (repeat).

## Changes
- New `cli_main(argc, argv, out, err, prompter)` in a separate `src/cli.cpp` so tests drive the same code path the binary does, with a `StdinPrompter` swapped in for production and a `ScriptedPrompter` swapped in for tests
- `src/main.cpp` is now a four-line wrapper that constructs a `StdinPrompter` and forwards to `cli_main`
- Errors are formatted as `<file>:<line>:<col>: <kind>: <message>` to stderr; exit codes are 0 success, 1 unknown invocation, 2 parse error, 3 semantic error, 4 runtime error, 5 file not found
- README's development warning paragraph is gone — the interpreter is functional now

## Test plan
- All 317 (7 new) tests pass locally
- New `tests/cli_test.cpp` covers a successful `spudplate run` against a real `.spud` file (asserts the directory it was supposed to create exists), parse error exits 2, semantic error exits 3, runtime error exits 4, unknown subcommand exits 1, no arguments exits 1, and missing file exits 5