### PR TITLE
feat: run shell commands from template

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -248,18 +248,20 @@ There is no source-level inlining; all template reuse goes through `include` and
 ### `run` — Execute a shell command
 
 ```
-run <expression> [when <condition>]
+run <expression> [in <path>] [when <condition>]
 ```
 
 Runs a shell command via `/bin/sh -c`. The expression evaluates to a string at runtime — supporting concatenation with `ask`/`let` values — and the resulting command is queued for execution at flush time, in source order alongside the file operations. Output streams live to the parent process's stdout/stderr.
 
+- `in <path>` — pin the command's working directory to `<path>`. Without it, the command inherits the cwd of the `spudplate` process, which is rarely what you want once the template has created a project subdirectory. The path is a regular path expression — alias references and `{expr}` interpolation work, and the directory must exist by the time the command runs (errors otherwise). The cwd is restored after the command, even on failure.
 - `when <condition>` — only run the command if the condition is true.
 
 ```
-ask use_git "Initialise a git repo?" bool default true
-run "git init" when use_git
+ask project "Project name?" string
+mkdir {project} as proj
+run "git init" in proj
 ask repo_url "Origin URL?" string default ""
-run "git remote add origin " + repo_url when repo_url != ""
+run "git remote add origin " + repo_url in proj when repo_url != ""
 ```
 
 #### Trust prompt
@@ -284,7 +286,7 @@ A non-zero exit, a signal-killed process, or a failure to invoke the shell raise
 #### Security caveats
 
 - **Shell injection via interpolation.** Commands are dispatched through `/bin/sh -c`. The trust prompt shows the literal source expression; the *evaluated* string is what executes. A command like `run "git clone " + url` looks safe in the prompt, but a malicious `url` answer (`; rm -rf $HOME`) would still be passed through. Treat any `ask`/`let` value flowing into a `run` command as untrusted and quote it appropriately in the command string, or restrict input via `options`.
-- **Working directory.** Commands run in whatever directory `spudplate run` was invoked from, *not* a per-template sandbox. Use `cd` inside the command if you need a different cwd.
+- **Working directory.** Without `in <path>`, commands run in whatever directory `spudplate run` was invoked from — *not* a per-template sandbox. Templates that create a project subdirectory should pin every following command to it via `in <path>`.
 - **No timeout.** A long-running command blocks the flush indefinitely. Templates running interactive commands (e.g. `vim`) will hand the terminal over.
 - **No allowlist.** Any command is permitted once authorised. Privilege escalation (e.g. `sudo`) prompts for the user's password — that natural friction is the safety net for anything destructive.
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -245,6 +245,51 @@ There is no source-level inlining; all template reuse goes through `include` and
 
 ---
 
+### `run` — Execute a shell command
+
+```
+run <expression> [when <condition>]
+```
+
+Runs a shell command via `/bin/sh -c`. The expression evaluates to a string at runtime — supporting concatenation with `ask`/`let` values — and the resulting command is queued for execution at flush time, in source order alongside the file operations. Output streams live to the parent process's stdout/stderr.
+
+- `when <condition>` — only run the command if the condition is true.
+
+```
+ask use_git "Initialise a git repo?" bool default true
+run "git init" when use_git
+ask repo_url "Origin URL?" string default ""
+run "git remote add origin " + repo_url when repo_url != ""
+```
+
+#### Trust prompt
+
+Every `spudplate run <file.spud>` invocation that contains any `run` clauses prompts the user once, before any statement executes:
+
+```
+This template will execute the following shell commands via /bin/sh:
+  1. "git init"
+  2. "git remote add origin " + repo_url
+Authorise these commands? [y/N]
+```
+
+The summary lists each command's source-form expression. Declining aborts cleanly with no side effects — no prompts run, no files are written, no commands execute. Conditional clauses appear in the summary regardless of the eventual `when` outcome (the validator can't predict runtime values), and commands inside `repeat` bodies are flagged as such.
+
+The `--yes` (or `-y`) flag bypasses the prompt for non-interactive callers; the caller takes responsibility for having vetted the source. Once `spudplate install` lands, install-time consent will be recorded so installed templates run without re-prompting.
+
+#### Failure handling
+
+A non-zero exit, a signal-killed process, or a failure to invoke the shell raises a runtime error and aborts the rest of the flush. File operations queued *before* the failed command have already been performed; later operations do not run. This matches the existing partial-failure model documented under "Safety" below.
+
+#### Security caveats
+
+- **Shell injection via interpolation.** Commands are dispatched through `/bin/sh -c`. The trust prompt shows the literal source expression; the *evaluated* string is what executes. A command like `run "git clone " + url` looks safe in the prompt, but a malicious `url` answer (`; rm -rf $HOME`) would still be passed through. Treat any `ask`/`let` value flowing into a `run` command as untrusted and quote it appropriately in the command string, or restrict input via `options`.
+- **Working directory.** Commands run in whatever directory `spudplate run` was invoked from, *not* a per-template sandbox. Use `cd` inside the command if you need a different cwd.
+- **No timeout.** A long-running command blocks the flush indefinitely. Templates running interactive commands (e.g. `vim`) will hand the terminal over.
+- **No allowlist.** Any command is permitted once authorised. Privilege escalation (e.g. `sudo`) prompts for the user's password — that natural friction is the safety net for anything destructive.
+
+---
+
 ## Expressions
 
 Expressions appear in `let` values, `content` values, `default` values, `options`, `{...}` interpolations, and `when` conditions.

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -259,6 +259,24 @@ struct CopyStmt {
 };
 
 /**
+ * @brief A `run` statement — executes a shell command after user authorisation.
+ *
+ * Example: `run "git init" when use_git`
+ *
+ * The command expression is evaluated to a string at runtime and dispatched
+ * via `/bin/sh -c`. Each `spudplate run` invocation prompts the user once,
+ * up front, listing every literal command in the program (regardless of
+ * `when` outcome) before any statement executes; declining aborts cleanly
+ * with no side effects.
+ */
+struct RunStmt {
+    ExprPtr command;                     ///< Expression whose string value is the command.
+    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding execution.
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
+};
+
+/**
  * @brief An `include` statement — runs another installed template as a subprocess.
  *
  * Example: `include claude_setup when use_claude`
@@ -275,7 +293,7 @@ struct IncludeStmt {
 
 /** @brief Discriminated union of all statement node types. */
 using StmtData = std::variant<AskStmt, LetStmt, MkdirStmt, FileStmt, RepeatStmt,
