### PR TITLE
feat: universal string-literal interpolation

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -197,7 +197,7 @@ Creates a file at `<path>`, either from a source file (`from`) or from an inline
 
 - `append` — appends to the file instead of overwriting. Without `append`, the file is created fresh (or overwritten if previously created in the same run).
 - `from <source>` — embeds the contents of `<source>` at compile time. `{var}` interpolation is applied at runtime unless `verbatim` is specified.
-- `content <expression>` — inline content. The resulting string is interpolated: any `{var}` occurrence in the value is replaced with the bound variable's value (`content "n={n}"` writes `n=1` when `n` is `1`). String concatenation also works (`content "n=" + name`). An unclosed `{` or an unknown variable name is a runtime error.
+- `content <expression>` — inline content. String literals interpolate `{expr}` like everywhere else (`content "n={n}"` writes `n=1` when `n` is `1`). String concatenation also works (`content "n=" + name`). See **Variable Interpolation** below for the full rules.
 - `mode <octal>` — sets file permissions (e.g., `mode 0644`, `mode 0755`).
 - `when <condition>` — only creates the file if the condition is true.
 - `as <name>` — binds the file path; useful for conditional appends.
@@ -372,10 +372,13 @@ use_tests
 
 ## Variable Interpolation
 
-Interpolation appears in two places with slightly different grammars:
+Spudlang interpolates `{expr}` in three places:
 
-- **Path expressions** support full `{expr}` interpolation (`mkdir week_{n}`, `mkdir {prefix}/notes`).
-- **`content` values**, **`from` source files**, and files copied by `copy` support only bare `{ident}` substitution — no function calls, no arithmetic, no string concatenation inside the braces. For richer values in a `content` expression, use string concatenation (`content "v" + version`). Use `verbatim` (on `from` and `copy`) to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
+- **String literals** in any expression — `let s = "hello {name}"`, `run "echo {label}"`, `ask q "{prompt_for}?" string`. The full expression grammar applies inside the braces (identifiers, arithmetic, function calls, string concatenation). Each interpolation result is stringified and concatenated with the surrounding literal text. Brace pairs are balanced, so `{f({x})}` parses as a single interpolation. A `"` inside an interpolation closes the surrounding string literal — keep the inner expression to identifiers and operations on them, or bind a value with `let` first.
+- **Path expressions** in `mkdir`, `file`, `copy` — `mkdir week_{n}`, `mkdir {prefix}/notes`. Same expression grammar, with no surrounding quotes.
+- **`from` source files** and files copied by `copy` — only bare `{ident}` substitution is applied to file contents read from disk; no function calls or arithmetic inside the braces. Use `verbatim` to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
+
+Errors are surfaced at parse time where possible: an unclosed `{`, an empty `{}`, or an interpolation whose contents don't parse as an expression all stop the build before the run begins. An interpolation that references an undeclared name surfaces in the validator the same as any other expression.
 
 ---
 

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -78,9 +78,26 @@ struct FunctionCallExpr {
     int column;  ///< 1-based source column where this node begins.
 };
 
+/**
+ * @brief A string literal containing one or more `{expr}` interpolations.
+ *
+ * Produced by the parser when a `"..."` string literal contains any
+ * `{...}` segment. Each `parts` entry is either a literal string fragment
+ * (the text between braces) or an expression to evaluate and stringify.
+ * Evaluation concatenates the stringified parts in order. A plain string
+ * literal (no `{...}`) parses as a `StringLiteralExpr`; this type is used
+ * only when at least one interpolation is present.
+ */
+struct TemplateStringExpr {
+    std::vector<std::variant<std::string, ExprPtr>> parts;  ///< Ordered literal/expression segments.
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
+};
+
 /** @brief Discriminated union of all expression node types. */
 using ExprData = std::variant<StringLiteralExpr, IntegerLiteralExpr, BoolLiteralExpr,
