### PR TITLE
chore(docs): clean up warnings and themes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,23 @@ gtest_discover_tests(spudplate_tests)
 # Documentation
 find_package(Doxygen OPTIONAL_COMPONENTS dot)
 if(DOXYGEN_FOUND)
+    # doxygen-awesome-css gives the generated HTML a modern look. Fetched
+    # only when docs are about to be built, kept entirely in the build tree.
+    FetchContent_Declare(
+        dox_awesome
+        GIT_REPOSITORY https://github.com/jothepro/doxygen-awesome-css.git
+        GIT_TAG v2.4.2
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_GetProperties(dox_awesome)
+    if(NOT dox_awesome_POPULATED)
+        FetchContent_Populate(dox_awesome)
+    endif()
+
     add_custom_target(docs
-        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Doxyfile
+        COMMAND ${CMAKE_COMMAND} -E env
+            "DOXYGEN_AWESOME_CSS_DIR=${dox_awesome_SOURCE_DIR}"
+            ${DOXYGEN_EXECUTABLE} ${CMAKE_SOURCE_DIR}/Doxyfile
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         COMMENT "Generating API documentation with Doxygen"
         VERBATIM

--- a/Doxyfile
+++ b/Doxyfile
@@ -17,6 +17,15 @@ EXTRACT_STATIC         = YES
 GENERATE_HTML          = YES
 HTML_OUTPUT            = html
 
+# doxygen-awesome-css theme. CMake injects DOXYGEN_AWESOME_CSS_DIR via the
+# `docs` target so the path resolves to the FetchContent-populated source
+# directory. HTML_COLORSTYLE must be LIGHT for the theme to apply.
+GENERATE_TREEVIEW      = YES
+DISABLE_INDEX          = NO
+FULL_SIDEBAR           = NO
+HTML_COLORSTYLE        = LIGHT
+HTML_EXTRA_STYLESHEET  = $(DOXYGEN_AWESOME_CSS_DIR)/doxygen-awesome.css
+
 GENERATE_LATEX         = NO
 
 QUIET                  = YES

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -14,29 +14,29 @@ namespace spudplate {
 /** @brief A string literal expression node, e.g. `"hello"`. */
 struct StringLiteralExpr {
     std::string value;  ///< The literal string value (without quotes).
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief An integer literal expression node, e.g. `42`. */
 struct IntegerLiteralExpr {
     int value;  ///< The literal integer value.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief A bool literal expression node, e.g. `true` or `false`. */
 struct BoolLiteralExpr {
     bool value;  ///< The literal boolean value.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief A variable reference expression node, e.g. `project_name`. */
 struct IdentifierExpr {
     std::string name;  ///< The variable name.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 // Forward declare Expr so recursive types can hold pointers to it
@@ -48,8 +48,8 @@ using ExprPtr = std::unique_ptr<Expr>;
 struct UnaryExpr {
     TokenType op;     ///< The operator token (NOT).
     ExprPtr operand;  ///< The operand expression.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -61,8 +61,8 @@ struct BinaryExpr {
     TokenType op;   ///< The operator token.
     ExprPtr left;   ///< Left-hand operand.
     ExprPtr right;  ///< Right-hand operand.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -74,8 +74,8 @@ struct BinaryExpr {
 struct FunctionCallExpr {
     std::string name;                  ///< Function name.
     std::vector<ExprPtr> arguments;    ///< Argument expressions.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief Discriminated union of all expression node types. */
@@ -84,7 +84,7 @@ using ExprData = std::variant<StringLiteralExpr, IntegerLiteralExpr, BoolLiteral
 
 /** @brief An expression node wrapping an ExprData variant. */
 struct Expr {
-    ExprData data;
+    ExprData data;  ///< The concrete expression alternative.
 };
 
 /** @brief The type of a variable declared by an `ask` statement. */
@@ -97,22 +97,22 @@ enum class VarType { String, Bool, Int };
 /** @brief A literal component of a path expression, e.g. `src` or `README.md`. */
 struct PathLiteral {
     std::string value;  ///< Literal text (identifiers, dots, slashes already joined).
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief A reference to a previously-bound path alias, e.g. `staticpath` in `staticpath/notes`. */
 struct PathVar {
     std::string name;  ///< The alias name.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief An inline `{expr}` interpolation inside a path, e.g. `week_{n}`. */
 struct PathInterp {
     ExprPtr expression;  ///< The expression whose string value is substituted at runtime.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief Discriminated union of the three path segment kinds. */
@@ -164,8 +164,8 @@ struct AskStmt {
     std::optional<ExprPtr> default_value;     ///< Expression evaluated when the user skips the prompt.
     std::vector<ExprPtr> options;             ///< Allowed literal values; empty means any.
     std::optional<ExprPtr> when_clause;       ///< Optional condition guarding the prompt.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -176,8 +176,8 @@ struct AskStmt {
 struct LetStmt {
     std::string name;  ///< Variable name to bind.
     ExprPtr value;     ///< Expression whose value is assigned.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -196,8 +196,8 @@ struct MkdirStmt {
     bool verbatim;                         ///< If true with from_source, suppress interpolation.
     std::optional<int> mode;               ///< Optional permission bits (e.g. 0755).
     std::optional<ExprPtr> when_clause;    ///< Optional condition guarding creation.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -212,8 +212,8 @@ struct FileStmt {
     bool append;                          ///< If true, append; otherwise create/overwrite.
     std::optional<int> mode;              ///< Optional permission bits.
     std::optional<ExprPtr> when_clause;   ///< Optional condition guarding creation.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 // Forward declare Stmt so RepeatStmt can hold a vector of them
@@ -236,8 +236,8 @@ struct RepeatStmt {
     std::string iterator_var;            ///< Name of the loop index variable (0-based).
     std::vector<StmtPtr> body;           ///< Statements inside the loop body.
     std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the whole loop.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -254,8 +254,8 @@ struct CopyStmt {
     PathExpr destination;                ///< Existing destination directory path.
     bool verbatim;                       ///< If true, suppress `{var}` interpolation.
     std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the copy.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /**
@@ -269,8 +269,8 @@ struct CopyStmt {
 struct IncludeStmt {
     std::string name;                    ///< Name of the installed template to run.
     std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the include.
-    int line;
-    int column;
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
 };
 
 /** @brief Discriminated union of all statement node types. */
@@ -279,7 +279,7 @@ using StmtData = std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt,
 
 /** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {
-    StmtData data;
+    StmtData data;  ///< The concrete statement alternative.
 };
 
 /** @brief The top-level AST node representing a complete `.spud` program. */

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -22,6 +22,7 @@ namespace spudplate {
  */
 class RuntimeError : public std::runtime_error {
   public:
+    /** @brief Construct an error tagged with the offending source position. */
     RuntimeError(const std::string& message, int line, int column)
         : std::runtime_error(message), line_(line), column_(column) {}
 
@@ -56,9 +57,12 @@ using Value = std::variant<std::string, std::int64_t, bool>;
  */
 class Environment {
   public:
+    /** @brief Start with one program-level frame already on the stack. */
     Environment() { push(); }
 
+    /** @brief Push a fresh frame for a nested scope (e.g. `repeat` body). */
     void push() { frames_.emplace_back(); }
+    /** @brief Pop the innermost frame, discarding any bindings it held. */
     void pop() { frames_.pop_back(); }
 
     /**
@@ -121,7 +125,10 @@ class Prompter {
  */
 class StdinPrompter : public Prompter {
   public:
+    /** @brief Default constructor: read from `std::cin`, write to `std::cout`,
+     *         auto-detect colour support. */
     StdinPrompter();
+    /** @brief Inject custom streams and explicit colour mode (test-only). */
     StdinPrompter(std::istream& in, std::ostream& out, bool use_colour);
 
     std::string prompt(const PromptRequest& req) override;
@@ -141,6 +148,7 @@ class StdinPrompter : public Prompter {
  */
 class ScriptedPrompter : public Prompter {
   public:
+    /** @brief Construct with the canned answers `prompt` will replay in order. */
     explicit ScriptedPrompter(std::vector<std::string> answers)
         : answers_(std::move(answers)) {}
 

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -18,6 +18,7 @@ namespace spudplate {
  */
 class ParseError : public std::runtime_error {
   public:
+    /** @brief Construct an error tagged with the offending source position. */
     ParseError(const std::string& message, int line, int column)
         : std::runtime_error(message), line_(line), column_(column) {}
 

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -82,8 +82,10 @@ struct Token {
     int line;           ///< 1-based source line number.
     int column;         ///< 1-based source column number.
 
+    /** @brief Default-construct an EOF token at position 0:0. */
     Token() : type(TokenType::EOF_TOKEN), line(0), column(0) {}
 
+    /** @brief Construct a token with explicit type, lexeme, and source position. */
     Token(TokenType type, std::string value, int line, int column)
         : type(type), value(std::move(value)), line(line), column(column) {}
 };

--- a/include/spudplate/validator.h
+++ b/include/spudplate/validator.h
@@ -23,6 +23,7 @@ using TypeMap = std::unordered_map<std::string, VarType>;
  */
 class SemanticError : public std::runtime_error {
   public:
+    /** @brief Construct an error tagged with the offending source position. */
     SemanticError(const std::string& message, int line, int column)
         : std::runtime_error(message), line_(line), column_(column) {}
 


### PR DESCRIPTION
## Summary
Doxygen now runs warning-free (was 47 warnings) and the generated HTML uses the doxygen-awesome theme.

## Changes
- Every AST node's `line` and `column` fields carry a one-line brief docstring saying they are 1-based source positions where the node begins.
- `Expr::data` and `Stmt::data` are documented as the concrete variant alternative.
- Constructors of `RuntimeError`, `ParseError`, `SemanticError`, `Token`, `StdinPrompter`, and `ScriptedPrompter` carry brief descriptions.
- `Environment::push` and `pop` are documented as scope-frame operations.
- `doxygen-awesome-css v2.4.2` is fetched at configure time via `FetchContent`. The CSS lives entirely in the build tree, no third-party files enter the repo. The `docs` target injects the populated source dir as `DOXYGEN_AWESOME_CSS_DIR`, which the Doxyfile expands into `HTML_EXTRA_STYLESHEET`.
- Doxyfile gains the four theme-required settings (`GENERATE_TREEVIEW`, `DISABLE_INDEX`, `FULL_SIDEBAR`, `HTML_COLORSTYLE`).

## Test plan
- All 406 tests pass locally
- `cmake --build build --target docs` completes with zero warnings
- Generated `docs/html/index.html` shows the new field/constructor descriptions and the doxygen-awesome theme is applied