### PR TITLE
feat(parser): allow hyphens in path expressions

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -76,16 +76,17 @@ let total_days = num_weeks * 7
 
 ### Path expressions
 
-Paths in `mkdir`, `file`, and `copy` are written as **path expressions** — an unquoted sequence of identifiers, slashes, dots, and `{expr}` interpolations.
+Paths in `mkdir`, `file`, and `copy` are written as **path expressions** — an unquoted sequence of identifiers, slashes, dots, hyphens, and `{expr}` interpolations.
 
 ```
 mkdir static/notes
 file static/notes/README.md content ""
 mkdir week_{n}
+mkdir my-project/pre-commit-hooks
 file src/main.cpp from base/main.cpp
 ```
 
-Paths containing spaces must be quoted: `mkdir "my notes"`.
+Hyphens are allowed inside a path but cannot start one — `mkdir -foo` would be ambiguous with the subtraction operator and is rejected. Paths containing spaces must be quoted: `mkdir "my notes"`.
 
 `{expr}` interpolation works directly in unquoted paths: `mkdir week_{n}`, `file {prefix}/README.md`.
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -159,6 +159,15 @@ PathExpr Parser::parse_path_expr() {
             Token tok = advance();
             start_buffer(tok.line, tok.column);
             buffer += tok.value;
+        } else if (check(TokenType::MINUS)) {
+            // Interior `-` is part of the path (e.g. `my-project`). Reject a
+            // leading `-` so `mkdir -foo` is not confused with subtraction.
+            if (buffer.empty() && path.segments.empty()) {
+                break;
+            }
+            start_buffer(current_.line, current_.column);
+            buffer += '-';
+            advance();
         } else if (check(TokenType::LBRACE)) {
             int line = current_.line;
             int col = current_.column;

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -705,6 +705,18 @@ TEST(MkdirTest, CreatesDirectory) {
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "my_project"));
 }
 
+TEST(MkdirTest, HyphenatedDirectoryName) {
+    TmpDir td;
+    auto p = parse(R"(mkdir my-project
+mkdir my-project/pre-commit-hooks
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "my-project"));
+    EXPECT_TRUE(std::filesystem::is_directory(
+        td.path() / "my-project" / "pre-commit-hooks"));
+}
+
 TEST(MkdirTest, MkdirP) {
     TmpDir td;
     auto p = parse(R"(mkdir a/b/c

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -687,6 +687,39 @@ TEST(ParserTest, MkdirAliasAndInterpolationInSamePath) {
     EXPECT_EQ(std::get<IdentifierExpr>(interp.expression->data).name, "n");
 }
 
+TEST(ParserTest, MkdirHyphenInPath) {
+    auto stmt = parse_mkdir("mkdir my-project\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "my-project");
+}
+
+TEST(ParserTest, MkdirMultipleHyphens) {
+    auto stmt = parse_mkdir("mkdir pre-commit-hooks\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "pre-commit-hooks");
+}
+
+TEST(ParserTest, MkdirHyphenAfterSlash) {
+    auto stmt = parse_mkdir("mkdir src/my-lib\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "src/my-lib");
+}
+
+TEST(ParserTest, MkdirHyphenAfterInterpolation) {
+    auto stmt = parse_mkdir("mkdir {slug}-app\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 2u);
+    EXPECT_TRUE(std::holds_alternative<PathInterp>(mk.path.segments[0]));
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "-app");
+}
+
+TEST(ParserTest, MkdirLeadingHyphenRejected) {
+    EXPECT_THROW(parse_mkdir("mkdir -foo\n"), ParseError);
+}
+
 TEST(ParserTest, MkdirQuotedPathWithSpaces) {
     auto stmt = parse_mkdir("mkdir \"my notes\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);


### PR DESCRIPTION
## Summary
Lets `mkdir`, `file`, and `copy` accept paths like `my-project` and `pre-commit-hooks` without quoting.

## Changes
- Path coalescer now treats `MINUS` as a literal character when it appears interior to a path. A leading `-` is still rejected so `mkdir -foo` does not collide with subtraction at the statement level.
- Hyphens compose with everything else paths already allow — slashes, dots, integers, and `{expr}` interpolation. So `src/my-lib`, `{slug}-app`, and `pre-commit-hooks` all parse.
- Docs updated to mention hyphens and the leading-`-` restriction.

## Examples now valid
```
mkdir my-project
mkdir src/my-lib
mkdir pre-commit-hooks
mkdir {slug}-app
```

## Test plan
- All 330 (6 new) tests pass locally
- Parser tests cover plain hyphens, multiple hyphens, hyphens after a slash, hyphens after `{expr}` interpolation, and the leading-hyphen rejection
- Interpreter test confirms a hyphenated directory is actually created on disk