### PR TITLE
feat(parser): allow expressions as ask defaults

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -22,7 +22,8 @@ ask <name> "<prompt>" <type> [options <v1> <v2> ...] [default <value>] [when <co
 
 Declares a variable `<name>` and asks the user a question at runtime.
 
-- A question is **required** unless it has a `default` value. With a `default`, the user may skip the prompt (empty input) and the default literal is used in its place.
+- A question is **required** unless it has a `default` value. With a `default`, the user may skip the prompt (empty input) and the default value is used in its place.
+- The `default` accepts any expression — a literal, a previously declared variable, or a computed expression like `lower(trim(project_name))`. The expression is evaluated against the live environment when the user skips the prompt.
 - `options` restricts valid answers to a fixed set, presented as a numbered menu.
 - `when <condition>` only asks the question if the condition is true.
 - `ask` is **not allowed inside a `repeat` block**.
@@ -44,6 +45,9 @@ ask license "License?" string default "MIT"
 ask num_weeks "How many weeks?" int when use_tests
 ask format "Output format?" string options "pdf" "html" "latex" default "pdf"
 ask postgres_version "Postgres version?" int options 15 16 17
+
+ask project_name "Project name?" string
+ask slug "Slug?" string default lower(trim(project_name))
 ```
 
 ---

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -161,7 +161,7 @@ struct AskStmt {
     std::string name;                         ///< Variable name to bind the answer to.
     std::string prompt;                       ///< The prompt string shown to the user.
     VarType var_type;                         ///< Expected type of the answer.
-    std::optional<ExprPtr> default_value;     ///< Literal used when the user skips the prompt.
+    std::optional<ExprPtr> default_value;     ///< Expression evaluated when the user skips the prompt.
     std::vector<ExprPtr> options;             ///< Allowed literal values; empty means any.
     std::optional<ExprPtr> when_clause;       ///< Optional condition guarding the prompt.
     int line;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -235,13 +235,13 @@ StmtPtr Parser::parseAsk() {
 
     std::optional<ExprPtr> default_value;
     if (match(TokenType::DEFAULT)) {
-        if (!is_literal_start()) {
-            throw ParseError("expected literal after 'default'", current_.line,
-                             current_.column);
+        auto expr = parseExpression();
+        if (std::holds_alternative<StringLiteralExpr>(expr->data) ||
+            std::holds_alternative<IntegerLiteralExpr>(expr->data) ||
+            std::holds_alternative<BoolLiteralExpr>(expr->data)) {
+            ensure_type_match(*expr);
         }
-        auto lit = parse_literal();
-        ensure_type_match(*lit);
-        default_value = std::move(lit);
+        default_value = std::move(expr);
     }
 
     auto when_clause = parse_when_clause();

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -584,6 +584,42 @@ TEST(AskTest, EmptyInputUsesDefault) {
     EXPECT_EQ(std::get<std::string>(*env.lookup("license")), "MIT");
 }
 
+TEST(AskTest, ComputedDefaultUsesPriorAnswer) {
+    auto p = parse(R"(ask project_name "Project?" string
+ask slug "Slug?" string default lower(trim(project_name))
+)");
+    ScriptedPrompter prompter({"  Hello World  ", ""});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("slug")), "hello world");
+}
+
+TEST(AskTest, ComputedDefaultStillOverridable) {
+    auto p = parse(R"(ask project_name "Project?" string
+ask slug "Slug?" string default lower(project_name)
+)");
+    ScriptedPrompter prompter({"MyProj", "custom"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("slug")), "custom");
+}
+
+TEST(AskTest, ComputedDefaultStringConcat) {
+    auto p = parse(R"(ask base "Base?" string
+ask dir "Dir?" string default base + "-app"
+)");
+    ScriptedPrompter prompter({"foo", ""});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("dir")), "foo-app");
+}
+
+TEST(AskTest, ComputedDefaultIntArithmetic) {
+    auto p = parse(R"(ask weeks "Weeks?" int
+ask days "Days?" int default weeks * 7
+)");
+    ScriptedPrompter prompter({"3", ""});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("days")), 21);
+}
+
 TEST(AskTest, EmptyInputWithoutDefaultRePrompts) {
     auto p = parse(R"(ask name "Name?" string
 )");

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -346,6 +346,29 @@ TEST(ParserTest, AskDefaultWrongTypeLiteral) {
                  ParseError);
 }
 
+TEST(ParserTest, AskDefaultComputedExpression) {
+    auto stmt = parse_ask(
+        "ask slug \"Slug?\" string default lower(trim(project_name))\n");
+    auto& ask = std::get<AskStmt>(stmt->data);
+    ASSERT_TRUE(ask.default_value.has_value());
+    EXPECT_TRUE(std::holds_alternative<FunctionCallExpr>((*ask.default_value)->data));
+}
+
+TEST(ParserTest, AskDefaultVariableReference) {
+    auto stmt = parse_ask("ask alt \"Alt?\" string default project_name\n");
+    auto& ask = std::get<AskStmt>(stmt->data);
+    ASSERT_TRUE(ask.default_value.has_value());
+    auto& var = std::get<IdentifierExpr>((*ask.default_value)->data);
+    EXPECT_EQ(var.name, "project_name");
+}
+
+TEST(ParserTest, AskDefaultConcatenation) {
+    auto stmt = parse_ask("ask dir \"Dir?\" string default slug + \"-app\"\n");
+    auto& ask = std::get<AskStmt>(stmt->data);
+    ASSERT_TRUE(ask.default_value.has_value());
+    EXPECT_TRUE(std::holds_alternative<BinaryExpr>((*ask.default_value)->data));
+}
+
 TEST(ParserTest, AskOptionsWrongTypeLiteral) {
     EXPECT_THROW(parse_ask("ask version \"Version?\" int options 1 \"two\"\n"),
                  ParseError);


### PR DESCRIPTION
## Summary
Lets `ask` defaults reference earlier answers and computed expressions, not just literals.

## Changes
- Parser now accepts any expression after `default`. Literal-vs-type matching is preserved when the default happens to be a literal, so `ask count "?" int default "three"` still errors at parse time.
- Doc comment on `AskStmt::default_value` updated to reflect the broader contract.
- Validator and interpreter required no changes — `default_value` was already an `ExprPtr` walked by the validator and evaluated against the live environment by the interpreter.

## Examples now valid
```
ask project_name "Project name?" string
ask slug "Slug?" string default lower(trim(project_name))
ask dir "Dir?" string default slug + "-app"
ask days "Days?" int default weeks * 7
```

## Test plan
- All 324 (7 new) tests pass locally
- Parser tests cover identifier, function call, and binary expression defaults
- Interpreter tests cover the prior-answer chain, override-with-non-empty-input, string concat, and int arithmetic