### PR TITLE
feat(interpreter): asset pipeline

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -299,11 +299,10 @@ use_tests
 
 ## Variable Interpolation
 
-`{expr}` interpolation is available in:
+Interpolation appears in two places with slightly different grammars:
 
-- Path expressions (`mkdir week_{n}`, `file {prefix}/README.md`)
-- `content` expressions (via string concatenation)
-- Contents of **`from` source files** and files copied by `copy` (unless `verbatim` is used)
+- **Path expressions** and `content` values support full `{expr}` interpolation (`mkdir week_{n}`, `content "v" + version`).
+- **`from` source files** and files copied by `copy` support only bare `{ident}` substitution — no function calls, no arithmetic, no string concatenation. Use `verbatim` to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
 
 ---
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -63,15 +63,97 @@ struct PendingFile {
     int column;
 };
 
-using PendingOp = std::variant<PendingMkdir, PendingFile>;
+// Verifies a path exists as a directory at flush time. Used by `copy` to
+// enforce its "destination must already exist" rule, where "exist" means
+// either pre-run or queued by an earlier `mkdir`/`mkdir from` op.
+struct PendingCheckDir {
+    std::string path;
+    int line;
+    int column;
+};
 
-// Until Part 4 lands, the Prompter forward-declared in the header has no
-// concrete implementation. The skeleton interpreter never reaches a code
-// path that calls it (every statement throws "not yet supported" first).
-void unsupported(const std::string& stmt_name, int line, int column) {
-    throw RuntimeError("statement '" + stmt_name +
-                           "' not yet supported in this build",
-                       line, column);
+using PendingOp = std::variant<PendingMkdir, PendingFile, PendingCheckDir>;
+
+// Read a regular file (cwd-relative) into a string. The position arguments
+// point at the *.spud* statement that triggered the read so error messages
+// surface there rather than at some unhelpful internal site.
+std::string read_source_file(const std::string& path, int line, int column) {
+    std::error_code ec;
+    auto status = std::filesystem::status(path, ec);
+    if (ec) {
+        throw RuntimeError("cannot stat source '" + path + "': " + ec.message(),
+                           line, column);
+    }
+    if (!std::filesystem::exists(status)) {
+        throw RuntimeError("source file '" + path + "' does not exist", line,
+                           column);
+    }
+    if (!std::filesystem::is_regular_file(status)) {
+        throw RuntimeError("source '" + path + "' is not a regular file", line,
+                           column);
+    }
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        throw RuntimeError("cannot open source '" + path + "' for reading", line,
+                           column);
+    }
+    std::string content((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    return content;
+}
+
+// Substitute `{ident}` occurrences in `content` with the stringified value
+// of `ident` looked up in `env`. The grammar is deliberately narrow for v1
+// — only bare identifiers are accepted; arbitrary expressions are not. Use
+// `verbatim` to copy file contents byte-for-byte without substitution.
+std::string interpolate_content(const std::string& content,
+                                const Environment& env, int line, int column) {
+    std::string out;
+    out.reserve(content.size());
+    std::size_t i = 0;
+    while (i < content.size()) {
+        char c = content[i];
+        if (c != '{') {
+            out.push_back(c);
+            ++i;
+            continue;
+        }
+        std::size_t close = content.find('}', i + 1);
+        if (close == std::string::npos) {
+            throw RuntimeError(
+                "unclosed '{' in source content; use 'verbatim' to suppress "
+                "interpolation",
+                line, column);
+        }
+        std::string name = content.substr(i + 1, close - i - 1);
+        if (name.empty()) {
+            throw RuntimeError("empty '{}' in source content", line, column);
+        }
+        auto is_ident_char = [](char ch) {
+            return std::isalnum(static_cast<unsigned char>(ch)) != 0 ||
+                   ch == '_';
+        };
+        bool head_ok = !name.empty() &&
+                       (std::isalpha(static_cast<unsigned char>(name[0])) != 0 ||
+                        name[0] == '_');
+        bool body_ok = std::all_of(name.begin(), name.end(), is_ident_char);
+        if (!head_ok || !body_ok) {
+            throw RuntimeError(
+                "source content interpolation only supports bare identifiers; "
+                "got '{" +
+                    name + "}' (use 'verbatim' to copy braces literally)",
+                line, column);
+        }
+        auto v = env.lookup(name);
+        if (!v.has_value()) {
+            throw RuntimeError(
+                "undefined variable '" + name + "' in source content", line,
+                column);
+        }
+        out += value_to_string(*v);
+        i = close + 1;
+    }
+    return out;
 }
 
 // Lower-case ASCII copy used for case-insensitive bool parsing.
@@ -479,9 +561,11 @@ class Interpreter {
                 } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                     execute_repeat(s);
                 } else if constexpr (std::is_same_v<T, CopyStmt>) {
-                    unsupported("copy", s.line, s.column);
+                    execute_copy(s);
                 } else if constexpr (std::is_same_v<T, IncludeStmt>) {
-                    unsupported("include", s.line, s.column);
+                    throw RuntimeError(
+                        "statement 'include' not yet supported in this build",
+                        s.line, s.column);
                 }
             },
             stmt.data);
