### PR TITLE
feat: stringify int in mixed concat

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -64,6 +64,8 @@ Computes a new variable from an expression. Useful for transforming user input b
 
 **Integer operations:** `+`, `-`, `*`, `/`
 
+**Mixed:** `+` between a string and an int stringifies the int (`"week " + n` → `"week 3"`).
+
 **Examples:**
 
 ```
@@ -354,7 +356,7 @@ use_tests
 
 | Operator | Types         | Description              |
 |----------|---------------|--------------------------|
-| `+`      | string, int   | Concatenation / addition |
+| `+`      | string, int   | Concatenation / addition (mixed string-and-int stringifies the int) |
 | `-`      | int           | Subtraction              |
 | `*`      | int           | Multiplication           |
 | `/`      | int           | Division                 |

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -322,11 +322,19 @@ Value eval_binary(const BinaryExpr& bin, const Environment& env) {
                                  std::get<std::int64_t>(right))};
     }
 
-    // Arithmetic — `+` accepts both int+int and string+string; the others
+    // Arithmetic — `+` accepts string+string, string+int, and int+int.
+    // A string-and-int combination stringifies the int side; the others
     // are int-only.
     if (bin.op == TokenType::PLUS && std::holds_alternative<std::string>(left) &&
         std::holds_alternative<std::string>(right)) {
         return Value{std::get<std::string>(left) + std::get<std::string>(right)};
+    }
+    if (bin.op == TokenType::PLUS &&
+        ((std::holds_alternative<std::string>(left) &&
+          std::holds_alternative<std::int64_t>(right)) ||
+         (std::holds_alternative<std::int64_t>(left) &&
+          std::holds_alternative<std::string>(right)))) {
+        return Value{value_to_string(left) + value_to_string(right)};
     }
     if (!std::holds_alternative<std::int64_t>(left) ||
         !std::holds_alternative<std::int64_t>(right)) {

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -375,9 +375,21 @@ TEST(EvalExprTest, StringConcat) {
     EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "foobar");
 }
 
-TEST(EvalExprTest, StringPlusIntThrows) {
+TEST(EvalExprTest, StringPlusIntStringifies) {
     Environment env;
     auto e = binop(TokenType::PLUS, str_lit("a"), int_lit(1));
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "a1");
+}
+
+TEST(EvalExprTest, IntPlusStringStringifies) {
+    Environment env;
+    auto e = binop(TokenType::PLUS, int_lit(42), str_lit("!"));
+    EXPECT_EQ(std::get<std::string>(evaluate_expr(*e, env)), "42!");
+}
+
+TEST(EvalExprTest, StringPlusBoolStillThrows) {
+    Environment env;
+    auto e = binop(TokenType::PLUS, str_lit("a"), bool_lit(true));
     EXPECT_THROW(evaluate_expr(*e, env), RuntimeError);
 }
 


### PR DESCRIPTION
## Summary
Allow `+` to concatenate a string and an int by stringifying the int side, so `"week " + n` produces `"week 3"`

## Changes
- `eval_binary` adds a string-and-int branch that stringifies via `value_to_string` and concatenates
- Replaces the old `StringPlusIntThrows` test with three new tests covering both orderings and confirming `string + bool` still errors
- `syntax.md` documents the mixed rule under `let` and the operator table

## Test plan
- All 468 (3 new, 1 reworked) tests pass locally