-                              IdentifierExpr, UnaryExpr, BinaryExpr, FunctionCallExpr>;
+                              IdentifierExpr, UnaryExpr, BinaryExpr, FunctionCallExpr,
+                              TemplateStringExpr>;
 
 /** @brief An expression node wrapping an ExprData variant. */
 struct Expr {

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -91,6 +91,13 @@ class Parser {
     std::optional<int> parse_mode_clause();
     PathExpr parse_path_expr();
     ExprPtr parse_literal();
+    /**
+     * Build the AST node for a string literal token. If the raw value
+     * contains `{...}` interpolations, returns a `TemplateStringExpr`
+     * with each interpolation sub-parsed as an expression. Otherwise
+     * returns a plain `StringLiteralExpr`.
+     */
+    ExprPtr make_string_expression(const std::string& raw, int line, int column);
     void expect_newline(const std::string& context);
 
     // Expression precedence climbing

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -942,7 +942,6 @@ class Interpreter {
         } else {
             const auto& content_src = std::get<FileContentSource>(s.source);
             content = value_to_string(evaluate_expr(*content_src.value, env_));
-            content = interpolate_content(content, env_, s.line, s.column);
         }
 
         std::string path_str = evaluate_path(s.path, env_, alias_map_);

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1227,6 +1227,17 @@ Value evaluate_expr(const Expr& expr, const Environment& env) {
                 return eval_binary(e, env);
             } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
                 return eval_call(e, env);
+            } else if constexpr (std::is_same_v<T, TemplateStringExpr>) {
+                std::string out;
+                for (const auto& p : e.parts) {
+                    if (std::holds_alternative<std::string>(p)) {
+                        out += std::get<std::string>(p);
+                    } else {
+                        out += value_to_string(
+                            evaluate_expr(*std::get<ExprPtr>(p), env));
+                    }
+                }
+                return Value{std::move(out)};
             }
         },
         expr.data);

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -468,6 +468,18 @@ std::string preview_expr(const Expr& expr) {
                 }
                 out += ")";
                 return out;
+            } else if constexpr (std::is_same_v<T, TemplateStringExpr>) {
+                std::string out = "\"";
+                for (const auto& p : e.parts) {
+                    if (std::holds_alternative<std::string>(p)) {
+                        out += std::get<std::string>(p);
+                    } else {
+                        out += "{" +
+                               preview_expr(*std::get<ExprPtr>(p)) + "}";
+                    }
+                }
+                out += "\"";
+                return out;
             }
             return "<unknown>";
         },

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -75,13 +75,75 @@ void Parser::expect_newline(const std::string& context) {
     expect(TokenType::NEWLINE, "expected newline after " + context);
 }
 
