### PR TITLE
feat: install layer for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ Write a `.spud` file in spudlang, install it once, and run it whenever you want 
 To share a template, export it as a `.spudpack` (a signed zip) and the recipient installs it the same way.
 
 ```
-spudplate install my_template.spud
-spudplate run my_template
+spudplate install my_template.spud      # validate, store under the install root
+spudplate run my_template               # run by installed name
+spudplate run path/to/file.spud         # or run a file directly
+spudplate list                          # list installed templates
+spudplate inspect my_template           # print the source
+spudplate uninstall my_template         # remove
 
 spudplate export my_template -o my_template.spudpack
 ```
+
+The install root is `$SPUDPLATE_HOME` if set, otherwise `$HOME/.spudplate`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ spudplate uninstall my_template         # remove
 spudplate export my_template -o my_template.spudpack
 ```
 
-The install root is `$SPUDPLATE_HOME` if set, otherwise `$HOME/.spudplate`.
+The install root is `$SPUDPLATE_HOME` if set, otherwise `$XDG_DATA_HOME/spudplate` (default `~/.local/share/spudplate` on most systems).
 
 ## Example
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,5 +1,6 @@
 #include "spudplate/cli.h"
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -8,6 +9,7 @@
 #include <sstream>
 #include <string>
 #include <system_error>
+#include <vector>
 
 #include "spudplate/interpreter.h"
 #include "spudplate/lexer.h"
@@ -172,6 +174,81 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     return 0;
 }
 
+int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    if (argc != 2) {
+        print_usage(err);
+        return 1;
+    }
+    std::filesystem::path home = install_dir();
+    if (home.empty()) {
+        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        return 1;
+    }
+    if (!std::filesystem::is_directory(home)) {
+        return 0;  // No installs yet — empty output, success.
+    }
+    std::vector<std::string> names;
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
+        if (entry.is_directory() &&
+            std::filesystem::is_regular_file(entry.path() / "template.spud")) {
+            names.push_back(entry.path().filename().string());
+        }
+    }
+    std::sort(names.begin(), names.end());
+    for (const auto& n : names) {
+        out << n << "\n";
+    }
+    return 0;
+}
+
+int cmd_inspect(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    if (argc - 2 != 1) {
+        print_usage(err);
+        return 1;
+    }
+    std::string name{argv[2]};
+    std::filesystem::path home = install_dir();
+    if (home.empty()) {
+        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        return 1;
+    }
+    std::filesystem::path file_path = home / name / "template.spud";
+    std::ifstream in(file_path);
+    if (!in) {
+        err << name << ": not installed\n";
+        return 5;
+    }
+    out << in.rdbuf();
+    return 0;
+}
+
+int cmd_uninstall(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    if (argc - 2 != 1) {
+        print_usage(err);
+        return 1;
+    }
+    std::string name{argv[2]};
+    std::filesystem::path home = install_dir();
+    if (home.empty()) {
+        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        return 1;
+    }
+    std::filesystem::path target = home / name;
+    if (!std::filesystem::is_directory(target)) {
+        err << name << ": not installed\n";
+        return 5;
+    }
+    std::error_code ec;
+    std::filesystem::remove_all(target, ec);
+    if (ec) {
+        err << name << ": cannot remove: " << ec.message() << "\n";
+        return 1;
+    }
+    out << "uninstalled " << name << "\n";
+    return 0;
+}
+
 int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
             Prompter& prompter) {
     bool dry_run_mode = false;
@@ -257,6 +334,15 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     }
     if (subcommand == "install") {
         return cmd_install(argc, argv, out, err);
+    }
+    if (subcommand == "list") {
+        return cmd_list(argc, argv, out, err);
+    }
+    if (subcommand == "inspect") {
+        return cmd_inspect(argc, argv, out, err);
+    }
+    if (subcommand == "uninstall") {
+        return cmd_uninstall(argc, argv, out, err);
     }
     print_usage(err);
     return 1;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -31,16 +31,21 @@ void print_usage(std::ostream& err) {
         << "  uninstall <name>                remove an installed template\n";
 }
 
-// Resolve the directory templates are installed into. Honours
-// `SPUDPLATE_HOME` for tests and ad-hoc overrides; otherwise falls back to
-// `$HOME/.spudplate`. Returns an empty path if neither is set so the
-// caller can surface a usable error.
+// Resolve the directory templates are installed into. Honours, in order:
+//   1. `SPUDPLATE_HOME` — explicit override (used by tests and dev setups).
+//   2. `XDG_DATA_HOME/spudplate` — the XDG Base Directory standard.
+//   3. `$HOME/.local/share/spudplate` — XDG default when the env var is unset.
+// Returns an empty path if none of those sources is available so the caller
+// can surface a usable error.
 std::filesystem::path install_dir() {
     if (const char* env = std::getenv("SPUDPLATE_HOME"); env != nullptr && *env != '\0') {
         return env;
     }
+    if (const char* xdg = std::getenv("XDG_DATA_HOME"); xdg != nullptr && *xdg != '\0') {
+        return std::filesystem::path(xdg) / "spudplate";
+    }
     if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0') {
-        return std::filesystem::path(home) / ".spudplate";
+        return std::filesystem::path(home) / ".local" / "share" / "spudplate";
     }
     return {};
 }
@@ -74,7 +79,8 @@ std::filesystem::path resolve_template_arg(const std::string& arg,
     }
     auto dir = install_dir();
     if (dir.empty()) {
-        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        err << "cannot determine install directory: set SPUDPLATE_HOME, "
+           "XDG_DATA_HOME, or HOME\n";
         return {};
     }
     return dir / arg / "template.spud";
@@ -130,7 +136,8 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
 
     std::filesystem::path home = install_dir();
     if (home.empty()) {
-        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        err << "cannot determine install directory: set SPUDPLATE_HOME, "
+           "XDG_DATA_HOME, or HOME\n";
         return 1;
     }
 
@@ -181,7 +188,8 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     }
     std::filesystem::path home = install_dir();
     if (home.empty()) {
-        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        err << "cannot determine install directory: set SPUDPLATE_HOME, "
+           "XDG_DATA_HOME, or HOME\n";
         return 1;
     }
     if (!std::filesystem::is_directory(home)) {
@@ -210,7 +218,8 @@ int cmd_inspect(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     std::string name{argv[2]};
     std::filesystem::path home = install_dir();
     if (home.empty()) {
-        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        err << "cannot determine install directory: set SPUDPLATE_HOME, "
+           "XDG_DATA_HOME, or HOME\n";
         return 1;
     }
     std::filesystem::path file_path = home / name / "template.spud";
@@ -231,7 +240,8 @@ int cmd_uninstall(int argc, char* argv[], std::ostream& out, std::ostream& err) 
     std::string name{argv[2]};
     std::filesystem::path home = install_dir();
     if (home.empty()) {
-        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        err << "cannot determine install directory: set SPUDPLATE_HOME, "
+           "XDG_DATA_HOME, or HOME\n";
         return 1;
     }
     std::filesystem::path target = home / name;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,10 +1,13 @@
 #include "spudplate/cli.h"
 
 #include <cerrno>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <system_error>
 
 #include "spudplate/interpreter.h"
 #include "spudplate/lexer.h"
@@ -16,7 +19,39 @@ namespace spudplate {
 namespace {
 
 void print_usage(std::ostream& err) {
-    err << "usage: spudplate run [--dry-run] [--yes] <file.spud>\n";
+    err << "usage: spudplate <command> [args...]\n"
+        << "  install <file.spud>             validate and store a template\n"
+        << "  run [--dry-run] [--yes] <name|file.spud>\n"
+        << "                                  run an installed template by name,\n"
+        << "                                  or run a .spud file directly\n"
+        << "  list                            list installed templates\n"
+        << "  inspect <name>                  print the source of an installed template\n"
+        << "  uninstall <name>                remove an installed template\n";
+}
+
+// Resolve the directory templates are installed into. Honours
+// `SPUDPLATE_HOME` for tests and ad-hoc overrides; otherwise falls back to
+// `$HOME/.spudplate`. Returns an empty path if neither is set so the
+// caller can surface a usable error.
+std::filesystem::path install_dir() {
+    if (const char* env = std::getenv("SPUDPLATE_HOME"); env != nullptr && *env != '\0') {
+        return env;
+    }
+    if (const char* home = std::getenv("HOME"); home != nullptr && *home != '\0') {
+        return std::filesystem::path(home) / ".spudplate";
+    }
+    return {};
+}
+
+// Heuristic: an argument that contains a slash or ends with `.spud` is
+// treated as a path. Anything else is an installed-template name.
+bool looks_like_path(const std::string& arg) {
+    if (arg.find('/') != std::string::npos) {
+        return true;
+    }
+    constexpr std::string_view ext = ".spud";
+    return arg.size() >= ext.size() &&
+           arg.compare(arg.size() - ext.size(), ext.size(), ext) == 0;
 }
 
 void print_error(std::ostream& err, const std::string& file, const char* kind,
@@ -25,20 +60,26 @@ void print_error(std::ostream& err, const std::string& file, const char* kind,
         << message << "\n";
 }
 
-}  // namespace
-
-int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
-             Prompter& prompter) {
-    if (argc < 2) {
-        print_usage(err);
-        return 1;
+// Resolve a `run`/`inspect`/`uninstall` argument to a `.spud` file path on
+// disk. If the argument looks like a path it is returned as-is; otherwise
+// it is treated as an installed template name. Returns the empty path and
+// writes a diagnostic to `err` if the install dir cannot be located. The
+// caller is responsible for checking whether the returned path exists.
+std::filesystem::path resolve_template_arg(const std::string& arg,
+                                           std::ostream& err) {
+    if (looks_like_path(arg)) {
+        return arg;
     }
-    std::string subcommand{argv[1]};
-    if (subcommand != "run") {
-        print_usage(err);
-        return 1;
+    auto dir = install_dir();
+    if (dir.empty()) {
+        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        return {};
     }
+    return dir / arg / "template.spud";
+}
 
+int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
+            Prompter& prompter) {
     bool dry_run_mode = false;
     bool skip_authorization = false;
     int positional_start = 2;
@@ -59,10 +100,15 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
         return 1;
     }
 
-    std::string file_path{argv[positional_start]};
+    std::string raw_arg{argv[positional_start]};
+    std::filesystem::path file_path = resolve_template_arg(raw_arg, err);
+    if (file_path.empty()) {
+        return 1;
+    }
     std::ifstream in(file_path);
     if (!in) {
-        err << file_path << ": cannot open: " << std::strerror(errno) << "\n";
+        err << file_path.string() << ": cannot open: " << std::strerror(errno)
+            << "\n";
         return 5;
     }
     std::stringstream buffer;
@@ -75,16 +121,16 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
         Parser parser(std::move(lexer));
         program = parser.parse();
     } catch (const ParseError& e) {
-        print_error(err, file_path, "parse error", e.line(), e.column(),
-                    e.what());
+        print_error(err, file_path.string(), "parse error", e.line(),
+                    e.column(), e.what());
         return 2;
     }
 
     try {
         validate(program);
     } catch (const SemanticError& e) {
-        print_error(err, file_path, "semantic error", e.line(), e.column(),
-                    e.what());
+        print_error(err, file_path.string(), "semantic error", e.line(),
+                    e.column(), e.what());
         return 3;
     }
 
@@ -95,12 +141,28 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
             run(program, prompter, skip_authorization);
         }
     } catch (const RuntimeError& e) {
-        print_error(err, file_path, "runtime error", e.line(), e.column(),
-                    e.what());
+        print_error(err, file_path.string(), "runtime error", e.line(),
+                    e.column(), e.what());
         return 4;
     }
 
     return 0;
+}
+
+}  // namespace
+
+int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
+             Prompter& prompter) {
+    if (argc < 2) {
+        print_usage(err);
+        return 1;
+    }
+    std::string subcommand{argv[1]};
+    if (subcommand == "run") {
+        return cmd_run(argc, argv, out, err, prompter);
+    }
+    print_usage(err);
+    return 1;
 }
 
 }  // namespace spudplate

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -78,6 +78,100 @@ std::filesystem::path resolve_template_arg(const std::string& arg,
     return dir / arg / "template.spud";
 }
 
+// Parse and validate `source` so install rejects broken templates before
+// they are copied. Returns true on success; on failure writes a `<file>:`
+// diagnostic to `err` and sets `exit_code` to the appropriate error.
+bool validate_template_source(const std::string& source,
+                              const std::string& file_label,
+                              std::ostream& err, int& exit_code) {
+    try {
+        Lexer lexer(source);
+        Parser parser(std::move(lexer));
+        Program program = parser.parse();
+        validate(program);
+    } catch (const ParseError& e) {
+        print_error(err, file_label, "parse error", e.line(), e.column(),
+                    e.what());
+        exit_code = 2;
+        return false;
+    } catch (const SemanticError& e) {
+        print_error(err, file_label, "semantic error", e.line(), e.column(),
+                    e.what());
+        exit_code = 3;
+        return false;
+    }
+    return true;
+}
+
+int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    if (argc - 2 != 1) {
+        print_usage(err);
+        return 1;
+    }
+
+    std::filesystem::path source_path{argv[2]};
+    std::ifstream in(source_path);
+    if (!in) {
+        err << source_path.string() << ": cannot open: " << std::strerror(errno)
+            << "\n";
+        return 5;
+    }
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    std::string source = buffer.str();
+
+    int exit_code = 0;
+    if (!validate_template_source(source, source_path.string(), err,
+                                  exit_code)) {
+        return exit_code;
+    }
+
+    std::filesystem::path home = install_dir();
+    if (home.empty()) {
+        err << "cannot determine install directory: set SPUDPLATE_HOME or HOME\n";
+        return 1;
+    }
+
+    std::string name = source_path.stem().string();
+    if (name.empty()) {
+        err << source_path.string() << ": cannot derive template name\n";
+        return 1;
+    }
+
+    std::filesystem::path target_dir = home / name;
+    if (std::filesystem::exists(target_dir)) {
+        err << name
+            << ": already installed (use 'spudplate uninstall " << name
+            << "' first)\n";
+        return 1;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(target_dir, ec);
+    if (ec) {
+        err << target_dir.string()
+            << ": cannot create install directory: " << ec.message() << "\n";
+        return 1;
+    }
+    std::filesystem::path target_file = target_dir / "template.spud";
+    std::ofstream sink(target_file, std::ios::binary);
+    if (!sink) {
+        err << target_file.string()
+            << ": cannot write: " << std::strerror(errno) << "\n";
+        std::filesystem::remove_all(target_dir, ec);
+        return 1;
+    }
+    sink << source;
+    if (!sink.good()) {
+        err << target_file.string() << ": write failed\n";
+        std::filesystem::remove_all(target_dir, ec);
+        return 1;
+    }
+
+    out << "installed " << name << " to " << target_dir.string() << "\n";
+    return 0;
+}
+
 int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
             Prompter& prompter) {
     bool dry_run_mode = false;
@@ -160,6 +254,9 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     std::string subcommand{argv[1]};
     if (subcommand == "run") {
         return cmd_run(argc, argv, out, err, prompter);
+    }
+    if (subcommand == "install") {
+        return cmd_install(argc, argv, out, err);
     }
     print_usage(err);
     return 1;

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -50,6 +50,33 @@ void write_file(const std::filesystem::path& p, const std::string& content) {
     out << content;
 }
 
+// Scoped override of `SPUDPLATE_HOME`. Tests use this to point the CLI at
+// a temporary install root so they don't touch the user's real
+// `~/.spudplate` directory. Restores the previous value on destruction.
+class ScopedHome {
+  public:
+    explicit ScopedHome(const std::filesystem::path& dir) {
+        if (const char* prev = std::getenv("SPUDPLATE_HOME"); prev != nullptr) {
+            had_prev_ = true;
+            prev_ = prev;
+        }
+        ::setenv("SPUDPLATE_HOME", dir.c_str(), /*overwrite=*/1);
+    }
+    ScopedHome(const ScopedHome&) = delete;
+    ScopedHome& operator=(const ScopedHome&) = delete;
+    ~ScopedHome() {
+        if (had_prev_) {
+            ::setenv("SPUDPLATE_HOME", prev_.c_str(), /*overwrite=*/1);
+        } else {
+            ::unsetenv("SPUDPLATE_HOME");
+        }
+    }
+
+  private:
+    bool had_prev_{false};
+    std::string prev_;
+};
+
 // Build an argv array suitable for cli_main from a vector of arguments.
 class Argv {
   public:
@@ -212,4 +239,69 @@ TEST(CliTest, MissingFileExitsFive) {
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 5);
     EXPECT_NE(err.str().find("cannot open"), std::string::npos);
+}
+
+// --- install ---
+
+TEST(CliTest, InstallSuccessStoresTemplate) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    auto src = td.path() / "demo.spud";
+    write_file(src, "ask name \"Project name?\" string\nmkdir {name}\n");
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_TRUE(std::filesystem::is_regular_file(home / "demo" / "template.spud"));
+    EXPECT_NE(out.str().find("installed demo"), std::string::npos);
+}
+
+TEST(CliTest, InstallRejectsDuplicate) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    auto src = td.path() / "demo.spud";
+    write_file(src, "mkdir foo\n");
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream out1;
+    std::stringstream err1;
+    ScriptedPrompter prompter({});
+    ASSERT_EQ(cli_main(args.argc(), args.argv(), out1, err1, prompter), 0)
+        << err1.str();
+    std::stringstream out2;
+    std::stringstream err2;
+    int code = cli_main(args.argc(), args.argv(), out2, err2, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err2.str().find("already installed"), std::string::npos);
+}
+
+TEST(CliTest, InstallRejectsBrokenTemplateAndLeavesNoTrace) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    auto src = td.path() / "broken.spud";
+    write_file(src, "ask\n");  // parse error: missing args
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 2);
+    EXPECT_FALSE(std::filesystem::exists(home / "broken"));
+}
+
+TEST(CliTest, InstallMissingFileExitsFive) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    auto src = td.path() / "absent.spud";
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
 }

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -50,31 +50,49 @@ void write_file(const std::filesystem::path& p, const std::string& content) {
     out << content;
 }
 
-// Scoped override of `SPUDPLATE_HOME`. Tests use this to point the CLI at
-// a temporary install root so they don't touch the user's real
-// `~/.spudplate` directory. Restores the previous value on destruction.
-class ScopedHome {
+// Save and restore an environment variable around a test. Set the value
+// with `set()` or remove it with `unset()`; the original is reinstated on
+// destruction so other tests in the suite are unaffected.
+class ScopedEnv {
   public:
-    explicit ScopedHome(const std::filesystem::path& dir) {
-        if (const char* prev = std::getenv("SPUDPLATE_HOME"); prev != nullptr) {
+    explicit ScopedEnv(std::string name) : name_(std::move(name)) {
+        if (const char* prev = std::getenv(name_.c_str()); prev != nullptr) {
             had_prev_ = true;
             prev_ = prev;
         }
-        ::setenv("SPUDPLATE_HOME", dir.c_str(), /*overwrite=*/1);
     }
-    ScopedHome(const ScopedHome&) = delete;
-    ScopedHome& operator=(const ScopedHome&) = delete;
-    ~ScopedHome() {
+    ScopedEnv(const ScopedEnv&) = delete;
+    ScopedEnv& operator=(const ScopedEnv&) = delete;
+    ~ScopedEnv() {
         if (had_prev_) {
-            ::setenv("SPUDPLATE_HOME", prev_.c_str(), /*overwrite=*/1);
+            ::setenv(name_.c_str(), prev_.c_str(), /*overwrite=*/1);
         } else {
-            ::unsetenv("SPUDPLATE_HOME");
+            ::unsetenv(name_.c_str());
         }
     }
 
+    void set(const std::string& value) {
+        ::setenv(name_.c_str(), value.c_str(), /*overwrite=*/1);
+    }
+    void unset() {
+        ::unsetenv(name_.c_str());
+    }
+
   private:
+    std::string name_;
     bool had_prev_{false};
     std::string prev_;
+};
+
+// Convenience: scope `SPUDPLATE_HOME` to a temp install root.
+class ScopedHome {
+  public:
+    explicit ScopedHome(const std::filesystem::path& dir) : env_("SPUDPLATE_HOME") {
+        env_.set(dir.string());
+    }
+
+  private:
+    ScopedEnv env_;
 };
 
 // Build an argv array suitable for cli_main from a vector of arguments.
@@ -291,6 +309,25 @@ TEST(CliTest, InstallRejectsBrokenTemplateAndLeavesNoTrace) {
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 2);
     EXPECT_FALSE(std::filesystem::exists(home / "broken"));
+}
+
+TEST(CliTest, InstallUsesXdgDataHomeWhenNoSpudplateHome) {
+    TmpDir td;
+    ScopedEnv spud_home("SPUDPLATE_HOME");
+    ScopedEnv xdg("XDG_DATA_HOME");
+    spud_home.unset();
+    auto xdg_root = td.path() / "xdg";
+    xdg.set(xdg_root.string());
+    auto src = td.path() / "demo.spud";
+    write_file(src, "mkdir foo\n");
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_TRUE(std::filesystem::is_regular_file(
+        xdg_root / "spudplate" / "demo" / "template.spud"));
 }
 
 TEST(CliTest, InstallMissingFileExitsFive) {

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -342,3 +342,98 @@ TEST(CliTest, RunByUnknownNameExitsFive) {
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 5);
 }
+
+// --- list / inspect / uninstall ---
+
+namespace {
+void install_template(const std::filesystem::path& src, const std::string& body) {
+    write_file(src, body);
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream o;
+    std::stringstream e;
+    ScriptedPrompter p({});
+    ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
+}
+}  // namespace
+
+TEST(CliTest, ListEmptyProducesNoOutput) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    Argv args({"spudplate", "list"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_EQ(out.str(), "");
+}
+
+TEST(CliTest, ListShowsInstalledNamesSorted) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "zebra.spud", "mkdir z\n");
+    install_template(td.path() / "alpha.spud", "mkdir a\n");
+    Argv args({"spudplate", "list"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_EQ(out.str(), "alpha\nzebra\n");
+}
+
+TEST(CliTest, InspectPrintsSource) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    const std::string body = "mkdir hello\n";
+    install_template(td.path() / "demo.spud", body);
+    Argv args({"spudplate", "inspect", "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_EQ(out.str(), body);
+}
+
+TEST(CliTest, InspectUnknownExitsFive) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    Argv args({"spudplate", "inspect", "ghost"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+}
+
+TEST(CliTest, UninstallRemovesTemplate) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud", "mkdir x\n");
+    ASSERT_TRUE(std::filesystem::is_directory(home / "demo"));
+    Argv args({"spudplate", "uninstall", "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_FALSE(std::filesystem::exists(home / "demo"));
+}
+
+TEST(CliTest, UninstallUnknownExitsFive) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    Argv args({"spudplate", "uninstall", "ghost"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+}

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -305,3 +305,40 @@ TEST(CliTest, InstallMissingFileExitsFive) {
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 5);
 }
+
+// --- run by installed name ---
+
+TEST(CliTest, RunByNameLooksUpInstalledTemplate) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    auto src = td.path() / "demo.spud";
+    write_file(src, "ask name \"Project name?\" string\nmkdir {name}\n");
+    {
+        Argv install_args({"spudplate", "install", src.string()});
+        std::stringstream o;
+        std::stringstream e;
+        ScriptedPrompter p({});
+        ASSERT_EQ(cli_main(install_args.argc(), install_args.argv(), o, e, p), 0)
+            << e.str();
+    }
+    Argv run_args({"spudplate", "run", "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({"my_project"});
+    int code = cli_main(run_args.argc(), run_args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "my_project"));
+}
+
+TEST(CliTest, RunByUnknownNameExitsFive) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    Argv args({"spudplate", "run", "ghost"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+}


### PR DESCRIPTION
## Summary
Add an install root so templates can be stored once and run by name, with `install`, `run`, `list`, `inspect`, and `uninstall` subcommands

## Changes
- Install root resolved in order: `SPUDPLATE_HOME` → `XDG_DATA_HOME/spudplate` → `$HOME/.local/share/spudplate`. Each installed template lives in its own subdirectory containing `template.spud`.
- New subcommands:
  - `spudplate install <file.spud>` parses, validates, then copies the source into `<root>/<name>/template.spud`. Rejects duplicates and broken templates without leaving any partial state behind.
  - `spudplate run <name>` looks the name up under the install root. `run path/to/file.spud` still runs a file directly — the resolver treats arguments containing `/` or ending in `.spud` as paths.
  - `spudplate list` prints installed names sorted alphabetically.
  - `spudplate inspect <name>` prints the source.
  - `spudplate uninstall <name>` removes the install entry.
- `cli_main` refactored to dispatch on subcommand instead of running a single hardcoded path.
- Asset bundling for `from`/`copy` source files is not yet implemented; templates that read assets via relative paths still need those resolvable from the working directory at run time. That is the next branch.

## Test plan
- All 501 (13 new) tests pass locally
- `install` covered: success, duplicate rejection, broken template leaves no residue, missing source file, XDG fallback when no `SPUDPLATE_HOME`
- `run` by name covered: success after install, unknown name exits with the file-not-found code
- `list` covered: empty install root and multiple installs sorted
- `inspect` covered: prints source, unknown name errors
- `uninstall` covered: removes the directory, unknown name errors