@@ -560,19 +644,81 @@ class Interpreter {
         if (!when_passes(s.when_clause, env_)) {
             return;
         }
-        if (s.from_source.has_value() || s.verbatim) {
-            throw RuntimeError(
-                "'mkdir from' / 'verbatim' not yet supported in this build",
-                s.line, s.column);
-        }
-        std::string path_str = evaluate_path(s.path, env_, alias_map_);
+        std::string dst = evaluate_path(s.path, env_, alias_map_);
         if (s.alias.has_value()) {
-            alias_map_[*s.alias] = path_str;
+            alias_map_[*s.alias] = dst;
         }
-        pending_.push_back(PendingMkdir{.path = std::move(path_str),
+        pending_.push_back(PendingMkdir{.path = dst,
                                         .mode = s.mode,
                                         .line = s.line,
                                         .column = s.column});
+        if (s.from_source.has_value()) {
+            std::string src = evaluate_path(*s.from_source, env_, alias_map_);
+            walk_source_into_pending(src, dst, s.verbatim, s.line, s.column);
+        }
+    }
+
+    void execute_copy(const CopyStmt& s) {
+        if (!when_passes(s.when_clause, env_)) {
+            return;
+        }
+        std::string dst = evaluate_path(s.destination, env_, alias_map_);
+        std::string src = evaluate_path(s.source, env_, alias_map_);
+        pending_.push_back(
+            PendingCheckDir{.path = dst, .line = s.line, .column = s.column});
+        walk_source_into_pending(src, dst, s.verbatim, s.line, s.column);
+    }
+
+    // Walks a source directory and pushes pending mkdir/file ops mirroring
+    // its tree under `dst_root`. recursive_directory_iterator visits parents
+    // before children, so the queued ops naturally satisfy create-parent-
+    // first ordering at flush time. Symlinks and other non-regular entries
+    // are skipped — v1 has no defined behaviour for them.
+    void walk_source_into_pending(const std::string& src,
+                                  const std::string& dst_root, bool verbatim,
+                                  int line, int column) {
+        namespace fs = std::filesystem;
+        std::error_code ec;
+        auto src_status = fs::status(src, ec);
+        if (ec) {
+            throw RuntimeError(
+                "cannot stat source '" + src + "': " + ec.message(), line,
+                column);
+        }
+        if (!fs::exists(src_status)) {
+            throw RuntimeError("source directory '" + src + "' does not exist",
+                               line, column);
+        }
+        if (!fs::is_directory(src_status)) {
+            throw RuntimeError("source '" + src + "' is not a directory", line,
+                               column);
+        }
+        fs::path src_path{src};
+        fs::path dst_path{dst_root};
+        for (auto it = fs::recursive_directory_iterator(src_path);
+             it != fs::recursive_directory_iterator{}; ++it) {
+            auto rel = fs::relative(it->path(), src_path);
+            auto target = (dst_path / rel).string();
+            if (it->is_directory()) {
+                pending_.push_back(PendingMkdir{.path = std::move(target),
+                                                .mode = std::nullopt,
+                                                .line = line,
+                                                .column = column});
+            } else if (it->is_regular_file()) {
+                std::string content =
+                    read_source_file(it->path().string(), line, column);
+                if (!verbatim) {
+                    content = interpolate_content(content, env_, line, column);
+                }
+                pending_.push_back(PendingFile{.path = std::move(target),
+                                               .content = std::move(content),
+                                               .append = false,
+                                               .mode = std::nullopt,
+                                               .line = line,
+                                               .column = column});
+            }
+            // symlinks, fifos, etc. are silently skipped for v1
+        }
     }
 
     void check_pre_existing(const std::string& path, int line, int col) {
@@ -602,14 +748,18 @@ class Interpreter {
         if (!when_passes(s.when_clause, env_)) {
             return;
         }
-        // Reject `from` first so a thrown statement leaves no stale alias.
+        std::string content;
         if (std::holds_alternative<FileFromSource>(s.source)) {
-            throw RuntimeError("'file from' not yet supported in this build",
-                               s.line, s.column);
+            const auto& fs = std::get<FileFromSource>(s.source);
+            std::string src_path = evaluate_path(fs.path, env_, alias_map_);
+            content = read_source_file(src_path, s.line, s.column);
+            if (!fs.verbatim) {
+                content = interpolate_content(content, env_, s.line, s.column);
+            }
+        } else {
+            const auto& content_src = std::get<FileContentSource>(s.source);
+            content = value_to_string(evaluate_expr(*content_src.value, env_));
         }
-        const auto& content_src = std::get<FileContentSource>(s.source);
-        std::string content =
-            value_to_string(evaluate_expr(*content_src.value, env_));
 
         std::string path_str = evaluate_path(s.path, env_, alias_map_);
         if (s.alias.has_value()) {
@@ -622,6 +772,15 @@ class Interpreter {
                                        .mode = s.mode,
                                        .line = s.line,
                                        .column = s.column});
+    }
+
+    void run_op(const PendingCheckDir& op) const {
+        if (!std::filesystem::is_directory(op.path)) {
+            throw RuntimeError(
+                "destination '" + op.path +
+                    "' does not exist (use 'mkdir from' to create it)",
+                op.line, op.column);
+        }
     }
 
     void run_op(const PendingFile& op) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -163,6 +163,13 @@ class TmpDir {
     std::filesystem::path prev_;
 };
 
+std::string read_file(const std::filesystem::path& p) {
+    std::ifstream in(p);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
 }  // namespace
 
 // --- RuntimeError shape ---
@@ -236,19 +243,7 @@ TEST(InterpreterTest, EmptyProgramRunsCleanly) {
     EXPECT_NO_THROW(run(empty, prompter));
 }
 
-// --- Every statement type throws "not yet supported" ---
-
-TEST(InterpreterTest, CopyThrowsNotYetSupported) {
-    auto program = parse(R"(copy src into dst
-)");
-    NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("copy"), std::string::npos);
-    }
-}
+// --- Statement types still pending an implementation ---
 
 TEST(InterpreterTest, IncludeThrowsNotYetSupported) {
     auto program = parse(R"(include claude_setup
@@ -1239,26 +1234,83 @@ TEST(MkdirTest, RejectsPreExistingPath) {
     EXPECT_THROW(run(p, prompter), RuntimeError);
 }
 
-TEST(MkdirTest, FromIsNotYetSupported) {
+TEST(MkdirTest, FromMissingSourceThrows) {
     TmpDir td;
     auto p = parse(R"(mkdir foo from base
 )");
     ScriptedPrompter prompter({});
-    try {
-        run(p, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("not yet supported"),
-                  std::string::npos);
-    }
+    EXPECT_THROW(run(p, prompter), RuntimeError);
     // The `from` rejection happens during execution, before flush — nothing
     // was written.
     EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
 }
 
+TEST(MkdirTest, FromCopiesSourceTree) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src" / "sub");
+    {
+        std::ofstream(td.path() / "src" / "top.txt") << "top";
+    }
+    {
+        std::ofstream(td.path() / "src" / "sub" / "nested.txt") << "nested";
+    }
+    auto p = parse(R"(mkdir dst from src
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "dst"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "dst" / "sub"));
+    EXPECT_EQ(read_file(td.path() / "dst" / "top.txt"), "top");
+    EXPECT_EQ(read_file(td.path() / "dst" / "sub" / "nested.txt"), "nested");
+}
+
+TEST(MkdirTest, FromInterpolatesFileContents) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "readme.md") << "# {name}";
+    }
+    auto p = parse(R"(let name = "spudplate"
+mkdir dst from src
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "readme.md"), "# spudplate");
+}
+
+TEST(MkdirTest, FromVerbatimSuppressesInterpolation) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "raw.txt") << "{name} stays";
+    }
+    auto p = parse(R"(let name = "ignored"
+mkdir dst from src verbatim
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "raw.txt"), "{name} stays");
+}
+
+TEST(MkdirTest, FromBindsAlias) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "a.txt") << "x";
+    }
+    auto p = parse(R"(mkdir dst from src as out
+file out/extra.txt content "extra"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "a.txt"), "x");
+    EXPECT_EQ(read_file(td.path() / "dst" / "extra.txt"), "extra");
+}
+
 TEST(MkdirTest, DeferredWriteAtomicityOnPreFlushFailure) {
     TmpDir td;
-    // First mkdir queues; second throws on `from` before any flush runs.
+    // First mkdir queues; second's `from` walk throws on missing source
+    // before any flush runs, so neither directory ends up on disk.
     auto p = parse(R"(mkdir a
 mkdir b from base
 )");
@@ -1298,17 +1350,6 @@ TEST(EvalPathTest, MixedSegments) {
 }
 
 // --- File content + flush (Part 6) ---
-
-namespace {
-
-std::string read_file(const std::filesystem::path& p) {
-    std::ifstream in(p);
-    std::stringstream ss;
-    ss << in.rdbuf();
-    return ss.str();
-}
-
-}  // namespace
 
 TEST(FileTest, ContentLiteral) {
     TmpDir td;
@@ -1420,19 +1461,92 @@ TEST(FileTest, RejectsPreExistingFile) {
     EXPECT_THROW(run(p, prompter), RuntimeError);
 }
 
-TEST(FileTest, FromIsNotYetSupported) {
+TEST(FileTest, FromCopiesSourceContents) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt from src
+    {
+        std::ofstream out(td.path() / "src.txt");
+        out << "from-source content";
+    }
+    auto p = parse(R"(file foo.txt from src.txt
 )");
     ScriptedPrompter prompter({});
-    try {
-        run(p, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("not yet supported"),
-                  std::string::npos);
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "from-source content");
+}
+
+TEST(FileTest, FromInterpolatesIdentifiers) {
+    TmpDir td;
+    {
+        std::ofstream out(td.path() / "src.txt");
+        out << "hello, {who}!";
     }
+    auto p = parse(R"(let who = "world"
+file foo.txt from src.txt
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "hello, world!");
+}
+
+TEST(FileTest, FromVerbatimSkipsInterpolation) {
+    TmpDir td;
+    {
+        std::ofstream out(td.path() / "src.txt");
+        out << "literal {braces}";
+    }
+    auto p = parse(R"(file foo.txt from src.txt verbatim
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "literal {braces}");
+}
+
+TEST(FileTest, FromUnknownIdentInterpolationThrows) {
+    TmpDir td;
+    {
+        std::ofstream out(td.path() / "src.txt");
+        out << "{missing}";
+    }
+    auto p = parse(R"(file foo.txt from src.txt
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
     EXPECT_FALSE(std::filesystem::exists(td.path() / "foo.txt"));
+}
+
+TEST(FileTest, FromMissingSourceThrows) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt from nope.txt
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo.txt"));
+}
+
+TEST(FileTest, FromAppendsToFile) {
+    TmpDir td;
+    {
+        std::ofstream out(td.path() / "src.txt");
+        out << "B";
+    }
+    auto p = parse(R"(file foo.txt content "A"
+file foo.txt append from src.txt
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "AB");
+}
+
+TEST(FileTest, FromUnclosedBraceThrows) {
+    TmpDir td;
+    {
+        std::ofstream out(td.path() / "src.txt");
+        out << "oops {name";
+    }
+    auto p = parse(R"(file foo.txt from src.txt
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
 }
 
 TEST(FileTest, WhenFalseSkips) {
@@ -1443,6 +1557,126 @@ file foo.txt content "hi" when use_f
     ScriptedPrompter prompter({"false"});
     run(p, prompter);
     EXPECT_FALSE(std::filesystem::exists(td.path() / "foo.txt"));
+}
+
+// --- Copy ---
+
+TEST(CopyTest, MergesIntoExistingDir) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "a.txt") << "a";
+    }
+    auto p = parse(R"(mkdir dst
+copy src into dst
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "a.txt"), "a");
+}
+
+TEST(CopyTest, MissingDestinationFailsAtFlush) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "a.txt") << "a";
+    }
+    auto p = parse(R"(copy src into dst
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "dst"));
+}
+
+TEST(CopyTest, MissingSourceThrows) {
+    TmpDir td;
+    auto p = parse(R"(mkdir dst
+copy nope into dst
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "dst"));
+}
+
+TEST(CopyTest, MergesMultipleSources) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src1");
+    std::filesystem::create_directories(td.path() / "src2");
+    {
+        std::ofstream(td.path() / "src1" / "a.txt") << "a";
+    }
+    {
+        std::ofstream(td.path() / "src2" / "b.txt") << "b";
+    }
+    auto p = parse(R"(mkdir dst
+copy src1 into dst
+copy src2 into dst
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "a.txt"), "a");
+    EXPECT_EQ(read_file(td.path() / "dst" / "b.txt"), "b");
+}
+
+TEST(CopyTest, RecursesIntoSubdirectories) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src" / "deep");
+    {
+        std::ofstream(td.path() / "src" / "deep" / "x.txt") << "x";
+    }
+    auto p = parse(R"(mkdir dst
+copy src into dst
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "dst" / "deep"));
+    EXPECT_EQ(read_file(td.path() / "dst" / "deep" / "x.txt"), "x");
+}
+
+TEST(CopyTest, InterpolatesByDefault) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "f.txt") << "hello {who}";
+    }
+    auto p = parse(R"(let who = "you"
+mkdir dst
+copy src into dst
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "f.txt"), "hello you");
+}
+
+TEST(CopyTest, VerbatimSuppressesInterpolation) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "f.txt") << "{who}";
+    }
+    auto p = parse(R"(let who = "ignored"
+mkdir dst
+copy src into dst verbatim
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "dst" / "f.txt"), "{who}");
+}
+
+TEST(CopyTest, WhenFalseSkips) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "f.txt") << "x";
+    }
+    auto p = parse(R"(ask flag "Copy?" bool
+mkdir dst
+copy src into dst when flag
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "dst"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "dst" / "f.txt"));
 }
 
 // --- Repeat (Part 7) ---


