### PR TITLE
docs: drop braces from alias references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ ask license "License?" string default "MIT"
 let slug = lower(trim(project_name))
 
 mkdir {slug} as project
-mkdir {project}/src
-mkdir {project}/tests when use_tests
+mkdir project/src
+mkdir project/tests when use_tests
 
-file {project}/README.md content "# " + project_name
-file {project}/src/main.cpp from templates/main.cpp
-file {project}/tests/test_main.cpp from templates/test_main.cpp when use_tests
+file project/README.md content "# " + project_name
+file project/src/main.cpp from templates/main.cpp
+file project/tests/test_main.cpp from templates/test_main.cpp when use_tests
 ```
 
 Spudlang supports questions with defaults and option lists, derived variables, conditional actions, path aliases, loops, and including other installed templates. See [docs/syntax.md](docs/syntax.md) for the full language reference.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -345,13 +345,13 @@ let slug = lower(trim(project_name))
 let dir = slug + "-project"
 
 mkdir {dir} as project
-mkdir {project}/src
-mkdir {project}/tests when use_tests
+mkdir project/src
+mkdir project/tests when use_tests
 
-file {project}/README.md content "# " + project_name as readme
+file project/README.md content "# " + project_name as readme
 file {readme} append content "\nLicensed under " + license + "\n"
-file {project}/src/main.cpp from templates/main.cpp
-file {project}/tests/test_main.cpp from templates/test_main.cpp when use_tests
+file project/src/main.cpp from templates/main.cpp
+file project/tests/test_main.cpp from templates/test_main.cpp when use_tests
 
 include claude_setup when use_claude
 ```


### PR DESCRIPTION
## Summary
Path aliases declared with `as` are referenced bare, not via `{...}` interpolation. The example in the syntax reference and the readme used `{project}/src`, which the runtime treats as an environment-variable lookup of `project` and rejects since `project` is bound as an alias, not a variable. Fixing the example so it actually runs.

## Changes
- `docs/syntax.md` full example: `mkdir {project}/src` becomes `mkdir project/src` and the same fix on the four other `{project}/...` lines
- `README.md` example: same fix

## Test plan
- Compared against the existing alias-reference rules already documented elsewhere in `docs/syntax.md` ("`mkdir staticpath/notespath/week_{n}` — both `staticpath` and `notespath` are alias references"), so the fix matches the language as documented in its own paragraph
- Ran a small `.spud` template using the corrected form against the freshly built `spudplate run`; the directory tree and files were created as expected