### PR TITLE
feat: allow ask inside repeat

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -26,7 +26,7 @@ Declares a variable `<name>` and asks the user a question at runtime.
 - The `default` accepts any expression — a literal, a previously declared variable, or a computed expression like `lower(trim(project_name))`. The expression is evaluated against the live environment when the user skips the prompt.
 - `options` restricts valid answers to a fixed set, presented as a numbered menu. The user may type either the literal value or its 1-based number.
 - `when <condition>` only asks the question if the condition is true.
-- `ask` is **not allowed inside a `repeat` block**.
+- `ask` is allowed inside `repeat`. Each iteration prompts afresh; the binding lives only for that iteration. Prompts inside `repeat` are indented by 2 spaces per nesting level and are not counted in the `(N/M)` progress indicator (since the iteration count is dynamic). Shadowing rules still apply — an `ask` cannot reuse a name visible from the surrounding scope.
 
 **Types:**
 
@@ -204,7 +204,7 @@ repeat <int_var> as <iter> [when <condition>]
 end
 ```
 
-Repeats the nested block `<int_var>` times. The loop variable `<iter>` holds the current iteration index (0-based). Nested `repeat` blocks and all action statements are allowed; **`ask` is not**.
+Repeats the nested block `<int_var>` times. The loop variable `<iter>` holds the current iteration index (0-based). Nested `repeat` blocks, `ask`, and all action statements are allowed inside the body.
 
 The optional `when` clause skips the entire loop if the condition is false.
 

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -92,6 +92,7 @@ struct PromptRequest {
     std::optional<std::string> previous_error;///< Set on retry; describes why the prior answer was rejected.
     int question_index{0};                    ///< 1-based position of this question among presented ones; 0 suppresses the counter.
     int question_total{0};                    ///< Total static `ask` statements in the program; 0 suppresses the counter.
+    int indent_level{0};                      ///< Number of nested `repeat` blocks above this prompt; renders as 2 spaces per level.
 };
 
 /**

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -307,7 +307,7 @@ const char* expected_message(VarType type) {
 }
 
 void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter,
-                 int question_index, int question_total) {
+                 int question_index, int question_total, int indent_level) {
     if (!when_passes(stmt.when_clause, env)) {
         return;
     }
@@ -334,6 +334,7 @@ void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter,
         .previous_error = std::nullopt,
         .question_index = question_index,
         .question_total = question_total,
+        .indent_level = indent_level,
     };
 
     while (true) {
@@ -463,8 +464,11 @@ class Interpreter {
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, AskStmt>) {
-                    int index = ask_total_ > 0 ? ++ask_index_ : 0;
-                    execute_ask(s, env_, prompter_, index, ask_total_);
+                    bool show_counter = ask_total_ > 0 && repeat_depth_ == 0;
+                    int index = show_counter ? ++ask_index_ : 0;
+                    int total = show_counter ? ask_total_ : 0;
+                    execute_ask(s, env_, prompter_, index, total,
+                                repeat_depth_);
                 } else if constexpr (std::is_same_v<T, LetStmt>) {
                     Value v = evaluate_expr(*s.value, env_);
                     env_.declare(s.name, std::move(v));
@@ -521,6 +525,7 @@ class Interpreter {
 
             env_.push();
             env_.declare(s.iterator_var, Value{i});
+            ++repeat_depth_;
             try {
                 for (const auto& stmt : s.body) {
                     execute(*stmt);
@@ -534,6 +539,7 @@ class Interpreter {
                         ++it;
                     }
                 }
+                --repeat_depth_;
                 env_.pop();
                 throw;
             }
@@ -545,6 +551,7 @@ class Interpreter {
                     ++it;
                 }
             }
+            --repeat_depth_;
             env_.pop();
         }
     }
@@ -652,6 +659,7 @@ class Interpreter {
     std::unordered_set<std::string> created_during_run_;
     int ask_total_{0};
     int ask_index_{0};
+    int repeat_depth_{0};
 };
 
 int count_ask_statements(const Program& program) {
@@ -711,13 +719,18 @@ std::string bool_hint(const std::optional<std::string>& default_value) {
 
 void render_request(std::ostream& out, const PromptRequest& req,
                     bool use_colour) {
+    std::string indent(static_cast<std::size_t>(req.indent_level) * 2, ' ');
+
     if (req.previous_error.has_value()) {
-        out << wrap("! " + *req.previous_error, kRed, use_colour) << '\n';
+        out << indent
+            << wrap("! " + *req.previous_error, kRed, use_colour) << '\n';
     }
 
     bool has_options = !req.options.empty();
     bool is_bool_inline = req.type == VarType::Bool && !has_options;
     std::string colon = wrap(":", kAccent, use_colour);
+
+    out << indent;
 
     if (req.question_total > 0 && req.question_index > 0) {
         std::string counter = "(" + std::to_string(req.question_index) + "/" +
@@ -731,9 +744,10 @@ void render_request(std::ostream& out, const PromptRequest& req,
         out << '\n';
         for (std::size_t i = 0; i < req.options.size(); ++i) {
             std::string marker = "[" + std::to_string(i + 1) + "]";
-            out << "  " << wrap(marker, kAccent, use_colour) << ' '
+            out << indent << "  " << wrap(marker, kAccent, use_colour) << ' '
                 << req.options[i] << '\n';
         }
+        out << indent;
         if (req.default_value.has_value()) {
             out << wrap("[" + *req.default_value + "]", kDim,
                         use_colour);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -228,10 +228,6 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
         [&](const auto& s) {
             using T = std::decay_t<decltype(s)>;
             if constexpr (std::is_same_v<T, AskStmt>) {
-                if (scope.inside_repeat()) {
-                    throw SemanticError("'ask' not allowed inside 'repeat'", s.line,
-                                        s.column);
-                }
                 if (s.default_value.has_value()) {
                     walk_expr(**s.default_value, scope);
                 }
@@ -239,6 +235,8 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
                     walk_expr(*opt, scope);
                 }
                 walk_optional_expr(s.when_clause, scope);
+                check_shadowing(s.name, s.line, s.column, scope);
+                scope.declare(s.name);
                 ctx.type_map[s.name] = s.var_type;
             } else if constexpr (std::is_same_v<T, LetStmt>) {
                 walk_expr(*s.value, scope);

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -98,8 +98,8 @@ TEST(CliTest, ParseErrorExitsTwo) {
 TEST(CliTest, SemanticErrorExitsThree) {
     TmpDir td;
     auto file = td.path() / "bad.spud";
-    // `ask` inside `repeat` is a semantic error, not a parse error.
-    write_file(file, "let n = 1\nrepeat n as i\n  ask x \"X?\" string\nend\n");
+    // Shadowing a name inside `repeat` is a semantic error, not a parse error.
+    write_file(file, "let x = 1\nlet n = 1\nrepeat n as i\n  let x = 2\nend\n");
     Argv args({"spudplate", "run", file.string()});
     std::stringstream out;
     std::stringstream err;

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -799,6 +799,66 @@ TEST(AskTest, EmptyOnRequiredQuestionPropagatesError) {
               "this question is required");
 }
 
+TEST(AskTest, AskInsideRepeatRunsPerIteration) {
+    TmpDir td;
+    auto p = parse(R"(ask n "Count?" int
+repeat n as i
+  ask name "Module name?" string
+  mkdir {name}
+end
+)");
+    ScriptedPrompter prompter({"3", "alpha", "beta", "gamma"});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "alpha"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "beta"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "gamma"));
+}
+
+TEST(AskTest, AskInsideRepeatGetsNoCounter) {
+    auto p = parse(R"(ask n "Count?" int
+repeat n as i
+  ask name "Module?" string
+end
+)");
+    ScriptedPrompter prompter({"1", "x"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request().has_value());
+    EXPECT_EQ(prompter.last_request()->question_index, 0);
+    EXPECT_EQ(prompter.last_request()->question_total, 0);
+    EXPECT_EQ(prompter.last_request()->indent_level, 1);
+}
+
+TEST(AskTest, NestedAskGetsDoubleIndent) {
+    auto p = parse(R"(ask n "Outer count?" int
+ask m "Inner count?" int
+repeat n as i
+  repeat m as j
+    ask name "Inner?" string
+  end
+end
+)");
+    ScriptedPrompter prompter({"1", "1", "leaf"});
+    run_for_tests(p, prompter);
+    EXPECT_EQ(prompter.last_request()->indent_level, 2);
+}
+
+TEST(AskTest, TopLevelCounterUnaffectedByRepeatAsks) {
+    // Three top-level asks. The ask inside repeat must not increment the
+    // running counter.
+    auto p = parse(R"(ask a "A?" string
+ask n "Count?" int
+repeat n as i
+  ask in_loop "In?" string
+end
+ask z "Z?" string
+)");
+    ScriptedPrompter prompter({"av", "1", "loopv", "zv"});
+    run_for_tests(p, prompter);
+    // Last presented prompt is `ask z` — top-level, should be (3/3).
+    EXPECT_EQ(prompter.last_request()->question_index, 3);
+    EXPECT_EQ(prompter.last_request()->question_total, 3);
+}
+
 TEST(AskTest, OffOptionPropagatesError) {
     auto p = parse(R"(ask format "Format?" string options "pdf" "html"
 )");
@@ -841,6 +901,60 @@ TEST(StdinPrompterTest, CounterPrefixWhenSet) {
     };
     p.prompt(req);
     EXPECT_EQ(out.str(), "(1/3) Project name?: ");
+}
+
+TEST(StdinPrompterTest, IndentLevelShiftsPrompt) {
+    std::stringstream in("x\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Module name?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+        .question_index = 0,
+        .question_total = 0,
+        .indent_level = 1,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str(), "  Module name?: ");
+}
+
+TEST(StdinPrompterTest, NestedIndentDoublesShift) {
+    std::stringstream in("x\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Inner?",
+        .type = VarType::String,
+        .options = {},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+        .indent_level = 2,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str(), "    Inner?: ");
+}
+
+TEST(StdinPrompterTest, IndentAppliesToOptions) {
+    std::stringstream in("1\n");
+    std::stringstream out;
+    StdinPrompter p(in, out, false);
+    PromptRequest req{
+        .text = "Format?",
+        .type = VarType::String,
+        .options = {"pdf", "html"},
+        .default_value = std::nullopt,
+        .previous_error = std::nullopt,
+        .indent_level = 1,
+    };
+    p.prompt(req);
+    EXPECT_EQ(out.str(),
+              "  Format?\n"
+              "    [1] pdf\n"
+              "    [2] html\n"
+              "  : ");
 }
 
 TEST(StdinPrompterTest, CounterSuppressedWhenZero) {

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -116,36 +116,44 @@ TEST(ValidatorTest, EmptyRepeatBodyValidates) {
     EXPECT_NO_THROW(validate(program));
 }
 
-TEST(ValidatorTest, AskInsideSingleRepeatIsError) {
+TEST(ValidatorTest, AskInsideSingleRepeatValidates) {
     auto program = parse(
         "ask n \"Count?\" int\n"
         "repeat n as i\n"
         "  ask use_extra \"Extra?\" bool\n"
         "end\n");
-    try {
-        validate(program);
-        FAIL() << "expected SemanticError";
-    } catch (const SemanticError& e) {
-        // The offending ask is on line 3 (ask n ... is line 1, repeat is line 2).
-        EXPECT_EQ(e.line(), 3);
-    }
+    EXPECT_NO_THROW(validate(program));
 }
 
-TEST(ValidatorTest, AskInsideNestedRepeatPointsAtAskLine) {
+TEST(ValidatorTest, AskInsideNestedRepeatValidates) {
     auto program = parse(
-        "ask n \"Count?\" int\n"       // line 1
-        "ask m \"Count?\" int\n"       // line 2
-        "repeat n as i\n"              // line 3 (outer)
-        "  repeat m as j\n"            // line 4 (inner)
-        "    ask bad \"bad?\" bool\n"  // line 5 — the offender
+        "ask n \"Count?\" int\n"
+        "ask m \"Count?\" int\n"
+        "repeat n as i\n"
+        "  repeat m as j\n"
+        "    ask name \"name?\" string\n"
         "  end\n"
         "end\n");
-    try {
-        validate(program);
-        FAIL() << "expected SemanticError";
-    } catch (const SemanticError& e) {
-        EXPECT_EQ(e.line(), 5);
-    }
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, AskInRepeatShadowingOuterIsError) {
+    auto program = parse(
+        "ask name \"Name?\" string\n"
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  ask name \"Module name?\" string\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AskInRepeatShadowingIteratorIsError) {
+    auto program = parse(
+        "ask n \"Count?\" int\n"
+        "repeat n as i\n"
+        "  ask i \"i?\" int\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
 }
 
 TEST(ValidatorTest, RepeatBodyWithNonAskStatementsValidates) {


### PR DESCRIPTION
## Summary
Lifts the validator's hard error on `ask` inside `repeat`. Each iteration prompts afresh and deferred writes still preserve the "questions before any disk write" guarantee.

## Changes
- Validator no longer rejects `ask` inside `repeat`. The shadowing rule that already applies to `let` and `as` now also applies to `ask`, an `ask` cannot reuse a name visible from the surrounding scope, including a `repeat` iterator.
- Prompts inside a `repeat` body skip the `(N/M)` counter (iteration count is dynamic) and indent by 2 spaces per nesting level. Top-level prompts are unaffected.
- `PromptRequest` gains an `indent_level` field so the prompter renders the indent without re-deriving it.
- Docs updated to describe the new rule and the indent behaviour.

## Examples now valid
```
ask num "How many modules?" int
repeat num as i
  ask name "Module name?" string
  mkdir {name}
end
```

## Test plan
- All 372 (7 new) tests pass locally
- Tests cover end-to-end ask-in-repeat with directory creation, nested ask getting double indent, the top-level counter ignoring in-loop prompts, and shadowing of outer names and iterators
- Manual run confirms in-loop prompts indent and stay uncounted while top-level ones still show `(N/M)`