### PR DESCRIPTION
## Summary
Wires up the four asset-pipeline statements that previously errored with "not yet supported": `file from`, `mkdir from`, `copy`, and the `verbatim` modifier on each. Source paths resolve relative to the current working directory.

## Changes
- `file from <src>` reads the source file from disk and writes it to the destination, applying `{ident}` substitution from the live environment unless `verbatim`. Append mode and the alias clause work as before.
- `mkdir from <src>` creates the destination directory and recursively walks the source, queuing one `mkdir` per subdirectory and one `file` per regular entry beneath it. Subdirectory permissions fall back to the system default; `mode` only applies to the top-level directory.
- `copy <src> into <dst>` queues a flush-time check that the destination directory exists, then walks the source the same way. The check fires after any earlier `mkdir` ops have run, so destinations created earlier in the same `.spud` file are accepted; otherwise the run errors before any flush has touched the queued destination contents.
- Source-content interpolation is restricted to bare `{ident}` substitution. Function calls or arithmetic inside content braces are a runtime error; use `verbatim` to copy braces literally. Path expressions and `content` values still take full `{expr}` interpolation.
- Symlinks and other non-regular entries inside source directories are silently skipped.

## Test plan
- All 389 (17 new) tests pass locally
- Tests cover: file-from happy path, identifier interpolation, `verbatim` suppression, missing source, append after a content write, unclosed brace, unknown identifier; mkdir-from with nested directories, content interpolation, `verbatim`, alias binding, deferred-write atomicity when the source walk fails; copy into an existing dir, copy missing destination, copy missing source, two-source merge, recursive copy, default interpolation, `verbatim`, and `when false` skip
- Manual run scaffolds a project with a templated README, a nested copied directory, and a runtime-bound alias