### PR TITLE
feat(interpreter): dry run preview

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -338,6 +338,24 @@ Combined with deferred file operations, this means a run either fully succeeds o
 
 ---
 
+## Dry-run preview
+
+`spudplate run --dry-run <file.spud>` runs every prompt and queues every action exactly like a real run, but instead of writing to disk it prints a tree of every path that would have been created:
+
+```
+Would create:
+└── cool-thing/
+    ├── README.md
+    ├── src/
+    │   └── main.cpp
+    └── tests/
+        └── test_main.cpp
+```
+
+Append-mode files appear once with a trailing `(append)` annotation. `mkdir from` and `copy` expand into the individual files they would create. `copy` destination-existence checks are skipped — dry-run cannot validate them without touching the filesystem. Conditional statements whose `when` clause evaluated to false are pruned from the queue, so the tree only shows what would actually happen.
+
+---
+
 ## Full Example
 
 ```

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -354,6 +354,8 @@ Would create:
 
 Append-mode files appear once with a trailing `(append)` annotation. `mkdir from` and `copy` expand into the individual files they would create. `copy` destination-existence checks are skipped — dry-run cannot validate them without touching the filesystem. Conditional statements whose `when` clause evaluated to false are pruned from the queue, so the tree only shows what would actually happen.
 
+Tree glyphs default to UTF-8 box-drawing characters (`├──`/`└──`/`│`). On terminals where the locale environment (`LC_ALL`, `LC_CTYPE`, or `LANG`) does not advertise UTF-8 support, spudplate falls back to plain ASCII (`|--`/`\\--`/`|`). The detection follows POSIX precedence — the first set variable wins.
+
 ---
 
 ## Full Example

--- a/include/spudplate/cli.h
+++ b/include/spudplate/cli.h
@@ -11,7 +11,9 @@ namespace spudplate {
  * @brief Command-line entry point factored out of `main` for testability.
  *
  * Recognised invocations:
- *   spudplate run <file.spud>     run a template (exit codes below)
+ *   spudplate run <file.spud>             run a template (exit codes below)
+ *   spudplate run --dry-run <file.spud>   prompt as normal, then print a
+ *                                         tree of would-be writes to stdout
  *
  * Exit codes:
  *   0 — success

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -183,10 +183,25 @@ Environment run_for_tests(const Program& program, Prompter& prompter);
  * been created to `out`. `copy` destination-existence checks are skipped
  * (they would always fail in dry-run since nothing was written).
  *
+ * Tree glyphs default to UTF-8 box drawing (`├──`/`└──`/`│  `). Pass
+ * `ascii_only = true` to fall back to plain ASCII (`|--`/`\\--`/`|  `) for
+ * terminals that don't render the box-drawing characters cleanly.
+ *
  * Throws `RuntimeError` on any failure that `run` would also throw before
  * the flush step.
  */
-void dry_run(const Program& program, Prompter& prompter, std::ostream& out);
+void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
+             bool ascii_only = false);
+
+/**
+ * @brief Heuristic check: does the current environment look UTF-8 capable?
+ *
+ * Looks at `LC_ALL`, `LC_CTYPE`, `LANG` (in that order) and returns true if
+ * any contains "UTF-8" or "utf8" (case-insensitive). Used by the CLI to
+ * decide whether to render the dry-run tree with UTF-8 box-drawing glyphs
+ * or fall back to ASCII.
+ */
+bool locale_is_utf8();
 
 /**
  * @brief Evaluate an expression against an environment.

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -175,6 +175,20 @@ void run(const Program& program, Prompter& prompter);
 Environment run_for_tests(const Program& program, Prompter& prompter);
 
 /**
+ * @brief Run a program without touching the filesystem.
+ *
+ * Walks the program exactly like `run` — same prompts, same expression
+ * evaluation, same alias bindings — but instead of flushing the deferred
+ * write queue prints a `Would create:` tree of every path that would have
+ * been created to `out`. `copy` destination-existence checks are skipped
+ * (they would always fail in dry-run since nothing was written).
+ *
+ * Throws `RuntimeError` on any failure that `run` would also throw before
+ * the flush step.
+ */
+void dry_run(const Program& program, Prompter& prompter, std::ostream& out);
+
+/**
  * @brief Evaluate an expression against an environment.
  *
  * Throws `RuntimeError` on type mismatch, unknown identifier, division by

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -81,7 +81,7 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
 
     try {
         if (dry_run_mode) {
-            dry_run(program, prompter, out);
+            dry_run(program, prompter, out, /*ascii_only=*/!locale_is_utf8());
         } else {
             run(program, prompter);
         }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -16,7 +16,7 @@ namespace spudplate {
 namespace {
 
 void print_usage(std::ostream& err) {
-    err << "usage: spudplate run <file.spud>\n";
+    err << "usage: spudplate run [--dry-run] <file.spud>\n";
 }
 
 void print_error(std::ostream& err, const std::string& file, const char* kind,
@@ -27,19 +27,30 @@ void print_error(std::ostream& err, const std::string& file, const char* kind,
 
 }  // namespace
 
-int cli_main(int argc, char* argv[], std::ostream& /*out*/, std::ostream& err,
+int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
              Prompter& prompter) {
     if (argc < 2) {
         print_usage(err);
         return 1;
     }
     std::string subcommand{argv[1]};
-    if (subcommand != "run" || argc != 3) {
+    if (subcommand != "run") {
         print_usage(err);
         return 1;
     }
 
-    std::string file_path{argv[2]};
+    bool dry_run_mode = false;
+    int positional_start = 2;
+    if (argc >= 3 && std::string{argv[2]} == "--dry-run") {
+        dry_run_mode = true;
+        positional_start = 3;
+    }
+    if (argc - positional_start != 1) {
+        print_usage(err);
+        return 1;
+    }
+
+    std::string file_path{argv[positional_start]};
     std::ifstream in(file_path);
     if (!in) {
         err << file_path << ": cannot open: " << std::strerror(errno) << "\n";
@@ -69,7 +80,11 @@ int cli_main(int argc, char* argv[], std::ostream& /*out*/, std::ostream& err,
     }
 
     try {
-        run(program, prompter);
+        if (dry_run_mode) {
+            dry_run(program, prompter, out);
+        } else {
+            run(program, prompter);
+        }
     } catch (const RuntimeError& e) {
         print_error(err, file_path, "runtime error", e.line(), e.column(),
                     e.what());

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -10,12 +10,15 @@
 #include <fstream>
 #include <ios>
 #include <iostream>
+#include <map>
+#include <ostream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
 #include <utility>
 #include <variant>
+#include <vector>
 
 #include <unistd.h>
 
@@ -572,6 +575,9 @@ class Interpreter {
     }
 
     [[nodiscard]] Environment& env() { return env_; }
+    [[nodiscard]] const std::vector<PendingOp>& pending() const {
+        return pending_;
+    }
 
     void flush() {
         for (const auto& op : pending_) {
@@ -1027,6 +1033,121 @@ Environment run_for_tests(const Program& program, Prompter& prompter) {
     Interpreter interp(prompter);
     run_program(program, interp);
     return std::move(interp.env());
+}
+
+namespace {
+
+// In-memory tree built from the deferred-op queue. `std::map` keeps
+// children sorted alphabetically so the rendered output is stable.
+struct DryRunNode {
+    bool is_dir{true};
+    bool is_append{false};
+    std::map<std::string, DryRunNode> children;
+};
+
+std::vector<std::string> split_path(const std::string& path) {
+    std::vector<std::string> parts;
+    std::string current;
+    for (char c : path) {
+        if (c == '/') {
+            if (!current.empty()) {
+                parts.push_back(std::move(current));
+                current.clear();
+            }
+        } else {
+            current.push_back(c);
+        }
+    }
+    if (!current.empty()) {
+        parts.push_back(std::move(current));
+    }
+    return parts;
+}
+
+// Insert `path` into the tree. `is_dir` and `is_append` apply to the leaf;
+// every intermediate component is implicitly a directory.
+void insert_path(DryRunNode& root, const std::string& path, bool is_dir,
+                 bool is_append) {
+    auto parts = split_path(path);
+    if (parts.empty()) {
+        return;
+    }
+    DryRunNode* cursor = &root;
+    for (std::size_t i = 0; i < parts.size(); ++i) {
+        const auto& name = parts[i];
+        auto& child = cursor->children[name];
+        if (i + 1 < parts.size()) {
+            child.is_dir = true;
+        } else {
+            // A path that appears first as an intermediate (auto-dir) and
+            // later as an explicit mkdir keeps is_dir=true. A path that
+            // appears as a file overrides any prior is_dir guess.
+            if (!is_dir) {
+                child.is_dir = false;
+                child.is_append = is_append;
+            }
+        }
+        cursor = &child;
+    }
+}
+
+void render_node(std::ostream& out, const DryRunNode& node,
+                 const std::string& prefix) {
+    std::size_t i = 0;
+    const std::size_t n = node.children.size();
+    for (const auto& [name, child] : node.children) {
+        bool last = (i + 1 == n);
+        out << prefix << (last ? "\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 "
+                               : "\xe2\x94\x9c\xe2\x94\x80\xe2\x94\x80 ")
+            << name;
+        if (child.is_dir) {
+            out << '/';
+        } else if (child.is_append) {
+            out << " (append)";
+        }
+        out << '\n';
+        std::string next_prefix =
+            prefix + (last ? "    " : "\xe2\x94\x82   ");
+        render_node(out, child, next_prefix);
+        ++i;
+    }
+}
+
+void render_pending(std::ostream& out, const std::vector<PendingOp>& pending) {
+    DryRunNode root;
+    for (const auto& op : pending) {
+        std::visit(
+            [&](const auto& o) {
+                using T = std::decay_t<decltype(o)>;
+                if constexpr (std::is_same_v<T, PendingMkdir>) {
+                    insert_path(root, o.path, /*is_dir=*/true,
+                                /*is_append=*/false);
+                } else if constexpr (std::is_same_v<T, PendingFile>) {
+                    insert_path(root, o.path, /*is_dir=*/false, o.append);
+                }
+                // PendingCheckDir is intentionally skipped — it doesn't
+                // create anything and dry-run can't validate it without
+                // hitting the real filesystem.
+            },
+            op);
+    }
+    out << "Would create:\n";
+    if (root.children.empty()) {
+        out << "  (nothing)\n";
+        return;
+    }
+    render_node(out, root, "");
+}
+
+}  // namespace
+
+void dry_run(const Program& program, Prompter& prompter, std::ostream& out) {
+    Interpreter interp(prompter);
+    interp.set_ask_total(count_ask_statements(program));
+    for (const auto& stmt : program.statements) {
+        interp.execute(*stmt);
+    }
+    render_pending(out, interp.pending());
 }
 
 }  // namespace spudplate

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1091,29 +1091,48 @@ void insert_path(DryRunNode& root, const std::string& path, bool is_dir,
     }
 }
 
+struct TreeGlyphs {
+    const char* tee;       // child with siblings below
+    const char* corner;    // last child
+    const char* vertical;  // continuation through ancestor with siblings below
+    const char* gap;       // continuation through ancestor that was last
+};
+
+constexpr TreeGlyphs kUtf8Glyphs{
+    .tee = "\xe2\x94\x9c\xe2\x94\x80\xe2\x94\x80 ",   // ├──
+    .corner = "\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 ",  // └──
+    .vertical = "\xe2\x94\x82   ",                       // │
+    .gap = "    ",
+};
+
+constexpr TreeGlyphs kAsciiGlyphs{
+    .tee = "|-- ",
+    .corner = "\\-- ",
+    .vertical = "|   ",
+    .gap = "    ",
+};
+
 void render_node(std::ostream& out, const DryRunNode& node,
-                 const std::string& prefix) {
+                 const std::string& prefix, const TreeGlyphs& glyphs) {
     std::size_t i = 0;
     const std::size_t n = node.children.size();
     for (const auto& [name, child] : node.children) {
         bool last = (i + 1 == n);
-        out << prefix << (last ? "\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 "
-                               : "\xe2\x94\x9c\xe2\x94\x80\xe2\x94\x80 ")
-            << name;
+        out << prefix << (last ? glyphs.corner : glyphs.tee) << name;
         if (child.is_dir) {
             out << '/';
         } else if (child.is_append) {
             out << " (append)";
         }
         out << '\n';
-        std::string next_prefix =
-            prefix + (last ? "    " : "\xe2\x94\x82   ");
-        render_node(out, child, next_prefix);
+        std::string next_prefix = prefix + (last ? glyphs.gap : glyphs.vertical);
+        render_node(out, child, next_prefix, glyphs);
         ++i;
     }
 }
 
-void render_pending(std::ostream& out, const std::vector<PendingOp>& pending) {
+void render_pending(std::ostream& out, const std::vector<PendingOp>& pending,
+                    const TreeGlyphs& glyphs) {
     DryRunNode root;
     for (const auto& op : pending) {
         std::visit(
@@ -1136,18 +1155,41 @@ void render_pending(std::ostream& out, const std::vector<PendingOp>& pending) {
         out << "  (nothing)\n";
         return;
     }
-    render_node(out, root, "");
+    render_node(out, root, "", glyphs);
 }
 
 }  // namespace
 
-void dry_run(const Program& program, Prompter& prompter, std::ostream& out) {
+bool locale_is_utf8() {
+    for (const char* var : {"LC_ALL", "LC_CTYPE", "LANG"}) {
+        const char* value = std::getenv(var);
+        if (value == nullptr || value[0] == '\0') {
+            continue;
+        }
+        std::string s(value);
+        for (auto& c : s) {
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        }
+        if (s.find("utf-8") != std::string::npos ||
+            s.find("utf8") != std::string::npos) {
+            return true;
+        }
+        // The first set variable wins; an explicitly non-UTF-8 locale should
+        // not be overridden by a later UTF-8 fallback.
+        return false;
+    }
+    return false;
+}
+
+void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
+             bool ascii_only) {
     Interpreter interp(prompter);
     interp.set_ask_total(count_ask_statements(program));
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }
-    render_pending(out, interp.pending());
+    render_pending(out, interp.pending(),
+                   ascii_only ? kAsciiGlyphs : kUtf8Glyphs);
 }
 
 }  // namespace spudplate

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -112,7 +112,8 @@ TEST(CliTest, SemanticErrorExitsThree) {
 TEST(CliTest, RuntimeErrorExitsFour) {
     TmpDir td;
     auto file = td.path() / "runtime.spud";
-    // `mkdir from` is rejected at runtime as not yet supported.
+    // `mkdir from` looks up `base` in the cwd; with no such directory the
+    // walker raises a runtime error.
     write_file(file, "mkdir foo from base\n");
     Argv args({"spudplate", "run", file.string()});
     std::stringstream out;
@@ -136,6 +137,33 @@ TEST(CliTest, UnknownSubcommandExitsOne) {
 
 TEST(CliTest, NoArgumentsExitsOne) {
     Argv args({"spudplate"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("usage"), std::string::npos);
+}
+
+TEST(CliTest, DryRunPrintsTreeAndDoesNotWrite) {
+    TmpDir td;
+    auto file = td.path() / "ok.spud";
+    write_file(file, "mkdir my_project\nfile my_project/README.md content \"hi\"\n");
+    Argv args({"spudplate", "run", "--dry-run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_EQ(err.str(), "");
+    EXPECT_NE(out.str().find("Would create:"), std::string::npos);
+    EXPECT_NE(out.str().find("my_project"), std::string::npos);
+    EXPECT_NE(out.str().find("README.md"), std::string::npos);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "my_project"));
+}
+
+TEST(CliTest, DryRunWithoutFileExitsOne) {
+    Argv args({"spudplate", "run", "--dry-run"});
     std::stringstream out;
     std::stringstream err;
     ScriptedPrompter prompter({});

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -22,7 +22,9 @@ using spudplate::AliasMap;
 using spudplate::BinaryExpr;
 using spudplate::BoolLiteralExpr;
 using spudplate::Environment;
+using spudplate::dry_run;
 using spudplate::evaluate_expr;
+using spudplate::locale_is_utf8;
 using spudplate::evaluate_path;
 using spudplate::PathExpr;
 using spudplate::PathInterp;
@@ -1905,6 +1907,66 @@ TEST(DryRunTest, MissingFromSourceStillThrows) {
     ScriptedPrompter prompter({});
     std::stringstream out;
     EXPECT_THROW(dry_run(p, prompter, out), RuntimeError);
+}
+
+TEST(DryRunTest, AsciiGlyphsWhenRequested) {
+    TmpDir td;
+    // Two top-level siblings ensure the `|   ` continuation glyph shows
+    // up under the non-last sibling.
+    auto p = parse(R"(mkdir foo
+file foo/bar.txt content "hi"
+file foo/baz.txt content "hi"
+mkdir last
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out, /*ascii_only=*/true);
+    const std::string& s = out.str();
+    EXPECT_NE(s.find("|-- "), std::string::npos);
+    EXPECT_NE(s.find("\\-- "), std::string::npos);
+    EXPECT_NE(s.find("|   "), std::string::npos);
+    // No UTF-8 box-drawing bytes leaked through.
+    EXPECT_EQ(s.find("\xe2\x94"), std::string::npos);
+}
+
+TEST(DryRunTest, Utf8GlyphsByDefault) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    EXPECT_NE(out.str().find("\xe2\x94\x94"), std::string::npos);
+}
+
+TEST(LocaleIsUtf8Test, EnUsUtf8Detected) {
+    setenv("LC_ALL", "", 1);
+    setenv("LC_CTYPE", "", 1);
+    setenv("LANG", "en_US.UTF-8", 1);
+    EXPECT_TRUE(locale_is_utf8());
+}
+
+TEST(LocaleIsUtf8Test, CLocaleNotDetected) {
+    setenv("LC_ALL", "C", 1);
+    setenv("LC_CTYPE", "", 1);
+    setenv("LANG", "", 1);
+    EXPECT_FALSE(locale_is_utf8());
+}
+
+TEST(LocaleIsUtf8Test, NoEnvVarsSetReturnsFalse) {
+    unsetenv("LC_ALL");
+    unsetenv("LC_CTYPE");
+    unsetenv("LANG");
+    EXPECT_FALSE(locale_is_utf8());
+}
+
+TEST(LocaleIsUtf8Test, FirstSetWinsOverLaterUtf8) {
+    // POSIX precedence: LC_ALL overrides everything. A non-UTF-8 LC_ALL
+    // means the user wants ASCII even if LANG happens to be UTF-8.
+    setenv("LC_ALL", "POSIX", 1);
+    setenv("LANG", "en_US.UTF-8", 1);
+    EXPECT_FALSE(locale_is_utf8());
+    unsetenv("LC_ALL");
 }
 
 TEST(DryRunTest, PromptsRunBeforeRendering) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1788,3 +1788,132 @@ end
     EXPECT_FALSE(std::filesystem::exists(td.path() / "week_0" / "sub_1"));
     EXPECT_FALSE(std::filesystem::exists(td.path() / "week_1" / "sub_0"));
 }
+
+// --- Dry run ---
+
+TEST(DryRunTest, EmptyProgramRendersNothing) {
+    TmpDir td;
+    Program empty;
+    NullPrompter prompter;
+    std::stringstream out;
+    dry_run(empty, prompter, out);
+    EXPECT_EQ(out.str(), "Would create:\n  (nothing)\n");
+}
+
+TEST(DryRunTest, MkdirAndFileRender) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo
+file foo/bar.txt content "hi"
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    EXPECT_EQ(out.str(),
+              "Would create:\n"
+              "\xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 foo/\n"
+              "    \xe2\x94\x94\xe2\x94\x80\xe2\x94\x80 bar.txt\n");
+}
+
+TEST(DryRunTest, AppendGetsAnnotation) {
+    TmpDir td;
+    auto p = parse(R"(file log.txt content "first"
+file log.txt append content "second"
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    // The file appears once (de-duplicated by path); since the second op is
+    // append the leaf carries the annotation.
+    EXPECT_NE(out.str().find("log.txt"), std::string::npos);
+    EXPECT_NE(out.str().find("(append)"), std::string::npos);
+}
+
+TEST(DryRunTest, SiblingsAreSortedAlphabetically) {
+    TmpDir td;
+    auto p = parse(R"(mkdir zeta
+mkdir alpha
+mkdir mu
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    auto idx_a = out.str().find("alpha");
+    auto idx_m = out.str().find("mu");
+    auto idx_z = out.str().find("zeta");
+    ASSERT_NE(idx_a, std::string::npos);
+    ASSERT_NE(idx_m, std::string::npos);
+    ASSERT_NE(idx_z, std::string::npos);
+    EXPECT_LT(idx_a, idx_m);
+    EXPECT_LT(idx_m, idx_z);
+}
+
+TEST(DryRunTest, MkdirFromExpandsTree) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src" / "sub");
+    {
+        std::ofstream(td.path() / "src" / "top.txt") << "x";
+    }
+    {
+        std::ofstream(td.path() / "src" / "sub" / "deep.txt") << "y";
+    }
+    auto p = parse(R"(mkdir dst from src
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    EXPECT_NE(out.str().find("dst/"), std::string::npos);
+    EXPECT_NE(out.str().find("sub/"), std::string::npos);
+    EXPECT_NE(out.str().find("top.txt"), std::string::npos);
+    EXPECT_NE(out.str().find("deep.txt"), std::string::npos);
+}
+
+TEST(DryRunTest, NoFilesystemSideEffects) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo
+file foo/bar.txt content "hi"
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo" / "bar.txt"));
+}
+
+TEST(DryRunTest, CopyToMissingDestStillRendersTree) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "src");
+    {
+        std::ofstream(td.path() / "src" / "f.txt") << "x";
+    }
+    // `copy` into a non-existent `dst` would be a runtime error during a
+    // real run; dry-run skips the existence check so the user still gets
+    // a useful preview.
+    auto p = parse(R"(copy src into dst
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    EXPECT_NO_THROW(dry_run(p, prompter, out));
+    EXPECT_NE(out.str().find("dst/"), std::string::npos);
+    EXPECT_NE(out.str().find("f.txt"), std::string::npos);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "dst"));
+}
+
+TEST(DryRunTest, MissingFromSourceStillThrows) {
+    TmpDir td;
+    auto p = parse(R"(mkdir dst from nope
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    EXPECT_THROW(dry_run(p, prompter, out), RuntimeError);
+}
+
+TEST(DryRunTest, PromptsRunBeforeRendering) {
+    TmpDir td;
+    auto p = parse(R"(ask name "Project?" string default "demo"
+mkdir {name}
+)");
+    ScriptedPrompter prompter({"hello"});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    EXPECT_NE(out.str().find("hello/"), std::string::npos);
+}


### PR DESCRIPTION
## Summary
Adds `spudplate run --dry-run <file.spud>`. The run walks every prompt, evaluates every expression, and queues every action exactly like a real run, but instead of writing to disk it prints a tree of every path that would have been created.

## Changes
- New `dry_run(program, prompter, out, ascii_only=false)` entry point alongside `run`. Reuses the existing deferred-write queue and renders it as a tree on the supplied stream.
- Tree renderer groups siblings under their common parent, sorts alphabetically, and marks directories with a trailing `/` and append-mode files with an `(append)` annotation.
- Glyphs default to UTF-8 box-drawing (`├──`/`└──`/`│`); the CLI auto-detects whether the active locale (`LC_ALL`, `LC_CTYPE`, `LANG` in POSIX precedence order) advertises UTF-8 and falls back to plain ASCII (`|--`/`\\--`/`|`) when it doesn't.
- The `--dry-run` flag is accepted between `run` and the file argument; with no file the CLI prints usage and exits 1.
- `copy` destination-existence checks are skipped during dry-run, since dry-run never writes the parent dir to disk and the check would always fail spuriously. Other runtime errors (missing source, undefined variables, type mismatches) still propagate.
- Empty queues render as `Would create:\n  (nothing)\n` so the user gets honest feedback when a template is fully gated off.

## Test plan
- All 406 (17 new) tests pass locally
- Interpreter tests cover empty programs, single mkdir, mkdir-with-file, append annotation, alphabetical sorting of siblings, mkdir-from expansion, no filesystem side effects, copy into a missing destination, propagation of source-missing errors, ASCII glyph rendering, default UTF-8 glyph rendering, and the locale detector across UTF-8, C, unset, and POSIX-precedence cases
- CLI tests cover the flag plumbing, exit code, presence of the tree in stdout, no disk writes, and the no-file usage path
- Manual run against a small template confirms the tree shape matches the spec