+ExprPtr Parser::make_string_expression(const std::string& raw, int line,
+                                       int column) {
+    if (raw.find('{') == std::string::npos) {
+        auto expr = std::make_unique<Expr>();
+        expr->data = StringLiteralExpr{.value = raw, .line = line, .column = column};
+        return expr;
+    }
+
+    std::vector<std::variant<std::string, ExprPtr>> parts;
+    std::string buf;
+    std::size_t i = 0;
+    while (i < raw.size()) {
+        char c = raw[i];
+        if (c != '{') {
+            buf.push_back(c);
+            ++i;
+            continue;
+        }
+        // Find the matching close, tracking brace depth so `{f({x})}` works.
+        std::size_t scan = i + 1;
+        int depth = 1;
+        while (scan < raw.size() && depth > 0) {
+            if (raw[scan] == '{') {
+                ++depth;
+            } else if (raw[scan] == '}') {
+                --depth;
+                if (depth == 0) {
+                    break;
+                }
+            }
+            ++scan;
+        }
+        if (depth != 0) {
+            throw ParseError("unclosed '{' in string literal", line, column);
+        }
+        std::string inner = raw.substr(i + 1, scan - i - 1);
+        if (inner.empty()) {
+            throw ParseError("empty '{}' in string literal", line, column);
+        }
+        if (!buf.empty()) {
+            parts.emplace_back(std::move(buf));
+            buf.clear();
+        }
+        Lexer sub_lexer(inner);
+        Parser sub_parser(std::move(sub_lexer));
+        ExprPtr inner_expr = sub_parser.parseExpression();
+        if (!sub_parser.check(TokenType::EOF_TOKEN) &&
+            !sub_parser.check(TokenType::NEWLINE)) {
+            throw ParseError(
+                "extra tokens in string interpolation '{" + inner + "}'", line,
+                column);
+        }
+        parts.emplace_back(std::move(inner_expr));
+        i = scan + 1;
+    }
+    if (!buf.empty()) {
+        parts.emplace_back(std::move(buf));
+    }
+
+    auto expr = std::make_unique<Expr>();
+    expr->data = TemplateStringExpr{
+        .parts = std::move(parts), .line = line, .column = column};
+    return expr;
+}
+
 ExprPtr Parser::parse_literal() {
     if (check(TokenType::STRING_LITERAL)) {
         Token tok = advance();
-        auto expr = std::make_unique<Expr>();
-        expr->data =
-            StringLiteralExpr{.value = tok.value, .line = tok.line, .column = tok.column};
-        return expr;
+        return make_string_expression(tok.value, tok.line, tok.column);
     }
     if (check(TokenType::INTEGER_LITERAL)) {
         Token tok = advance();
@@ -654,10 +716,7 @@ ExprPtr Parser::parse_unary() {
 ExprPtr Parser::parse_primary() {
     if (check(TokenType::STRING_LITERAL)) {
         Token tok = advance();
-        auto expr = std::make_unique<Expr>();
-        expr->data =
-            StringLiteralExpr{.value = tok.value, .line = tok.line, .column = tok.column};
-        return expr;
+        return make_string_expression(tok.value, tok.line, tok.column);
     }
 
     if (check(TokenType::INTEGER_LITERAL)) {

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -185,6 +185,12 @@ void walk_expr(const Expr& expr, const Scope& scope) {
                 for (const auto& arg : e.arguments) {
                     walk_expr(*arg, scope);
                 }
+            } else if constexpr (std::is_same_v<T, TemplateStringExpr>) {
+                for (const auto& p : e.parts) {
+                    if (std::holds_alternative<ExprPtr>(p)) {
+                        walk_expr(*std::get<ExprPtr>(p), scope);
+                    }
+                }
             }
             // String, Integer, Bool literals have no children.
         },
@@ -365,6 +371,20 @@ ExprPtr clone_expr(const Expr& expr) {
                                                   .arguments = std::move(cloned_args),
                                                   .line = n.line,
                                                   .column = n.column});
+            } else if constexpr (std::is_same_v<T, TemplateStringExpr>) {
+                std::vector<std::variant<std::string, ExprPtr>> cloned_parts;
+                cloned_parts.reserve(n.parts.size());
+                for (const auto& p : n.parts) {
+                    if (std::holds_alternative<std::string>(p)) {
+                        cloned_parts.emplace_back(std::get<std::string>(p));
+                    } else {
+                        cloned_parts.emplace_back(
+                            clone_expr(*std::get<ExprPtr>(p)));
+                    }
+                }
+                return make_expr(TemplateStringExpr{.parts = std::move(cloned_parts),
+                                                    .line = n.line,
+                                                    .column = n.column});
             }
         },
         expr.data);