-                              CopyStmt, IncludeStmt>;
+                              CopyStmt, IncludeStmt, RunStmt>;
 
 /** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -261,16 +261,19 @@ struct CopyStmt {
 /**
  * @brief A `run` statement — executes a shell command after user authorisation.
  *
- * Example: `run "git init" when use_git`
+ * Example: `run "git init" in {dir} when use_git`
  *
  * The command expression is evaluated to a string at runtime and dispatched
- * via `/bin/sh -c`. Each `spudplate run` invocation prompts the user once,
- * up front, listing every literal command in the program (regardless of
- * `when` outcome) before any statement executes; declining aborts cleanly
- * with no side effects.
+ * via `/bin/sh -c`. The optional `in <path>` clause pins the working
+ * directory for the command — without it, the command inherits the cwd of
+ * the `spudplate` process. Each `spudplate run` invocation prompts the
+ * user once, up front, listing every literal command (and its `in <path>`,
+ * if any) before any statement executes; declining aborts cleanly with no
+ * side effects.
  */
 struct RunStmt {
     ExprPtr command;                     ///< Expression whose string value is the command.
+    std::optional<PathExpr> cwd;         ///< Optional `in <path>` working directory.
     std::optional<ExprPtr> when_clause;  ///< Optional condition guarding execution.
     int line;    ///< 1-based source line where this node begins.
     int column;  ///< 1-based source column where this node begins.

--- a/include/spudplate/cli.h
+++ b/include/spudplate/cli.h
@@ -14,6 +14,8 @@ namespace spudplate {
  *   spudplate run <file.spud>             run a template (exit codes below)
  *   spudplate run --dry-run <file.spud>   prompt as normal, then print a
  *                                         tree of would-be writes to stdout
+ *   spudplate run --yes <file.spud>       skip the run-statement trust prompt
+ *                                         (caller has vetted the source)
  *
  * Exit codes:
  *   0 — success

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -114,6 +114,16 @@ class Prompter {
      * Implementations deliver one raw line per call.
      */
     virtual std::string prompt(const PromptRequest& req) = 0;
+
+    /**
+     * @brief Display a security summary and return whether to proceed.
+     *
+     * Called once, before any statement runs, when the program contains
+     * `run` clauses. The summary is multi-line and lists every literal
+     * command that may execute. Returning `false` aborts the run cleanly
+     * with no side effects.
+     */
+    virtual bool authorize(const std::string& summary) = 0;
 };
 
 /**
@@ -132,6 +142,7 @@ class StdinPrompter : public Prompter {
     StdinPrompter(std::istream& in, std::ostream& out, bool use_colour);
 
     std::string prompt(const PromptRequest& req) override;
+    bool authorize(const std::string& summary) override;
 
   private:
     std::istream& in_;
@@ -153,16 +164,27 @@ class ScriptedPrompter : public Prompter {
         : answers_(std::move(answers)) {}
 
     std::string prompt(const PromptRequest& req) override;
+    bool authorize(const std::string& summary) override;
 
     /** @brief Most recent request seen, for assertions on rendering inputs. */
     [[nodiscard]] const std::optional<PromptRequest>& last_request() const {
         return last_;
     }
 
+    /** @brief Set what `authorize` returns. Defaults to true (accept). */
+    void set_authorize_response(bool value) { authorize_response_ = value; }
+
+    /** @brief Most recent authorize summary seen, for assertions. */
+    [[nodiscard]] const std::optional<std::string>& last_authorize_summary() const {
+        return last_authorize_summary_;
+    }
+
   private:
     std::vector<std::string> answers_;
     std::size_t index_{0};
     std::optional<PromptRequest> last_;
+    bool authorize_response_{true};
+    std::optional<std::string> last_authorize_summary_;
 };
 
 /**
@@ -171,8 +193,16 @@ class ScriptedPrompter : public Prompter {
  * Walks `program.statements` top-to-bottom, prompting through `prompter` for
  * `ask` statements and queueing filesystem operations to be flushed at the
  * end of the run. Throws `RuntimeError` on the first failure.
+ *
+ * If the program contains any `run` statements, `prompter.authorize` is
+ * called once before any statement executes, with a summary of every
+ * literal command. A `false` return aborts the run cleanly with no side
+ * effects. The `skip_authorization` flag bypasses the prompt for non-
+ * interactive callers — they take responsibility for having vetted the
+ * source.
  */
-void run(const Program& program, Prompter& prompter);
+void run(const Program& program, Prompter& prompter,
+         bool skip_authorization = false);
 
 /**
  * @brief Test-only entry point: like `run`, but returns the final environment.

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -66,6 +66,7 @@ class Parser {
     StmtPtr parseCopy();
     /** @brief Parses an `include` statement. */
     StmtPtr parseInclude();
+    StmtPtr parseRun();
     /** @brief Dispatches to the appropriate statement parser based on the current token.
      */
     StmtPtr parseStatement();

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -26,6 +26,7 @@ enum class TokenType {
     COPY,      ///< `copy` — copy a source directory into an existing destination
     INTO,      ///< `into` — destination marker used by `copy`
     INCLUDE,   ///< `include` — run another installed template as a subprocess
+    RUN,       ///< `run` — execute a shell command (gated by trust prompt)
 
     // Logical operators (keywords)
     AND,  ///< `and` — logical AND
@@ -129,6 +130,8 @@ inline std::string tokenTypeToString(TokenType type) {
             return "INTO";
         case TokenType::INCLUDE:
             return "INCLUDE";
+        case TokenType::RUN:
+            return "RUN";
         case TokenType::AND:
             return "AND";
         case TokenType::OR:

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -27,6 +27,7 @@ enum class TokenType {
     INTO,      ///< `into` — destination marker used by `copy`
     INCLUDE,   ///< `include` — run another installed template as a subprocess
     RUN,       ///< `run` — execute a shell command (gated by trust prompt)
+    IN,        ///< `in` — working-directory marker on `run` statements
 
     // Logical operators (keywords)
     AND,  ///< `and` — logical AND
@@ -132,6 +133,8 @@ inline std::string tokenTypeToString(TokenType type) {
             return "INCLUDE";
         case TokenType::RUN:
             return "RUN";
+        case TokenType::IN:
+            return "IN";
         case TokenType::AND:
             return "AND";
         case TokenType::OR:

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -16,7 +16,7 @@ namespace spudplate {
 namespace {
 
 void print_usage(std::ostream& err) {
-    err << "usage: spudplate run [--dry-run] <file.spud>\n";
+    err << "usage: spudplate run [--dry-run] [--yes] <file.spud>\n";
 }
 
 void print_error(std::ostream& err, const std::string& file, const char* kind,
@@ -40,10 +40,19 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     }
 
     bool dry_run_mode = false;
+    bool skip_authorization = false;
     int positional_start = 2;
-    if (argc >= 3 && std::string{argv[2]} == "--dry-run") {
-        dry_run_mode = true;
-        positional_start = 3;
+    while (positional_start < argc) {
+        std::string arg{argv[positional_start]};
+        if (arg == "--dry-run") {
+            dry_run_mode = true;
+            ++positional_start;
+        } else if (arg == "--yes" || arg == "-y") {
+            skip_authorization = true;
+            ++positional_start;
+        } else {
+            break;
+        }
     }
     if (argc - positional_start != 1) {
         print_usage(err);
@@ -83,7 +92,7 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
         if (dry_run_mode) {
             dry_run(program, prompter, out, /*ascii_only=*/!locale_is_utf8());
         } else {
-            run(program, prompter);
+            run(program, prompter, skip_authorization);
         }
     } catch (const RuntimeError& e) {
         print_error(err, file_path, "runtime error", e.line(), e.column(),

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -20,6 +20,9 @@
 #include <variant>
 #include <vector>
 
+#include <cerrno>
+#include <cstring>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "spudplate/ast.h"
@@ -75,7 +78,20 @@ struct PendingCheckDir {
     int column;
 };
 
-using PendingOp = std::variant<PendingMkdir, PendingFile, PendingCheckDir>;
+// A `run` statement queued for flush-time execution. The command stored
+// here is the *evaluated* expression result — what /bin/sh -c will run.
+// The user authorised the literal source at the start of the run, before
+// any expression evaluated. Source-vs-resolved drift (the shell-injection
+// surface for `run "git clone " + url` patterns) is documented as a known
+// caveat rather than mitigated at this layer.
+struct PendingRun {
+    std::string command;
+    int line;
+    int column;
+};
+
+using PendingOp =
+    std::variant<PendingMkdir, PendingFile, PendingCheckDir, PendingRun>;
 
 // Read a regular file (cwd-relative) into a string. The position arguments
 // point at the *.spud* statement that triggered the read so error messages
@@ -391,6 +407,105 @@ const char* expected_message(VarType type) {
     return "invalid input";
 }
 
+// Render an expression as a readable approximation of its source text. Used
+// only by the trust prompt — users see the *structure* of each `run`
+// command before authorising, even though the actual value executed at
+// flush time may differ (interpolated identifiers, computed strings, etc).
+std::string preview_expr(const Expr& expr) {
+    return std::visit(
+        [](const auto& e) -> std::string {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                return "\"" + e.value + "\"";
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                return std::to_string(e.value);
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                return e.value ? "true" : "false";
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                return e.name;
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                return "not " + preview_expr(*e.operand);
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                const char* sym = "?";
+                switch (e.op) {
+                    case TokenType::PLUS: sym = "+"; break;
+                    case TokenType::MINUS: sym = "-"; break;
+                    case TokenType::STAR: sym = "*"; break;
+                    case TokenType::SLASH: sym = "/"; break;
+                    case TokenType::EQUALS: sym = "=="; break;
+                    case TokenType::NOT_EQUALS: sym = "!="; break;
+                    case TokenType::GREATER: sym = ">"; break;
+                    case TokenType::LESS: sym = "<"; break;
+                    case TokenType::GREATER_EQUAL: sym = ">="; break;
+                    case TokenType::LESS_EQUAL: sym = "<="; break;
+                    case TokenType::AND: sym = "and"; break;
+                    case TokenType::OR: sym = "or"; break;
+                    default: break;
+                }
+                return preview_expr(*e.left) + " " + sym + " " +
+                       preview_expr(*e.right);
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                std::string out = e.name + "(";
+                for (std::size_t i = 0; i < e.arguments.size(); ++i) {
+                    if (i != 0) {
+                        out += ", ";
+                    }
+                    out += preview_expr(*e.arguments[i]);
+                }
+                out += ")";
+                return out;
+            }
+            return "<unknown>";
+        },
+        expr.data);
+}
+
+// Walk every RunStmt in the program (top-level and inside repeat bodies)
+// and append a one-line preview of each command's source-form expression
+// to `out`. Repeat-internal commands are tagged so the user knows they
+// may run multiple times — or not at all.
+void collect_run_previews(const std::vector<StmtPtr>& body,
+                          std::vector<std::string>& out, bool inside_repeat) {
+    for (const auto& stmt : body) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, RunStmt>) {
+                    std::string line = preview_expr(*s.command);
+                    if (inside_repeat) {
+                        line += "  (inside repeat — may run 0 or many times)";
+                    }
+                    if (s.when_clause.has_value()) {
+                        line += "  (conditional)";
+                    }
+                    out.push_back(std::move(line));
+                } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                    collect_run_previews(s.body, out, /*inside_repeat=*/true);
+                }
+            },
+            stmt->data);
+    }
+}
+
+std::string build_authorize_summary(const Program& program) {
+    std::vector<std::string> previews;
+    collect_run_previews(program.statements, previews, /*inside_repeat=*/false);
+    if (previews.empty()) {
+        return {};
+    }
+    std::string summary =
+        "This template will execute the following shell command";
+    summary += previews.size() == 1 ? "" : "s";
+    summary += " via /bin/sh:\n";
+    for (std::size_t i = 0; i < previews.size(); ++i) {
+        summary += "  " + std::to_string(i + 1) + ". " + previews[i] + "\n";
+    }
+    summary +=
+        "\nValues interpolated from `ask`/`let` are not shown above and "
+        "execute verbatim.\n";
+    return summary;
+}
+
 void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter,
                  int question_index, int question_total, int indent_level) {
     if (!when_passes(stmt.when_clause, env)) {
@@ -569,6 +684,8 @@ class Interpreter {
                     throw RuntimeError(
                         "statement 'include' not yet supported in this build",
                         s.line, s.column);
+                } else if constexpr (std::is_same_v<T, RunStmt>) {
+                    execute_run(s);
                 }
             },
             stmt.data);
@@ -662,6 +779,20 @@ class Interpreter {
             std::string src = evaluate_path(*s.from_source, env_, alias_map_);
             walk_source_into_pending(src, dst, s.verbatim, s.line, s.column);
         }
+    }
+
+    void execute_run(const RunStmt& s) {
+        if (!when_passes(s.when_clause, env_)) {
+            return;
+        }
+        Value v = evaluate_expr(*s.command, env_);
+        if (!std::holds_alternative<std::string>(v)) {
+            throw RuntimeError("'run' command must evaluate to a string",
+                               s.line, s.column);
+        }
+        pending_.push_back(PendingRun{.command = std::get<std::string>(v),
+                                      .line = s.line,
+                                      .column = s.column});
     }
 
     void execute_copy(const CopyStmt& s) {
@@ -778,6 +909,31 @@ class Interpreter {
                                        .mode = s.mode,
                                        .line = s.line,
                                        .column = s.column});
+    }
+
+    void run_op(const PendingRun& op) const {
+        // /bin/sh -c is what std::system invokes on POSIX. Output streams
+        // through to stdout/stderr inherited from the parent. A non-zero
+        // exit aborts the rest of the flush.
+        int rc = std::system(op.command.c_str());
+        if (rc == -1) {
+            throw RuntimeError("failed to invoke shell for command '" +
+                                   op.command + "': " +
+                                   std::strerror(errno),
+                               op.line, op.column);
+        }
+        if (WIFSIGNALED(rc)) {
+            throw RuntimeError("command killed by signal " +
+                                   std::to_string(WTERMSIG(rc)) + ": " +
+                                   op.command,
+                               op.line, op.column);
+        }
+        if (WIFEXITED(rc) && WEXITSTATUS(rc) != 0) {
+            throw RuntimeError("command exited with status " +
+                                   std::to_string(WEXITSTATUS(rc)) + ": " +
+                                   op.command,
+                               op.line, op.column);
+        }
     }
 
     void run_op(const PendingCheckDir& op) const {
@@ -947,12 +1103,30 @@ std::string StdinPrompter::prompt(const PromptRequest& req) {
     return line;
 }
 
+bool StdinPrompter::authorize(const std::string& summary) {
+    out_ << '\n' << summary;
+    out_ << "Authorise these commands? [y/N] " << std::flush;
+    std::string line;
+    std::getline(in_, line);
+    if (line.empty()) {
+        return false;
+    }
+    char first = static_cast<char>(
+        std::tolower(static_cast<unsigned char>(line[0])));
+    return first == 'y';
+}
+
 std::string ScriptedPrompter::prompt(const PromptRequest& req) {
     last_ = req;
     if (index_ >= answers_.size()) {
         throw std::logic_error("ScriptedPrompter exhausted");
     }
     return answers_[index_++];
+}
+
+bool ScriptedPrompter::authorize(const std::string& summary) {
+    last_authorize_summary_ = summary;
+    return authorize_response_;
 }
 
 Value evaluate_expr(const Expr& expr, const Environment& env) {
@@ -1024,7 +1198,13 @@ std::string value_to_string(const Value& value) {
         value);
 }
 
-void run(const Program& program, Prompter& prompter) {
+void run(const Program& program, Prompter& prompter, bool skip_authorization) {
+    if (!skip_authorization) {
+        std::string summary = build_authorize_summary(program);
+        if (!summary.empty() && !prompter.authorize(summary)) {
+            return;  // declined: clean exit, no side effects, no statements ran
+        }
+    }
     Interpreter interp(prompter);
     run_program(program, interp);
 }

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -80,12 +80,14 @@ struct PendingCheckDir {
 
 // A `run` statement queued for flush-time execution. The command stored
 // here is the *evaluated* expression result — what /bin/sh -c will run.
-// The user authorised the literal source at the start of the run, before
-// any expression evaluated. Source-vs-resolved drift (the shell-injection
-// surface for `run "git clone " + url` patterns) is documented as a known
-// caveat rather than mitigated at this layer.
+// `cwd` is the optional resolved working directory from the `in <path>`
+// clause. The user authorised the literal source at the start of the run,
+// before any expression evaluated. Source-vs-resolved drift (the shell-
+// injection surface for `run "git clone " + url` patterns) is documented
+// as a known caveat rather than mitigated at this layer.
 struct PendingRun {
     std::string command;
+    std::optional<std::string> cwd;
     int line;
     int column;
 };
@@ -464,6 +466,27 @@ std::string preview_expr(const Expr& expr) {
 // and append a one-line preview of each command's source-form expression
 // to `out`. Repeat-internal commands are tagged so the user knows they
 // may run multiple times — or not at all.
+// Render a path expression as a readable approximation of its source. Used
+// by the trust prompt to surface the `in <path>` clause on `run` statements.
+std::string preview_path(const PathExpr& path) {
+    std::string out;
+    for (const auto& seg : path.segments) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, PathLiteral>) {
+                    out += s.value;
+                } else if constexpr (std::is_same_v<T, PathVar>) {
+                    out += s.name;
+                } else if constexpr (std::is_same_v<T, PathInterp>) {
+                    out += "{" + preview_expr(*s.expression) + "}";
+                }
+            },
+            seg);
+    }
+    return out;
+}
+
 void collect_run_previews(const std::vector<StmtPtr>& body,
                           std::vector<std::string>& out, bool inside_repeat) {
     for (const auto& stmt : body) {
@@ -472,6 +495,9 @@ void collect_run_previews(const std::vector<StmtPtr>& body,
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, RunStmt>) {
                     std::string line = preview_expr(*s.command);
+                    if (s.cwd.has_value()) {
+                        line += " in " + preview_path(*s.cwd);
+                    }
                     if (inside_repeat) {
                         line += "  (inside repeat — may run 0 or many times)";
                     }
@@ -790,7 +816,12 @@ class Interpreter {
             throw RuntimeError("'run' command must evaluate to a string",
                                s.line, s.column);
         }
+        std::optional<std::string> cwd;
+        if (s.cwd.has_value()) {
+            cwd = evaluate_path(*s.cwd, env_, alias_map_);
+        }
         pending_.push_back(PendingRun{.command = std::get<std::string>(v),
+                                      .cwd = std::move(cwd),
                                       .line = s.line,
                                       .column = s.column});
     }
@@ -914,7 +945,35 @@ class Interpreter {
     void run_op(const PendingRun& op) const {
         // /bin/sh -c is what std::system invokes on POSIX. Output streams
         // through to stdout/stderr inherited from the parent. A non-zero
-        // exit aborts the rest of the flush.
+        // exit aborts the rest of the flush. If `op.cwd` is set, the chdir
+        // is restored on every exit path via the destructor.
+        struct ChdirScope {
+            std::filesystem::path saved;
+            bool active{false};
+            ~ChdirScope() {
+                if (active) {
+                    std::error_code ec;
+                    std::filesystem::current_path(saved, ec);
+                }
+            }
+        };
+        ChdirScope scope;
+        if (op.cwd.has_value()) {
+            std::error_code ec;
+            scope.saved = std::filesystem::current_path(ec);
+            if (ec) {
+                throw RuntimeError(
+                    "cannot read current directory: " + ec.message(), op.line,
+                    op.column);
+            }
+            std::filesystem::current_path(*op.cwd, ec);
+            if (ec) {
+                throw RuntimeError("cannot chdir to '" + *op.cwd + "' for run: " +
+                                       ec.message(),
+                                   op.line, op.column);
+            }
+            scope.active = true;
+        }
         int rc = std::system(op.command.c_str());
         if (rc == -1) {
             throw RuntimeError("failed to invoke shell for command '" +
@@ -1352,7 +1411,11 @@ void render_pending(std::ostream& out, const std::vector<PendingOp>& pending,
     for (const auto& op : pending) {
         if (const auto* r = std::get_if<PendingRun>(&op)) {
             ++i;
-            out << "  " << i << ". " << r->command << '\n';
+            out << "  " << i << ". " << r->command;
+            if (r->cwd.has_value()) {
+                out << " (in " << *r->cwd << ")";
+            }
+            out << '\n';
         }
     }
 }

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1333,9 +1333,28 @@ void render_pending(std::ostream& out, const std::vector<PendingOp>& pending,
     out << "Would create:\n";
     if (root.children.empty()) {
         out << "  (nothing)\n";
+    } else {
+        render_node(out, root, "", glyphs);
+    }
+
+    bool has_run = false;
+    for (const auto& op : pending) {
+        if (std::holds_alternative<PendingRun>(op)) {
+            has_run = true;
+            break;
+        }
+    }
+    if (!has_run) {
         return;
     }
-    render_node(out, root, "", glyphs);
+    out << "\nWould execute:\n";
+    std::size_t i = 0;
+    for (const auto& op : pending) {
+        if (const auto* r = std::get_if<PendingRun>(&op)) {
+            ++i;
+            out << "  " << i << ". " << r->command << '\n';
+        }
+    }
 }
 
 }  // namespace

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -14,7 +14,7 @@ static const std::unordered_map<std::string, TokenType> keywords = {
     {"mode", TokenType::MODE},         {"as", TokenType::AS},
     {"default", TokenType::DEFAULT},   {"options", TokenType::OPTIONS},
     {"copy", TokenType::COPY},         {"into", TokenType::INTO},
-    {"include", TokenType::INCLUDE},
+    {"include", TokenType::INCLUDE},   {"run", TokenType::RUN},
     {"and", TokenType::AND},           {"or", TokenType::OR},
     {"not", TokenType::NOT},           {"string", TokenType::STRING_TYPE},
     {"bool", TokenType::BOOL_TYPE},    {"int", TokenType::INT_TYPE},

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -15,6 +15,7 @@ static const std::unordered_map<std::string, TokenType> keywords = {
     {"default", TokenType::DEFAULT},   {"options", TokenType::OPTIONS},
     {"copy", TokenType::COPY},         {"into", TokenType::INTO},
     {"include", TokenType::INCLUDE},   {"run", TokenType::RUN},
+    {"in", TokenType::IN},
     {"and", TokenType::AND},           {"or", TokenType::OR},
     {"not", TokenType::NOT},           {"string", TokenType::STRING_TYPE},
     {"bool", TokenType::BOOL_TYPE},    {"int", TokenType::INT_TYPE},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -389,11 +389,16 @@ StmtPtr Parser::parseCopy() {
 StmtPtr Parser::parseRun() {
     Token start = expect(TokenType::RUN, "expected 'run'");
     auto command = parseExpression();
+    std::optional<PathExpr> cwd;
+    if (match(TokenType::IN)) {
+        cwd = parse_path_expr();
+    }
     auto when_clause = parse_when_clause();
     expect_newline("run statement");
 
     auto stmt = std::make_unique<Stmt>();
     stmt->data = RunStmt{.command = std::move(command),
+                         .cwd = std::move(cwd),
                          .when_clause = std::move(when_clause),
                          .line = start.line,
                          .column = start.column};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -384,6 +384,22 @@ StmtPtr Parser::parseCopy() {
     return stmt;
 }
 
+// Run statement parser
+
+StmtPtr Parser::parseRun() {
+    Token start = expect(TokenType::RUN, "expected 'run'");
+    auto command = parseExpression();
+    auto when_clause = parse_when_clause();
+    expect_newline("run statement");
+
+    auto stmt = std::make_unique<Stmt>();
+    stmt->data = RunStmt{.command = std::move(command),
+                         .when_clause = std::move(when_clause),
+                         .line = start.line,
+                         .column = start.column};
+    return stmt;
+}
+
 // Include statement parser
 
 StmtPtr Parser::parseInclude() {
@@ -456,6 +472,9 @@ StmtPtr Parser::parseStatement() {
     }
     if (check(TokenType::INCLUDE)) {
         return parseInclude();
+    }
+    if (check(TokenType::RUN)) {
+        return parseRun();
     }
     throw ParseError("unexpected token: " + current_.value, current_.line,
                      current_.column);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -277,6 +277,9 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
                 walk_optional_expr(s.when_clause, scope);
             } else if constexpr (std::is_same_v<T, IncludeStmt>) {
                 walk_optional_expr(s.when_clause, scope);
+            } else if constexpr (std::is_same_v<T, RunStmt>) {
+                walk_expr(*s.command, scope);
+                walk_optional_expr(s.when_clause, scope);
             } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                 check_reference(s.collection_var, s.line, s.column, scope);
                 walk_optional_expr(s.when_clause, scope);

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -279,6 +279,9 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
                 walk_optional_expr(s.when_clause, scope);
             } else if constexpr (std::is_same_v<T, RunStmt>) {
                 walk_expr(*s.command, scope);
+                if (s.cwd.has_value()) {
+                    walk_path(*s.cwd, scope, ctx, s.when_clause);
+                }
                 walk_optional_expr(s.when_clause, scope);
             } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                 check_reference(s.collection_var, s.line, s.column, scope);

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -172,6 +172,36 @@ TEST(CliTest, DryRunWithoutFileExitsOne) {
     EXPECT_NE(err.str().find("usage"), std::string::npos);
 }
 
+TEST(CliTest, RunWithYesSkipsAuthorization) {
+    TmpDir td;
+    auto file = td.path() / "ok.spud";
+    write_file(file, "run \"touch marker\"\n");
+    Argv args({"spudplate", "run", "--yes", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    prompter.set_authorize_response(false);  // would abort if --yes ignored
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "marker"));
+    EXPECT_FALSE(prompter.last_authorize_summary().has_value());
+}
+
+TEST(CliTest, RunWithoutYesAsksAuthorization) {
+    TmpDir td;
+    auto file = td.path() / "ok.spud";
+    write_file(file, "run \"touch should_not_exist\"\n");
+    Argv args({"spudplate", "run", file.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    prompter.set_authorize_response(false);
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "should_not_exist"));
+    EXPECT_TRUE(prompter.last_authorize_summary().has_value());
+}
+
 TEST(CliTest, MissingFileExitsFive) {
     TmpDir td;
     auto file = td.path() / "absent.spud";

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1908,6 +1908,80 @@ TEST(RunTest, SkipAuthorizationBypassesPrompt) {
     EXPECT_FALSE(prompter.last_authorize_summary().has_value());
 }
 
+TEST(RunTest, InClausePinsCwd) {
+    TmpDir td;
+    auto p = parse(R"(mkdir myapp
+run "touch marker" in myapp
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "myapp" / "marker"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "marker"));
+}
+
+TEST(RunTest, InClauseRestoresCwdAfterRun) {
+    TmpDir td;
+    auto saved = std::filesystem::current_path();
+    auto p = parse(R"(mkdir myapp
+run "touch marker" in myapp
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(std::filesystem::current_path(), saved);
+}
+
+TEST(RunTest, InClauseAcceptsAlias) {
+    TmpDir td;
+    auto p = parse(R"(mkdir myapp as proj
+run "touch marker" in proj
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "myapp" / "marker"));
+}
+
+TEST(RunTest, InClauseAcceptsInterpolation) {
+    TmpDir td;
+    auto p = parse(R"(let dir = "myapp"
+mkdir {dir}
+run "touch marker" in {dir}
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "myapp" / "marker"));
+}
+
+TEST(RunTest, InClauseMissingDirIsRuntimeError) {
+    TmpDir td;
+    auto p = parse(R"(run "echo hi" in nope
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+}
+
+TEST(RunTest, InClauseRestoresCwdOnCommandFailure) {
+    TmpDir td;
+    auto saved = std::filesystem::current_path();
+    auto p = parse(R"(mkdir myapp
+run "false" in myapp
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+    EXPECT_EQ(std::filesystem::current_path(), saved);
+}
+
+TEST(RunTest, AuthorizeSummaryIncludesInClause) {
+    TmpDir td;
+    auto p = parse(R"(mkdir myapp
+run "git init" in myapp
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    ASSERT_TRUE(prompter.last_authorize_summary().has_value());
+    EXPECT_NE(prompter.last_authorize_summary()->find("in myapp"),
+              std::string::npos);
+}
+
 TEST(RunTest, DryRunShowsCommandsButDoesNotExecute) {
     TmpDir td;
     auto p = parse(R"(run "touch should_not_exist"

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -63,6 +63,9 @@ class NullPrompter : public Prompter {
     std::string prompt(const PromptRequest& /*req*/) override {
         throw std::logic_error("NullPrompter should not be called");
     }
+    bool authorize(const std::string& /*summary*/) override {
+        throw std::logic_error("NullPrompter::authorize should not be called");
+    }
 };
 
 Program parse(const std::string& source) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1795,6 +1795,131 @@ end
     EXPECT_FALSE(std::filesystem::exists(td.path() / "week_1" / "sub_0"));
 }
 
+// --- Run statement ---
+
+TEST(RunTest, AuthorizedCommandExecutes) {
+    TmpDir td;
+    auto p = parse(R"(run "touch marker"
+)");
+    ScriptedPrompter prompter({});  // accept by default
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "marker"));
+}
+
+TEST(RunTest, DeclinedAbortsCleanly) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo
+run "touch foo/marker"
+)");
+    ScriptedPrompter prompter({});
+    prompter.set_authorize_response(false);
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
+}
+
+TEST(RunTest, NonZeroExitAbortsRun) {
+    TmpDir td;
+    auto p = parse(R"(mkdir before
+run "false"
+mkdir after
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+    // `before` was queued in pending_ before `run`, so the flush has
+    // already created it by the time `false` errors.
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "before"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "after"));
+}
+
+TEST(RunTest, WhenFalseSkipsCommand) {
+    TmpDir td;
+    auto p = parse(R"(ask flag "Run?" bool default false
+run "touch should_not_exist" when flag
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "should_not_exist"));
+}
+
+TEST(RunTest, InterpolatedCommandExecutes) {
+    TmpDir td;
+    auto p = parse(R"(let name = "marker.txt"
+run "touch " + name
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "marker.txt"));
+}
+
+TEST(RunTest, NonStringCommandIsRuntimeError) {
+    TmpDir td;
+    auto p = parse(R"(run 42
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), RuntimeError);
+}
+
+TEST(RunTest, ProgramWithoutRunDoesNotInvokeAuthorize) {
+    TmpDir td;
+    auto p = parse(R"(mkdir foo
+)");
+    ScriptedPrompter prompter({});
+    prompter.set_authorize_response(false);  // would abort if called
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "foo"));
+    EXPECT_FALSE(prompter.last_authorize_summary().has_value());
+}
+
+TEST(RunTest, AuthorizeSummaryListsLiteralCommands) {
+    TmpDir td;
+    auto p = parse(R"(run "git init"
+run "touch x"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    ASSERT_TRUE(prompter.last_authorize_summary().has_value());
+    const auto& s = *prompter.last_authorize_summary();
+    EXPECT_NE(s.find("git init"), std::string::npos);
+    EXPECT_NE(s.find("touch x"), std::string::npos);
+}
+
+TEST(RunTest, AuthorizeFlagsRepeatInternalCommands) {
+    TmpDir td;
+    auto p = parse(R"(let n = 1
+repeat n as i
+  run "echo loop"
+end
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    ASSERT_TRUE(prompter.last_authorize_summary().has_value());
+    EXPECT_NE(prompter.last_authorize_summary()->find("inside repeat"),
+              std::string::npos);
+}
+
+TEST(RunTest, SkipAuthorizationBypassesPrompt) {
+    TmpDir td;
+    auto p = parse(R"(run "touch from_skip"
+)");
+    ScriptedPrompter prompter({});
+    prompter.set_authorize_response(false);  // would abort if called
+    run(p, prompter, /*skip_authorization=*/true);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "from_skip"));
+    EXPECT_FALSE(prompter.last_authorize_summary().has_value());
+}
+
+TEST(RunTest, DryRunShowsCommandsButDoesNotExecute) {
+    TmpDir td;
+    auto p = parse(R"(run "touch should_not_exist"
+)");
+    ScriptedPrompter prompter({});
+    std::stringstream out;
+    dry_run(p, prompter, out);
+    EXPECT_NE(out.str().find("Would execute:"), std::string::npos);
+    EXPECT_NE(out.str().find("touch should_not_exist"), std::string::npos);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "should_not_exist"));
+}
+
 // --- Dry run ---
 
 TEST(DryRunTest, EmptyProgramRendersNothing) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1443,7 +1443,8 @@ file f append content "B"
 
 TEST(FileTest, ModeApplied) {
     TmpDir td;
-    auto p = parse(R"(file run.sh content "echo hi" mode 0755
+    // `run` is a reserved keyword; quote the path to use it as a filename.
+    auto p = parse(R"(file "run.sh" content "echo hi" mode 0755
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -103,6 +103,7 @@ TEST(LexerTest, AllKeywords) {
         {"end", TokenType::END},
         {"verbatim", TokenType::VERBATIM},
         {"run", TokenType::RUN},
+        {"in", TokenType::IN},
         {"mode", TokenType::MODE},
         {"as", TokenType::AS},
         {"and", TokenType::AND},

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -102,6 +102,7 @@ TEST(LexerTest, AllKeywords) {
         {"repeat", TokenType::REPEAT},
         {"end", TokenType::END},
         {"verbatim", TokenType::VERBATIM},
+        {"run", TokenType::RUN},
         {"mode", TokenType::MODE},
         {"as", TokenType::AS},
         {"and", TokenType::AND},

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -1128,8 +1128,37 @@ TEST(ParserTest, RunStringLiteral) {
     auto& cmd = std::get<StringLiteralExpr>(r.command->data);
     EXPECT_EQ(cmd.value, "git init");
     EXPECT_FALSE(r.when_clause.has_value());
+    EXPECT_FALSE(r.cwd.has_value());
     EXPECT_EQ(r.line, 1);
     EXPECT_EQ(r.column, 1);
+}
+
+TEST(ParserTest, RunWithInClause) {
+    auto stmt = parse_run("run \"git init\" in myapp\n");
+    auto& r = std::get<spudplate::RunStmt>(stmt->data);
+    ASSERT_TRUE(r.cwd.has_value());
+    ASSERT_EQ(r.cwd->segments.size(), 1u);
+    EXPECT_EQ(std::get<PathLiteral>(r.cwd->segments[0]).value, "myapp");
+    EXPECT_FALSE(r.when_clause.has_value());
+}
+
+TEST(ParserTest, RunWithInAndWhen) {
+    auto stmt = parse_run("run \"git init\" in myapp when use_git\n");
+    auto& r = std::get<spudplate::RunStmt>(stmt->data);
+    ASSERT_TRUE(r.cwd.has_value());
+    ASSERT_TRUE(r.when_clause.has_value());
+}
+
+TEST(ParserTest, RunInClauseAcceptsInterpolation) {
+    auto stmt = parse_run("run \"git init\" in {dir}\n");
+    auto& r = std::get<spudplate::RunStmt>(stmt->data);
+    ASSERT_TRUE(r.cwd.has_value());
+    ASSERT_EQ(r.cwd->segments.size(), 1u);
+    EXPECT_TRUE(std::holds_alternative<PathInterp>(r.cwd->segments[0]));
+}
+
+TEST(ParserTest, RunInWithoutPathIsError) {
+    EXPECT_THROW(parse_run("run \"x\" in\n"), ParseError);
 }
 
 TEST(ParserTest, RunWithWhen) {

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -1113,3 +1113,54 @@ TEST(ParserTest, IncludeAtTopLevelInProgram) {
 TEST(ParserTest, UnexpectedTokenAtTopLevel) {
     EXPECT_THROW(parse_program("42\n"), ParseError);
 }
+
+// --- Run statement tests ---
+
+static StmtPtr parse_run(const std::string& input) {
+    Lexer lexer(input);
+    Parser parser(std::move(lexer));
+    return parser.parseRun();
+}
+
+TEST(ParserTest, RunStringLiteral) {
+    auto stmt = parse_run("run \"git init\"\n");
+    auto& r = std::get<spudplate::RunStmt>(stmt->data);
+    auto& cmd = std::get<StringLiteralExpr>(r.command->data);
+    EXPECT_EQ(cmd.value, "git init");
+    EXPECT_FALSE(r.when_clause.has_value());
+    EXPECT_EQ(r.line, 1);
+    EXPECT_EQ(r.column, 1);
+}
+
+TEST(ParserTest, RunWithWhen) {
+    auto stmt = parse_run("run \"git init\" when use_git\n");
+    auto& r = std::get<spudplate::RunStmt>(stmt->data);
+    ASSERT_TRUE(r.when_clause.has_value());
+    auto& cond = std::get<IdentifierExpr>((*r.when_clause)->data);
+    EXPECT_EQ(cond.name, "use_git");
+}
+
+TEST(ParserTest, RunConcatenatedExpression) {
+    // Commands can be assembled from runtime values so a template can
+    // interpolate ask answers into the command string.
+    auto stmt = parse_run("run \"git clone \" + url\n");
+    auto& r = std::get<spudplate::RunStmt>(stmt->data);
+    EXPECT_EQ(std::get<BinaryExpr>(r.command->data).op, TokenType::PLUS);
+}
+
+TEST(ParserTest, RunMissingCommand) {
+    EXPECT_THROW(parse_run("run\n"), ParseError);
+}
+
+TEST(ParserTest, RunBareWhenRaisesError) {
+    EXPECT_THROW(parse_run("run \"x\" when\n"), ParseError);
+}
+
+TEST(ParserTest, RunAtTopLevelInProgram) {
+    auto program = parse_program(
+        "ask use_git \"Init git?\" bool\n"
+        "run \"git init\" when use_git\n");
+    ASSERT_EQ(program.statements.size(), 2u);
+    auto& r = std::get<spudplate::RunStmt>(program.statements[1]->data);
+    EXPECT_TRUE(r.when_clause.has_value());
+}

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -503,6 +503,42 @@ TEST(ValidatorTest, RepeatWhenNotFoldedIntoAliasCondition) {
     EXPECT_THROW(validate(program), SemanticError);
 }
 
+TEST(ValidatorTest, RunReferencesKnownVariable) {
+    auto program = parse(
+        "ask repo_url \"Repo url?\" string\n"
+        "run \"git clone \" + repo_url\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, RunInsideRepeatSeesIterator) {
+    auto program = parse(
+        "let n = 1\n"
+        "repeat n as i\n"
+        "  run \"echo \" + i\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, RunReferencesIteratorOutsideRepeatIsError) {
+    // The iterator goes out of scope when the repeat ends; using it after
+    // is what walk_expr's check_reference catches.
+    auto program = parse(
+        "let n = 1\n"
+        "repeat n as i\n"
+        "end\n"
+        "run \"echo \" + i\n");
+    EXPECT_THROW(validate(program), spudplate::SemanticError);
+}
+
+TEST(ValidatorTest, RunWhenReferencesIteratorOutsideRepeatIsError) {
+    auto program = parse(
+        "let n = 1\n"
+        "repeat n as i\n"
+        "end\n"
+        "run \"x\" when i > 0\n");
+    EXPECT_THROW(validate(program), spudplate::SemanticError);
+}
+
 TEST(ValidatorTest, ComposedRulesEndToEnd) {
     // Exercises Part A (repeat when), Part B (no ask-in-repeat — valid case),
     // Part C (nested let scoping), and Part E (bool-equivalent alias when).

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -530,6 +530,23 @@ TEST(ValidatorTest, RunReferencesIteratorOutsideRepeatIsError) {
     EXPECT_THROW(validate(program), spudplate::SemanticError);
 }
 
+TEST(ValidatorTest, RunInClauseReferencesAlias) {
+    auto program = parse(
+        "mkdir myapp as proj\n"
+        "run \"git init\" in proj\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, RunInClauseReferencesPoppedAliasIsError) {
+    auto program = parse(
+        "let n = 1\n"
+        "repeat n as i\n"
+        "  mkdir foo as bar\n"
+        "end\n"
+        "run \"echo hi\" in bar\n");
+    EXPECT_THROW(validate(program), spudplate::SemanticError);
+}
+
 TEST(ValidatorTest, RunWhenReferencesIteratorOutsideRepeatIsError) {
     auto program = parse(
         "let n = 1\n"


### PR DESCRIPTION
## Summary
Adds `run "<command>" [in <path>] [when <cond>]` to spudlang. Each `spudplate run` invocation that contains run clauses prompts the user once for authorisation before any statement executes; declining aborts cleanly with no side effects. Commands run via `/bin/sh -c` during the deferred-write flush, in source order alongside the file ops, and the optional `in <path>` clause pins the working directory.

## Changes
- New `run` and `in` keywords. Parses `run <expression> [in <path>] [when <condition>]`. Command is an expression so it can compose runtime values (e.g. `"git clone " + url`); cwd is a regular path expression supporting alias references and `{expr}` interpolation.
- Validator walks the command expression, the cwd path, and the when clause through the existing scope check.
- Interpreter runs a pre-execution scan, builds a multi-line summary listing each command's source-form expression (including `in <path>`, with notes for repeat-internal and conditional clauses), and calls `Prompter::authorize`. Returning false aborts cleanly. The `Prompter` interface gains an `authorize(summary)` method; both `StdinPrompter` and `ScriptedPrompter` implement it.
- Authorised `run` statements queue a `PendingRun` op with the resolved cwd alongside file ops. At flush time each command runs via `std::system`; if a cwd is set the interpreter chdirs under RAII so the original cwd is restored on every exit path. A non-zero exit, signal, or invocation failure raises a runtime error and aborts the rest of the flush.
- Dry-run mode lists evaluated commands in a separate `Would execute:` block under the file tree (with `(in <cwd>)` annotation when set) and never executes them.
- CLI accepts `--yes` (or `-y`) to bypass the trust prompt for non-interactive callers; the caller takes responsibility for vetting the source.
- The existing `FileTest.ModeApplied` template path was unquoted `run.sh`, now quoted, since `run` is a reserved keyword.
- Trust prompt fires every `spudplate run`. Once `spudplate install` lands, install-time consent will record a per-template authorisation so installed templates run without re-prompting.
- The summary lists literal source expressions; the *evaluated* command is what executes. `ask`/`let` values flowing into a run command are untrusted and the user is responsible for quoting them appropriately. Documented as a known caveat with example.
- Working directory: without `in <path>`, commands inherit `spudplate`'s cwd. Templates that create a project subdirectory should pin every following command to it via `in <path>`. No timeout. No allowlist. Privilege escalation prompts naturally (sudo).

## Test plan
- All 442 (35 new) tests pass locally
- New tests cover: lexing both keywords, parsing literal/concatenated commands, the `in` clause with literal/alias/interpolated paths, error paths, validator scope checks across command/cwd/when, runtime authorisation accept/decline, non-zero exit aborting the flush, when-false skipping, runtime interpolation, type-mismatch (non-string command), bypass via `--yes`, the `in` clause pinning cwd and restoring it on success and failure, missing-cwd-dir runtime error, dry-run rendering with cwd annotation, and CLI flag plumbing
- Manual run with both accept and decline paths confirms no side effects on decline and the in-clause lands files in the expected subdirectory