### PR TITLE
feat: interpolate file content strings

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -197,7 +197,7 @@ Creates a file at `<path>`, either from a source file (`from`) or from an inline
 
 - `append` — appends to the file instead of overwriting. Without `append`, the file is created fresh (or overwritten if previously created in the same run).
 - `from <source>` — embeds the contents of `<source>` at compile time. `{var}` interpolation is applied at runtime unless `verbatim` is specified.
-- `content <expression>` — inline content; supports `{var}` interpolation via string concatenation.
+- `content <expression>` — inline content. The resulting string is interpolated: any `{var}` occurrence in the value is replaced with the bound variable's value (`content "n={n}"` writes `n=1` when `n` is `1`). String concatenation also works (`content "n=" + name`). An unclosed `{` or an unknown variable name is a runtime error.
 - `mode <octal>` — sets file permissions (e.g., `mode 0644`, `mode 0755`).
 - `when <condition>` — only creates the file if the condition is true.
 - `as <name>` — binds the file path; useful for conditional appends.
@@ -374,8 +374,8 @@ use_tests
 
 Interpolation appears in two places with slightly different grammars:
 
-- **Path expressions** and `content` values support full `{expr}` interpolation (`mkdir week_{n}`, `content "v" + version`).
-- **`from` source files** and files copied by `copy` support only bare `{ident}` substitution — no function calls, no arithmetic, no string concatenation. Use `verbatim` to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
+- **Path expressions** support full `{expr}` interpolation (`mkdir week_{n}`, `mkdir {prefix}/notes`).
+- **`content` values**, **`from` source files**, and files copied by `copy` support only bare `{ident}` substitution — no function calls, no arithmetic, no string concatenation inside the braces. For richer values in a `content` expression, use string concatenation (`content "v" + version`). Use `verbatim` (on `from` and `copy`) to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
 
 ---
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -942,6 +942,7 @@ class Interpreter {
         } else {
             const auto& content_src = std::get<FileContentSource>(s.source);
             content = value_to_string(evaluate_expr(*content_src.value, env_));
+            content = interpolate_content(content, env_, s.line, s.column);
         }
 
         std::string path_str = evaluate_path(s.path, env_, alias_map_);

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1436,6 +1436,53 @@ file foo.txt content "hello, " + name
     EXPECT_EQ(read_file(td.path() / "foo.txt"), "hello, world");
 }
 
+TEST(FileTest, ContentBraceInterpolatesString) {
+    TmpDir td;
+    auto p = parse(R"(let name = "world"
+file foo.txt content "hello, {name}!"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "hello, world!");
+}
+
+TEST(FileTest, ContentBraceInterpolatesInt) {
+    TmpDir td;
+    auto p = parse(R"(let n = 7
+file foo.txt content "n={n}"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "n=7");
+}
+
+TEST(FileTest, ContentBraceInterpolatesMultipleVars) {
+    TmpDir td;
+    auto p = parse(R"(let a = "x"
+let b = "y"
+file foo.txt content "{a} and {b}"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_EQ(read_file(td.path() / "foo.txt"), "x and y");
+}
+
+TEST(FileTest, ContentBraceMissingVarErrors) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt content "{nope}"
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), spudplate::RuntimeError);
+}
+
+TEST(FileTest, ContentBraceUnclosedErrors) {
+    TmpDir td;
+    auto p = parse(R"(file foo.txt content "{name"
+)");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(run(p, prompter), spudplate::RuntimeError);
+}
+
 TEST(FileTest, FileInsideQueuedDirectory) {
     TmpDir td;
     auto p = parse(R"(mkdir x


### PR DESCRIPTION
## Summary
Apply `{var}` substitution to `content` strings on `file`, matching the documented behaviour and the existing `from`/`copy` interpolation

## Changes
- `execute_file` runs `interpolate_content` over the resolved content string
- `syntax.md` describes the substitution rule on `content` and aligns the Variable Interpolation section with what each form actually supports

## Test plan
- All 466 (5 new) tests pass locally
- Covers single string substitution, single int substitution, multiple variables, missing variable error, and unclosed brace error