### PR TITLE
feat(interpreter): richer ask prompts

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -24,17 +24,17 @@ Declares a variable `<name>` and asks the user a question at runtime.
 
 - A question is **required** unless it has a `default` value. With a `default`, the user may skip the prompt (empty input) and the default value is used in its place.
 - The `default` accepts any expression — a literal, a previously declared variable, or a computed expression like `lower(trim(project_name))`. The expression is evaluated against the live environment when the user skips the prompt.
-- `options` restricts valid answers to a fixed set, presented as a numbered menu.
+- `options` restricts valid answers to a fixed set, presented as a numbered menu. The user may type either the literal value or its 1-based number.
 - `when <condition>` only asks the question if the condition is true.
 - `ask` is **not allowed inside a `repeat` block**.
 
 **Types:**
 
-| Type     | Description                        |
-|----------|------------------------------------|
-| `string` | Arbitrary text input               |
-| `bool`   | `true` / `false` (yes/no prompt)   |
-| `int`    | Integer input                      |
+| Type     | Description                                              |
+|----------|----------------------------------------------------------|
+| `string` | Arbitrary text input                                     |
+| `bool`   | Accepts `y`, `yes`, `true` and `n`, `no`, `false` (case-insensitive). The hint shows `[Y/n]` for `default true`, `[y/N]` for `default false`, `[y/n]` otherwise |
+| `int`    | Integer input                                            |
 
 **Examples:**
 

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -90,6 +90,8 @@ struct PromptRequest {
     std::vector<std::string> options;         ///< Stringified allowed answers; empty means any.
     std::optional<std::string> default_value; ///< Stringified default; empty means required.
     std::optional<std::string> previous_error;///< Set on retry; describes why the prior answer was rejected.
+    int question_index{0};                    ///< 1-based position of this question among presented ones; 0 suppresses the counter.
+    int question_total{0};                    ///< Total static `ask` statements in the program; 0 suppresses the counter.
 };
 
 /**

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -2,6 +2,7 @@
 #define SPUDPLATE_INTERPRETER_H
 
 #include <cstdint>
+#include <iosfwd>
 #include <optional>
 #include <stdexcept>
 #include <string>
@@ -76,6 +77,22 @@ class Environment {
 };
 
 /**
+ * @brief Structured description of an `ask` prompt for the prompter to render.
+ *
+ * The interpreter populates this struct from an `AskStmt` and the live
+ * environment, then hands it to the prompter. Rendering — colour, layout,
+ * `[Y/n]` hints, numbered option menus, rejection feedback — is the
+ * prompter's responsibility.
+ */
+struct PromptRequest {
+    std::string text;                         ///< The question text from the `.spud` source.
+    VarType type;                             ///< Expected answer type.
+    std::vector<std::string> options;         ///< Stringified allowed answers; empty means any.
+    std::optional<std::string> default_value; ///< Stringified default; empty means required.
+    std::optional<std::string> previous_error;///< Set on retry; describes why the prior answer was rejected.
+};
+
+/**
  * @brief Abstract source of user input for `ask` statements.
  */
 class Prompter {
@@ -83,21 +100,33 @@ class Prompter {
     virtual ~Prompter() = default;
 
     /**
-     * @brief Display `message` and obtain the user's raw answer string.
+     * @brief Display the prompt described by `req` and return the user's raw answer.
      *
-     * The interpreter parses the returned string into a `Value` according to
-     * the question's `type` and re-prompts on invalid input — implementations
-     * just deliver one raw line per call.
+     * The interpreter parses the returned string, validates it against type
+     * and options, and on rejection calls back with `previous_error` set.
+     * Implementations deliver one raw line per call.
      */
-    virtual std::string prompt(const std::string& message, VarType type) = 0;
+    virtual std::string prompt(const PromptRequest& req) = 0;
 };
 
 /**
- * @brief Production prompter: writes to stdout and reads a line from stdin.
+ * @brief Production prompter: writes to a stream and reads a line from another.
+ *
+ * Defaults to `std::cin` and `std::cout` with auto-detected colour support
+ * (suppressed when `NO_COLOR` is set or stdout is not a tty). The
+ * stream-injecting constructor exists for tests.
  */
 class StdinPrompter : public Prompter {
   public:
-    std::string prompt(const std::string& message, VarType type) override;
+    StdinPrompter();
+    StdinPrompter(std::istream& in, std::ostream& out, bool use_colour);
+
+    std::string prompt(const PromptRequest& req) override;
+
+  private:
+    std::istream& in_;
+    std::ostream& out_;
+    bool use_colour_;
 };
 
 /**
@@ -112,11 +141,17 @@ class ScriptedPrompter : public Prompter {
     explicit ScriptedPrompter(std::vector<std::string> answers)
         : answers_(std::move(answers)) {}
 
-    std::string prompt(const std::string& message, VarType type) override;
+    std::string prompt(const PromptRequest& req) override;
+
+    /** @brief Most recent request seen, for assertions on rendering inputs. */
+    [[nodiscard]] const std::optional<PromptRequest>& last_request() const {
+        return last_;
+    }
 
   private:
     std::vector<std::string> answers_;
     std::size_t index_{0};
+    std::optional<PromptRequest> last_;
 };
 
 /**

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -694,32 +694,33 @@ void render_request(std::ostream& out, const PromptRequest& req,
         out << wrap("> " + *req.previous_error, kRed, use_colour) << '\n';
     }
 
+    bool has_options = !req.options.empty();
+    bool is_bool_inline = req.type == VarType::Bool && !has_options;
+
     out << wrap(req.text, kBold, use_colour);
 
-    if (req.type == VarType::Bool && req.options.empty()) {
-        out << ' ' << wrap(bool_hint(req.default_value), kDim, use_colour);
-    }
-
-    if (!req.options.empty()) {
+    if (has_options) {
         out << '\n';
         for (std::size_t i = 0; i < req.options.size(); ++i) {
-            std::string entry =
-                "  [" + std::to_string(i + 1) + "] " + req.options[i];
-            out << wrap(entry, kDim, use_colour) << '\n';
+            out << "  [" << (i + 1) << "] " << req.options[i] << '\n';
         }
+        if (req.default_value.has_value()) {
+            out << wrap("[default: " + *req.default_value + "]", kDim,
+                        use_colour)
+                << '\n';
+        }
+        out << wrap("> ", kCyan, use_colour) << std::flush;
+        return;
     }
 
-    if (req.default_value.has_value()) {
-        std::string hint;
-        if (req.type == VarType::Bool && req.options.empty()) {
-            // [Y/n] already encodes the default — skip the explicit hint.
-        } else {
-            hint = " [default: " + *req.default_value + "]";
-            out << wrap(hint, kDim, use_colour);
-        }
+    if (is_bool_inline) {
+        out << ' ' << bool_hint(req.default_value);
+    } else if (req.default_value.has_value()) {
+        out << ' '
+            << wrap("[default: " + *req.default_value + "]", kDim, use_colour);
     }
 
-    out << '\n' << wrap("> ", kCyan, use_colour) << std::flush;
+    out << ": " << wrap("> ", kCyan, use_colour) << std::flush;
 }
 
 }  // namespace

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -306,7 +306,8 @@ const char* expected_message(VarType type) {
     return "invalid input";
 }
 
-void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter) {
+void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter,
+                 int question_index, int question_total) {
     if (!when_passes(stmt.when_clause, env)) {
         return;
     }
@@ -331,6 +332,8 @@ void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter) {
                 ? std::optional<std::string>{value_to_string(*default_value)}
                 : std::nullopt,
         .previous_error = std::nullopt,
+        .question_index = question_index,
+        .question_total = question_total,
     };
 
     while (true) {
@@ -453,12 +456,15 @@ class Interpreter {
   public:
     explicit Interpreter(Prompter& prompter) : prompter_(prompter) {}
 
+    void set_ask_total(int total) { ask_total_ = total; }
+
     void execute(const Stmt& stmt) {
         std::visit(
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, AskStmt>) {
-                    execute_ask(s, env_, prompter_);
+                    int index = ask_total_ > 0 ? ++ask_index_ : 0;
+                    execute_ask(s, env_, prompter_, index, ask_total_);
                 } else if constexpr (std::is_same_v<T, LetStmt>) {
                     Value v = evaluate_expr(*s.value, env_);
                     env_.declare(s.name, std::move(v));
@@ -644,9 +650,22 @@ class Interpreter {
     AliasMap alias_map_;
     std::vector<PendingOp> pending_;
     std::unordered_set<std::string> created_during_run_;
+    int ask_total_{0};
+    int ask_index_{0};
 };
 
+int count_ask_statements(const Program& program) {
+    int total = 0;
+    for (const auto& stmt : program.statements) {
+        if (std::holds_alternative<AskStmt>(stmt->data)) {
+            ++total;
+        }
+    }
+    return total;
+}
+
 void run_program(const Program& program, Interpreter& interp) {
+    interp.set_ask_total(count_ask_statements(program));
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }
@@ -669,7 +688,7 @@ constexpr const char* kReset = "\x1b[0m";
 constexpr const char* kBold = "\x1b[1m";
 constexpr const char* kDim = "\x1b[2m";
 constexpr const char* kRed = "\x1b[31m";
-constexpr const char* kCyan = "\x1b[36m";
+constexpr const char* kYellow = "\x1b[33m";
 
 std::string wrap(const std::string& s, const char* code, bool on) {
     if (!on) {
@@ -691,25 +710,33 @@ std::string bool_hint(const std::optional<std::string>& default_value) {
 void render_request(std::ostream& out, const PromptRequest& req,
                     bool use_colour) {
     if (req.previous_error.has_value()) {
-        out << wrap("> " + *req.previous_error, kRed, use_colour) << '\n';
+        out << wrap("! " + *req.previous_error, kRed, use_colour) << '\n';
     }
 
     bool has_options = !req.options.empty();
     bool is_bool_inline = req.type == VarType::Bool && !has_options;
+    std::string colon = wrap(":", kYellow, use_colour);
+
+    if (req.question_total > 0 && req.question_index > 0) {
+        std::string counter = "(" + std::to_string(req.question_index) + "/" +
+                              std::to_string(req.question_total) + ") ";
+        out << wrap(counter, kYellow, use_colour);
+    }
 
     out << wrap(req.text, kBold, use_colour);
 
     if (has_options) {
         out << '\n';
         for (std::size_t i = 0; i < req.options.size(); ++i) {
-            out << "  [" << (i + 1) << "] " << req.options[i] << '\n';
+            std::string marker = "[" + std::to_string(i + 1) + "]";
+            out << "  " << wrap(marker, kYellow, use_colour) << ' '
+                << req.options[i] << '\n';
         }
         if (req.default_value.has_value()) {
             out << wrap("[default: " + *req.default_value + "]", kDim,
-                        use_colour)
-                << '\n';
+                        use_colour);
         }
-        out << wrap("> ", kCyan, use_colour) << std::flush;
+        out << colon << ' ' << std::flush;
         return;
     }
 
@@ -720,7 +747,7 @@ void render_request(std::ostream& out, const PromptRequest& req,
             << wrap("[default: " + *req.default_value + "]", kDim, use_colour);
     }
 
-    out << ": " << wrap("> ", kCyan, use_colour) << std::flush;
+    out << colon << ' ' << std::flush;
 }
 
 }  // namespace

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -686,9 +686,11 @@ bool detect_colour_support() {
 
 constexpr const char* kReset = "\x1b[0m";
 constexpr const char* kBold = "\x1b[1m";
-constexpr const char* kDim = "\x1b[2m";
+constexpr const char* kDim = "\x1b[38;5;250m";  // light grey
 constexpr const char* kRed = "\x1b[31m";
-constexpr const char* kYellow = "\x1b[33m";
+// Single source of truth for the accent colour used on counter, option
+// numbers, and the input colon. Swap this one constant to retheme.
+constexpr const char* kAccent = "\x1b[38;5;226m";  // pure bright yellow
 
 std::string wrap(const std::string& s, const char* code, bool on) {
     if (!on) {
@@ -715,12 +717,12 @@ void render_request(std::ostream& out, const PromptRequest& req,
 
     bool has_options = !req.options.empty();
     bool is_bool_inline = req.type == VarType::Bool && !has_options;
-    std::string colon = wrap(":", kYellow, use_colour);
+    std::string colon = wrap(":", kAccent, use_colour);
 
     if (req.question_total > 0 && req.question_index > 0) {
         std::string counter = "(" + std::to_string(req.question_index) + "/" +
                               std::to_string(req.question_total) + ") ";
-        out << wrap(counter, kYellow, use_colour);
+        out << wrap(counter, kAccent, use_colour);
     }
 
     out << wrap(req.text, kBold, use_colour);
@@ -729,11 +731,11 @@ void render_request(std::ostream& out, const PromptRequest& req,
         out << '\n';
         for (std::size_t i = 0; i < req.options.size(); ++i) {
             std::string marker = "[" + std::to_string(i + 1) + "]";
-            out << "  " << wrap(marker, kYellow, use_colour) << ' '
+            out << "  " << wrap(marker, kAccent, use_colour) << ' '
                 << req.options[i] << '\n';
         }
         if (req.default_value.has_value()) {
-            out << wrap("[default: " + *req.default_value + "]", kDim,
+            out << wrap("[" + *req.default_value + "]", kDim,
                         use_colour);
         }
         out << colon << ' ' << std::flush;
@@ -741,10 +743,11 @@ void render_request(std::ostream& out, const PromptRequest& req,
     }
 
     if (is_bool_inline) {
-        out << ' ' << bool_hint(req.default_value);
+        out << ' '
+            << wrap(bool_hint(req.default_value), kDim, use_colour);
     } else if (req.default_value.has_value()) {
         out << ' '
-            << wrap("[default: " + *req.default_value + "]", kDim, use_colour);
+            << wrap("[" + *req.default_value + "]", kDim, use_colour);
     }
 
     out << colon << ' ' << std::flush;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -17,6 +17,8 @@
 #include <utility>
 #include <variant>
 
+#include <unistd.h>
+
 #include "spudplate/ast.h"
 #include "spudplate/token.h"
 
@@ -246,10 +248,10 @@ std::optional<Value> parse_answer(const std::string& raw, VarType type) {
     }
     if (type == VarType::Bool) {
         std::string lc = ascii_lower(raw);
-        if (lc == "true") {
+        if (lc == "true" || lc == "yes" || lc == "y") {
             return Value{true};
         }
-        if (lc == "false") {
+        if (lc == "false" || lc == "no" || lc == "n") {
             return Value{false};
         }
         return std::nullopt;
@@ -270,6 +272,40 @@ std::optional<Value> parse_answer(const std::string& raw, VarType type) {
     }
 }
 
+// If raw parses as a 1-based index into options, return the corresponding
+// option string. Otherwise return raw unchanged.
+std::string apply_option_index(const std::string& raw,
+                               const std::vector<std::string>& options) {
+    if (options.empty() || raw.empty()) {
+        return raw;
+    }
+    for (char c : raw) {
+        if (std::isdigit(static_cast<unsigned char>(c)) == 0) {
+            return raw;
+        }
+    }
+    try {
+        std::size_t idx = std::stoul(raw);
+        if (idx >= 1 && idx <= options.size()) {
+            return options[idx - 1];
+        }
+    } catch (...) {
+    }
+    return raw;
+}
+
+const char* expected_message(VarType type) {
+    switch (type) {
+        case VarType::Bool:
+            return "expected yes or no";
+        case VarType::Int:
+            return "expected an integer";
+        case VarType::String:
+            return "invalid input";
+    }
+    return "invalid input";
+}
+
 void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter) {
     if (!when_passes(stmt.when_clause, env)) {
         return;
@@ -286,32 +322,31 @@ void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter) {
         option_strings.push_back(value_to_string(evaluate_expr(*opt, env)));
     }
 
-    std::string message = stmt.prompt;
-    if (!option_strings.empty()) {
-        message += " [";
-        for (std::size_t i = 0; i < option_strings.size(); ++i) {
-            if (i != 0) {
-                message += ", ";
-            }
-            message += option_strings[i];
-        }
-        message += "]";
-    }
-    if (default_value.has_value()) {
-        message += " (default: " + value_to_string(*default_value) + ")";
-    }
+    PromptRequest req{
+        .text = stmt.prompt,
+        .type = stmt.var_type,
+        .options = option_strings,
+        .default_value =
+            default_value.has_value()
+                ? std::optional<std::string>{value_to_string(*default_value)}
+                : std::nullopt,
+        .previous_error = std::nullopt,
+    };
 
     while (true) {
-        std::string raw = prompter.prompt(message, stmt.var_type);
+        std::string raw = prompter.prompt(req);
         if (raw.empty()) {
             if (default_value.has_value()) {
                 env.declare(stmt.name, *default_value);
                 return;
             }
-            continue;  // required question, re-prompt
+            req.previous_error = "this question is required";
+            continue;
         }
-        auto parsed = parse_answer(raw, stmt.var_type);
+        std::string mapped = apply_option_index(raw, option_strings);
+        auto parsed = parse_answer(mapped, stmt.var_type);
         if (!parsed.has_value()) {
+            req.previous_error = expected_message(stmt.var_type);
             continue;
         }
         if (!option_strings.empty()) {
@@ -324,6 +359,7 @@ void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter) {
                 }
             }
             if (!match) {
+                req.previous_error = "not one of the listed options";
                 continue;
             }
         }
@@ -619,16 +655,90 @@ void run_program(const Program& program, Interpreter& interp) {
 
 }  // namespace
 
-std::string StdinPrompter::prompt(const std::string& message,
-                                  VarType /*type*/) {
-    std::cout << message << ": " << std::flush;
+namespace {
+
+bool detect_colour_support() {
+    const char* nc = std::getenv("NO_COLOR");
+    if (nc != nullptr && nc[0] != '\0') {
+        return false;
+    }
+    return ::isatty(::fileno(stdout)) != 0;
+}
+
+constexpr const char* kReset = "\x1b[0m";
+constexpr const char* kBold = "\x1b[1m";
+constexpr const char* kDim = "\x1b[2m";
+constexpr const char* kRed = "\x1b[31m";
+constexpr const char* kCyan = "\x1b[36m";
+
+std::string wrap(const std::string& s, const char* code, bool on) {
+    if (!on) {
+        return s;
+    }
+    return std::string{code} + s + kReset;
+}
+
+std::string bool_hint(const std::optional<std::string>& default_value) {
+    if (!default_value.has_value()) {
+        return "[y/n]";
+    }
+    if (*default_value == "true") {
+        return "[Y/n]";
+    }
+    return "[y/N]";
+}
+
+void render_request(std::ostream& out, const PromptRequest& req,
+                    bool use_colour) {
+    if (req.previous_error.has_value()) {
+        out << wrap("> " + *req.previous_error, kRed, use_colour) << '\n';
+    }
+
+    out << wrap(req.text, kBold, use_colour);
+
+    if (req.type == VarType::Bool && req.options.empty()) {
+        out << ' ' << wrap(bool_hint(req.default_value), kDim, use_colour);
+    }
+
+    if (!req.options.empty()) {
+        out << '\n';
+        for (std::size_t i = 0; i < req.options.size(); ++i) {
+            std::string entry =
+                "  [" + std::to_string(i + 1) + "] " + req.options[i];
+            out << wrap(entry, kDim, use_colour) << '\n';
+        }
+    }
+
+    if (req.default_value.has_value()) {
+        std::string hint;
+        if (req.type == VarType::Bool && req.options.empty()) {
+            // [Y/n] already encodes the default — skip the explicit hint.
+        } else {
+            hint = " [default: " + *req.default_value + "]";
+            out << wrap(hint, kDim, use_colour);
+        }
+    }
+
+    out << '\n' << wrap("> ", kCyan, use_colour) << std::flush;
+}
+
+}  // namespace
+
+StdinPrompter::StdinPrompter()
+    : in_(std::cin), out_(std::cout), use_colour_(detect_colour_support()) {}
+
+StdinPrompter::StdinPrompter(std::istream& in, std::ostream& out, bool use_colour)
+    : in_(in), out_(out), use_colour_(use_colour) {}
+
+std::string StdinPrompter::prompt(const PromptRequest& req) {
+    render_request(out_, req, use_colour_);
     std::string line;
-    std::getline(std::cin, line);
+    std::getline(in_, line);
     return line;
 }
 
-std::string ScriptedPrompter::prompt(const std::string& /*message*/,
-                                     VarType /*type*/) {
+std::string ScriptedPrompter::prompt(const PromptRequest& req) {
+    last_ = req;
     if (index_ >= answers_.size()) {
         throw std::logic_error("ScriptedPrompter exhausted");
     }

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -823,7 +823,39 @@ TEST(StdinPrompterTest, PlainStringPromptIsSingleLine) {
         .previous_error = std::nullopt,
     };
     EXPECT_EQ(p.prompt(req), "MyProj");
-    EXPECT_EQ(out.str(), "What is the project name?: > ");
+    EXPECT_EQ(out.str(), "What is the project name?: ");
+}
+
+TEST(StdinPrompterTest, CounterPrefixWhenSet) {
+    std::stringstream in("x\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Project name?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+        .question_index = 1,
+        .question_total = 3,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str(), "(1/3) Project name?: ");
+}
+
+TEST(StdinPrompterTest, CounterSuppressedWhenZero) {
+    std::stringstream in("x\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Name?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str().find("("), std::string::npos);
 }
 
 TEST(StdinPrompterTest, BoolDefaultTrueShowsCapitalY) {
@@ -889,8 +921,7 @@ TEST(StdinPrompterTest, OptionsRenderAsNumberedMenu) {
               "  [1] pdf\n"
               "  [2] html\n"
               "  [3] latex\n"
-              "[default: pdf]\n"
-              "> ");
+              "[default: pdf]: ");
 }
 
 TEST(StdinPrompterTest, BoolInlineHasColon) {
@@ -905,7 +936,7 @@ TEST(StdinPrompterTest, BoolInlineHasColon) {
         .previous_error = std::nullopt,
     };
     p.prompt(req);
-    EXPECT_EQ(out.str(), "Use git? [Y/n]: > ");
+    EXPECT_EQ(out.str(), "Use git? [Y/n]: ");
 }
 
 TEST(StdinPrompterTest, StringWithDefaultIsSingleLine) {
@@ -920,7 +951,7 @@ TEST(StdinPrompterTest, StringWithDefaultIsSingleLine) {
         .previous_error = std::nullopt,
     };
     p.prompt(req);
-    EXPECT_EQ(out.str(), "License? [default: MIT]: > ");
+    EXPECT_EQ(out.str(), "License? [default: MIT]: ");
 }
 
 TEST(StdinPrompterTest, PreviousErrorPrintedAbovePrompt) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -871,7 +871,7 @@ TEST(StdinPrompterTest, BoolDefaultTrueShowsCapitalY) {
     };
     p.prompt(req);
     EXPECT_NE(out.str().find("[Y/n]"), std::string::npos);
-    EXPECT_EQ(out.str().find("[default:"), std::string::npos);
+    EXPECT_EQ(out.str().find("[true]"), std::string::npos);
 }
 
 TEST(StdinPrompterTest, BoolDefaultFalseShowsCapitalN) {
@@ -921,7 +921,7 @@ TEST(StdinPrompterTest, OptionsRenderAsNumberedMenu) {
               "  [1] pdf\n"
               "  [2] html\n"
               "  [3] latex\n"
-              "[default: pdf]: ");
+              "[pdf]: ");
 }
 
 TEST(StdinPrompterTest, BoolInlineHasColon) {
@@ -951,7 +951,7 @@ TEST(StdinPrompterTest, StringWithDefaultIsSingleLine) {
         .previous_error = std::nullopt,
     };
     p.prompt(req);
-    EXPECT_EQ(out.str(), "License? [default: MIT]: ");
+    EXPECT_EQ(out.str(), "License? [MIT]: ");
 }
 
 TEST(StdinPrompterTest, PreviousErrorPrintedAbovePrompt) {
@@ -1016,7 +1016,7 @@ TEST(StdinPrompterTest, DefaultRenderedWithBrackets) {
         .previous_error = std::nullopt,
     };
     p.prompt(req);
-    EXPECT_NE(out.str().find("[default: MIT]"), std::string::npos);
+    EXPECT_NE(out.str().find("[MIT]"), std::string::npos);
 }
 
 TEST(LetTest, ArithmeticOverPriorAsk) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -811,7 +811,7 @@ TEST(AskTest, OffOptionPropagatesError) {
 
 // --- StdinPrompter rendering ---
 
-TEST(StdinPrompterTest, PlainStringPromptHasMarker) {
+TEST(StdinPrompterTest, PlainStringPromptIsSingleLine) {
     std::stringstream in("MyProj\n");
     std::stringstream out;
     StdinPrompter p(in, out, /*use_colour=*/false);
@@ -823,9 +823,7 @@ TEST(StdinPrompterTest, PlainStringPromptHasMarker) {
         .previous_error = std::nullopt,
     };
     EXPECT_EQ(p.prompt(req), "MyProj");
-    std::string s = out.str();
-    EXPECT_NE(s.find("What is the project name?"), std::string::npos);
-    EXPECT_NE(s.find("> "), std::string::npos);
+    EXPECT_EQ(out.str(), "What is the project name?: > ");
 }
 
 TEST(StdinPrompterTest, BoolDefaultTrueShowsCapitalY) {
@@ -886,11 +884,43 @@ TEST(StdinPrompterTest, OptionsRenderAsNumberedMenu) {
         .previous_error = std::nullopt,
     };
     p.prompt(req);
-    std::string s = out.str();
-    EXPECT_NE(s.find("[1] pdf"), std::string::npos);
-    EXPECT_NE(s.find("[2] html"), std::string::npos);
-    EXPECT_NE(s.find("[3] latex"), std::string::npos);
-    EXPECT_NE(s.find("[default: pdf]"), std::string::npos);
+    EXPECT_EQ(out.str(),
+              "Format?\n"
+              "  [1] pdf\n"
+              "  [2] html\n"
+              "  [3] latex\n"
+              "[default: pdf]\n"
+              "> ");
+}
+
+TEST(StdinPrompterTest, BoolInlineHasColon) {
+    std::stringstream in("\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Use git?",
+        .type = VarType::Bool,
+        .options = {},
+        .default_value = "true",
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str(), "Use git? [Y/n]: > ");
+}
+
+TEST(StdinPrompterTest, StringWithDefaultIsSingleLine) {
+    std::stringstream in("\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "License?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = "MIT",
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str(), "License? [default: MIT]: > ");
 }
 
 TEST(StdinPrompterTest, PreviousErrorPrintedAbovePrompt) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -39,10 +39,12 @@ using spudplate::Lexer;
 using spudplate::Parser;
 using spudplate::Program;
 using spudplate::Prompter;
+using spudplate::PromptRequest;
 using spudplate::run;
 using spudplate::run_for_tests;
 using spudplate::RuntimeError;
 using spudplate::ScriptedPrompter;
+using spudplate::StdinPrompter;
 using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
 using spudplate::UnaryExpr;
@@ -56,8 +58,7 @@ namespace {
 // statement throws "not yet supported" before the prompter is reached.
 class NullPrompter : public Prompter {
   public:
-    std::string prompt(const std::string& /*message*/,
-                       VarType /*type*/) override {
+    std::string prompt(const PromptRequest& /*req*/) override {
         throw std::logic_error("NullPrompter should not be called");
     }
 };
@@ -734,6 +735,227 @@ TEST(AskTest, BadIntRetries) {
     ScriptedPrompter prompter({"abc", "7"});
     Environment env = run_for_tests(p, prompter);
     EXPECT_EQ(std::get<std::int64_t>(*env.lookup("n")), 7);
+}
+
+TEST(AskTest, BoolAcceptsYesNo) {
+    auto p = parse(R"(ask flag "Enable?" bool
+)");
+    ScriptedPrompter prompter({"yes"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_TRUE(std::get<bool>(*env.lookup("flag")));
+}
+
+TEST(AskTest, BoolAcceptsShortYN) {
+    auto p = parse(R"(ask flag "Enable?" bool
+)");
+    ScriptedPrompter prompter({"n"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_FALSE(std::get<bool>(*env.lookup("flag")));
+}
+
+TEST(AskTest, NumberedOptionIndexResolves) {
+    auto p = parse(R"(ask format "Format?" string options "pdf" "html" "latex"
+)");
+    ScriptedPrompter prompter({"2"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("format")), "html");
+}
+
+TEST(AskTest, NumberedIndexOnIntOptions) {
+    auto p = parse(R"(ask v "PG?" int options 15 16 17
+)");
+    ScriptedPrompter prompter({"3"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("v")), 17);
+}
+
+TEST(AskTest, OutOfRangeIndexFallsThrough) {
+    // "5" is outside the index range so it parses as the int 5, which is not
+    // in the options list — re-prompt rather than crash.
+    auto p = parse(R"(ask v "PG?" int options 15 16 17
+)");
+    ScriptedPrompter prompter({"5", "16"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::int64_t>(*env.lookup("v")), 16);
+}
+
+TEST(AskTest, RejectionPropagatesPreviousError) {
+    auto p = parse(R"(ask flag "Enable?" bool
+)");
+    ScriptedPrompter prompter({"maybe", "true"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request().has_value());
+    ASSERT_TRUE(prompter.last_request()->previous_error.has_value());
+    EXPECT_EQ(*prompter.last_request()->previous_error, "expected yes or no");
+}
+
+TEST(AskTest, EmptyOnRequiredQuestionPropagatesError) {
+    auto p = parse(R"(ask name "Name?" string
+)");
+    ScriptedPrompter prompter({"", "x"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request()->previous_error.has_value());
+    EXPECT_EQ(*prompter.last_request()->previous_error,
+              "this question is required");
+}
+
+TEST(AskTest, OffOptionPropagatesError) {
+    auto p = parse(R"(ask format "Format?" string options "pdf" "html"
+)");
+    ScriptedPrompter prompter({"foo", "pdf"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request()->previous_error.has_value());
+    EXPECT_EQ(*prompter.last_request()->previous_error,
+              "not one of the listed options");
+}
+
+// --- StdinPrompter rendering ---
+
+TEST(StdinPrompterTest, PlainStringPromptHasMarker) {
+    std::stringstream in("MyProj\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, /*use_colour=*/false);
+    PromptRequest req{
+        .text = "What is the project name?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+    };
+    EXPECT_EQ(p.prompt(req), "MyProj");
+    std::string s = out.str();
+    EXPECT_NE(s.find("What is the project name?"), std::string::npos);
+    EXPECT_NE(s.find("> "), std::string::npos);
+}
+
+TEST(StdinPrompterTest, BoolDefaultTrueShowsCapitalY) {
+    std::stringstream in("\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Use git?",
+        .type = VarType::Bool,
+        .options = {},
+        .default_value = "true",
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_NE(out.str().find("[Y/n]"), std::string::npos);
+    EXPECT_EQ(out.str().find("[default:"), std::string::npos);
+}
+
+TEST(StdinPrompterTest, BoolDefaultFalseShowsCapitalN) {
+    std::stringstream in("\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Use git?",
+        .type = VarType::Bool,
+        .options = {},
+        .default_value = "false",
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_NE(out.str().find("[y/N]"), std::string::npos);
+}
+
+TEST(StdinPrompterTest, BoolNoDefaultShowsLowercaseHint) {
+    std::stringstream in("yes\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Use git?",
+        .type = VarType::Bool,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_NE(out.str().find("[y/n]"), std::string::npos);
+}
+
+TEST(StdinPrompterTest, OptionsRenderAsNumberedMenu) {
+    std::stringstream in("1\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Format?",
+        .type = VarType::String,
+        .options = {"pdf", "html", "latex"},
+        .default_value = "pdf",
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    std::string s = out.str();
+    EXPECT_NE(s.find("[1] pdf"), std::string::npos);
+    EXPECT_NE(s.find("[2] html"), std::string::npos);
+    EXPECT_NE(s.find("[3] latex"), std::string::npos);
+    EXPECT_NE(s.find("[default: pdf]"), std::string::npos);
+}
+
+TEST(StdinPrompterTest, PreviousErrorPrintedAbovePrompt) {
+    std::stringstream in("\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Format?",
+        .type = VarType::String,
+        .options = {"pdf"},
+        .default_value = std::nullopt,
+        .previous_error = "not one of the listed options",
+    };
+    p.prompt(req);
+    std::string s = out.str();
+    auto err_pos = s.find("not one of the listed options");
+    auto prompt_pos = s.find("Format?");
+    ASSERT_NE(err_pos, std::string::npos);
+    ASSERT_NE(prompt_pos, std::string::npos);
+    EXPECT_LT(err_pos, prompt_pos);
+}
+
+TEST(StdinPrompterTest, ColourEnabledEmitsAnsiCodes) {
+    std::stringstream in("x\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, /*use_colour=*/true);
+    PromptRequest req{
+        .text = "Name?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_NE(out.str().find("\x1b["), std::string::npos);
+}
+
+TEST(StdinPrompterTest, ColourDisabledEmitsNoAnsi) {
+    std::stringstream in("x\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Name?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str().find("\x1b["), std::string::npos);
+}
+
+TEST(StdinPrompterTest, DefaultRenderedWithBrackets) {
+    std::stringstream in("\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "License?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = "MIT",
+        .previous_error = std::nullopt,
+    };
+    p.prompt(req);
+    EXPECT_NE(out.str().find("[default: MIT]"), std::string::npos);
 }
 
 TEST(LetTest, ArithmeticOverPriorAsk) {


### PR DESCRIPTION
## Summary
Replaces the bare `<message>:` prompt with a richer, friendlier UI: colour, a question counter, numbered option menus, `[Y/n]` hints, compact default rendering, and rejection feedback.

## Changes
- The prompter now receives a structured `PromptRequest` (text, type, options, default, previous error, question index, question total) and is responsible for rendering. The interpreter still owns the validation loop.
- `bool` prompts accept `y`, `yes`, `true` and `n`, `no`, `false` (case-insensitive). The hint shows `[Y/n]` for `default true`, `[y/N]` for `default false`, `[y/n]` otherwise.
- Options render as a numbered menu and the user can type either the literal value or its 1-based number.
- On rejection (bad type, off-options, empty when required), a short red error line prints above the re-prompt instead of silently looping.
- Single-line layout for non-multi-option prompts: `(N/M) Text? [hint]: ` with a yellow accent counter and colon, no trailing reply marker. Multi-option prompts list options on their own lines.
- Defaults are rendered as `[X]` (just the value, no `default:` prefix) and shown in light grey.
- `[Y/n]` hints render in the same light grey.
- A single accent constant drives the counter prefix, option numbers, and the input colon, so retheming is one line.
- Colour uses ANSI escapes; auto-suppressed when `NO_COLOR` is set or stdout is not a tty. The `StdinPrompter` has a stream-injecting constructor for tests.

## Test plan
- All 363 tests pass locally (27 new since base)
- `ScriptedPrompter` records the most recent request so tests can assert that previous-error context is propagated on retry
- `StdinPrompter` rendering tests use `std::stringstream` to verify menu layout, `[Y/n]` shape, error placement, default rendering, the counter prefix, and the colour/no-colour switch
- Manual run of a sample template confirms the new layout