@@ -442,6 +462,25 @@ bool exprs_equal(const Expr& a, const Expr& b) {
                 }
                 for (size_t i = 0; i < ax.arguments.size(); ++i) {
                     if (!exprs_equal(*ax.arguments[i], *bx.arguments[i])) {
+                        return false;
+                    }
+                }
+                return true;
+            } else if constexpr (std::is_same_v<T, TemplateStringExpr>) {
+                if (ax.parts.size() != bx.parts.size()) {
+                    return false;
+                }
+                for (size_t i = 0; i < ax.parts.size(); ++i) {
+                    if (ax.parts[i].index() != bx.parts[i].index()) {
+                        return false;
+                    }
+                    if (std::holds_alternative<std::string>(ax.parts[i])) {
+                        if (std::get<std::string>(ax.parts[i]) !=
+                            std::get<std::string>(bx.parts[i])) {
+                            return false;
+                        }
+                    } else if (!exprs_equal(*std::get<ExprPtr>(ax.parts[i]),
+                                            *std::get<ExprPtr>(bx.parts[i]))) {
                         return false;
                     }
                 }

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -1151,6 +1151,88 @@ let slug = lower(trim(project_name))
     EXPECT_EQ(std::get<std::string>(*env.lookup("slug")), "my project");
 }
 
+// --- Universal string-literal interpolation ---
+
+TEST(TemplateStringTest, InterpolatesIdentifierInLet) {
+    auto p = parse(R"(let name = "world"
+let greet = "hello {name}!"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("greet")), "hello world!");
+}
+
+TEST(TemplateStringTest, StringifiesIntInInterpolation) {
+    auto p = parse(R"(let n = 42
+let s = "n={n}"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("s")), "n=42");
+}
+
+TEST(TemplateStringTest, StringifiesBoolInInterpolation) {
+    auto p = parse(R"(let b = true
+let s = "b={b}"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("s")), "b=true");
+}
+
+TEST(TemplateStringTest, ArithmeticInInterpolation) {
+    auto p = parse(R"(let n = 5
+let s = "next={n + 1}"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("s")), "next=6");
+}
+
+TEST(TemplateStringTest, FunctionCallInInterpolation) {
+    auto p = parse(R"(let raw = "  Hi  "
+let s = "[{trim(raw)}]"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("s")), "[Hi]");
+}
+
+TEST(TemplateStringTest, MultipleInterpolations) {
+    auto p = parse(R"(let a = "x"
+let b = 2
+let s = "{a} times {b}"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("s")), "x times 2");
+}
+
+TEST(TemplateStringTest, StringifyOnly) {
+    // `"{n}"` is a single-part template that stringifies n as the entire result.
+    auto p = parse(R"(let n = 7
+let s = "{n}"
+)");
+    ScriptedPrompter prompter({});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("s")), "7");
+}
+
+TEST(TemplateStringTest, RunCommandPreviewKeepsBraceForm) {
+    // The trust prompt shows the literal source — interpolations stay
+    // visible as `{...}` so the user sees what flows into the command.
+    TmpDir td;
+    auto p = parse(R"(let label = "ok"
+run "echo hi {label}"
+)");
+    ScriptedPrompter prompter({});
+    prompter.set_authorize_response(false);
+    run(p, prompter);
+    ASSERT_TRUE(prompter.last_authorize_summary().has_value());
+    EXPECT_NE(prompter.last_authorize_summary()->find("{label}"),
+              std::string::npos);
+}
+
 TEST(ScriptedPrompterTest, ExhaustionThrowsLogicError) {
     auto p = parse(R"(ask name "Name?" string
 )");
@@ -1475,12 +1557,10 @@ TEST(FileTest, ContentBraceMissingVarErrors) {
     EXPECT_THROW(run(p, prompter), spudplate::RuntimeError);
 }
 
-TEST(FileTest, ContentBraceUnclosedErrors) {
-    TmpDir td;
-    auto p = parse(R"(file foo.txt content "{name"
-)");
-    ScriptedPrompter prompter({});
-    EXPECT_THROW(run(p, prompter), spudplate::RuntimeError);
+TEST(FileTest, ContentBraceUnclosedErrorsAtParse) {
+    EXPECT_THROW(parse(R"(file foo.txt content "{name"
+)"),
+                 spudplate::ParseError);
 }
 
 TEST(FileTest, FileInsideQueuedDirectory) {

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -31,6 +31,7 @@ using spudplate::Program;
 using spudplate::RepeatStmt;
 using spudplate::StmtPtr;
 using spudplate::StringLiteralExpr;
+using spudplate::TemplateStringExpr;
 using spudplate::TokenType;
 using spudplate::UnaryExpr;
 using spudplate::VarType;
@@ -518,6 +519,90 @@ TEST(ParserTest, AssignDispatchedFromProgram) {
     std::get<LetStmt>(program.statements[0]->data);
     auto& a = std::get<AssignStmt>(program.statements[1]->data);
     EXPECT_EQ(a.name, "n");
+}
+
+// --- String-literal template parsing ---
+
+TEST(ParserTest, PlainStringStaysLiteral) {
+    auto e = parse_expr(R"("hello")");
+    auto& lit = std::get<StringLiteralExpr>(e->data);
+    EXPECT_EQ(lit.value, "hello");
+}
+
+TEST(ParserTest, EmptyStringStaysLiteral) {
+    auto e = parse_expr(R"("")");
+    auto& lit = std::get<StringLiteralExpr>(e->data);
+    EXPECT_EQ(lit.value, "");
+}
+
+TEST(ParserTest, SingleInterpolationProducesTemplate) {
+    auto e = parse_expr(R"("hello {name}")");
+    auto& tpl = std::get<TemplateStringExpr>(e->data);
+    ASSERT_EQ(tpl.parts.size(), 2u);
+    EXPECT_EQ(std::get<std::string>(tpl.parts[0]), "hello ");
+    auto& id = std::get<IdentifierExpr>(
+        std::get<ExprPtr>(tpl.parts[1])->data);
+    EXPECT_EQ(id.name, "name");
+}
+
+TEST(ParserTest, SoleInterpolationHasOnlyExprPart) {
+    auto e = parse_expr(R"("{n}")");
+    auto& tpl = std::get<TemplateStringExpr>(e->data);
+    ASSERT_EQ(tpl.parts.size(), 1u);
+    auto& id = std::get<IdentifierExpr>(
+        std::get<ExprPtr>(tpl.parts[0])->data);
+    EXPECT_EQ(id.name, "n");
+}
+
+TEST(ParserTest, MultipleInterpolations) {
+    auto e = parse_expr(R"("{a} and {b}!")");
+    auto& tpl = std::get<TemplateStringExpr>(e->data);
+    ASSERT_EQ(tpl.parts.size(), 4u);
+    auto& a = std::get<IdentifierExpr>(
+        std::get<ExprPtr>(tpl.parts[0])->data);
+    EXPECT_EQ(a.name, "a");
+    EXPECT_EQ(std::get<std::string>(tpl.parts[1]), " and ");
+    auto& b = std::get<IdentifierExpr>(
+        std::get<ExprPtr>(tpl.parts[2])->data);
+    EXPECT_EQ(b.name, "b");
+    EXPECT_EQ(std::get<std::string>(tpl.parts[3]), "!");
+}
+
+TEST(ParserTest, InterpolationWithArithmetic) {
+    auto e = parse_expr(R"("week {n + 1}")");
+    auto& tpl = std::get<TemplateStringExpr>(e->data);
+    ASSERT_EQ(tpl.parts.size(), 2u);
+    auto& bin = std::get<BinaryExpr>(
+        std::get<ExprPtr>(tpl.parts[1])->data);
+    EXPECT_EQ(bin.op, TokenType::PLUS);
+}
+
+TEST(ParserTest, InterpolationWithFunctionCall) {
+    auto e = parse_expr(R"("slug={lower(name)}")");
+    auto& tpl = std::get<TemplateStringExpr>(e->data);
+    ASSERT_EQ(tpl.parts.size(), 2u);
+    auto& call = std::get<FunctionCallExpr>(
+        std::get<ExprPtr>(tpl.parts[1])->data);
+    EXPECT_EQ(call.name, "lower");
+}
+
+TEST(ParserTest, NestedBracesInInterpolation) {
+    // Brace-balanced scanning so the inner `{ }` doesn't close the outer.
+    auto e = parse_expr(R"("{a + b}")");
+    auto& tpl = std::get<TemplateStringExpr>(e->data);
+    EXPECT_EQ(tpl.parts.size(), 1u);
+}
+
+TEST(ParserTest, UnclosedBraceErrors) {
+    EXPECT_THROW(parse_expr(R"("hello {name")"), ParseError);
+}
+
+TEST(ParserTest, EmptyBraceErrors) {
+    EXPECT_THROW(parse_expr(R"("hello {}")"), ParseError);
+}
+
+TEST(ParserTest, GarbageInterpolationErrors) {
+    EXPECT_THROW(parse_expr(R"("hello {1 +}")"), ParseError);
 }
 
 // --- Mkdir statement tests ---

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -613,6 +613,34 @@ TEST(ValidatorTest, ReassignOutOfScopeLetIsError) {
     EXPECT_THROW(validate(program), spudplate::SemanticError);
 }
 
+// --- String-literal template scoping ---
+
+TEST(ValidatorTest, TemplateInLetReferencesDeclaredVar) {
+    auto program = parse(
+        "let n = 1\n"
+        "let m = \"value={n}\"\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, TemplateReferencingUndeclaredOutOfScopeIsError) {
+    auto program = parse(
+        "let n = 3\n"
+        "repeat n as i\n"
+        "  let local = 0\n"
+        "end\n"
+        "let s = \"value={local}\"\n");
+    EXPECT_THROW(validate(program), spudplate::SemanticError);
+}
+
+TEST(ValidatorTest, TemplateInWhenInRunIsWalked) {
+    auto program = parse(
+        "let n = 1\n"
+        "repeat n as i\n"
+        "end\n"
+        "run \"echo {i}\"\n");
+    EXPECT_THROW(validate(program), spudplate::SemanticError);
+}
+
 TEST(ValidatorTest, ComposedRulesEndToEnd) {
     // Exercises Part A (repeat when), Part B (no ask-in-repeat — valid case),
     // Part C (nested let scoping), and Part E (bool-equivalent alias when).


### PR DESCRIPTION
## Summary
Make `{expr}` interpolation work inside any string literal, not just paths and `from`/`copy` source contents

## Changes
- New `TemplateStringExpr` AST node carrying ordered literal/expression parts
- Parser splits any string literal containing `{...}` at parse time, sub-parsing each interpolation as a full expression with brace-balanced scanning so `{f({x})}` works as one segment
- Validator walks each interpolation expression for scope and identifier checks; `clone_expr` and `exprs_equal` handle the new node
- Interpreter evaluates by stringifying each part and concatenating; the trust prompt's preview keeps the literal source form so `run "echo {label}"` still surfaces `{label}` to the user
- Removes the runtime `interpolate_content` pass over `file content` strings, since string literals now self-template at expression-evaluation time. `from`/`copy` file contents still go through runtime interpolation as before
- Documents the new universal rule in `syntax.md` and aligns the per-statement notes

## Test plan
- All 488 (22 new) tests pass locally
- Parser coverage: plain string, empty string, single interpolation, sole-expression template, multiple parts, arithmetic, function call, brace nesting, unclosed brace, empty `{}`, garbage expression
- Validator coverage: template references in `let` value, out-of-scope reference from `let`, out-of-scope reference inside a `run` command
- Interpreter coverage: string, int, and bool stringification; arithmetic and function call inside braces; multi-part templates; single-expression templates; literal `{label}` form preserved in the run trust prompt