### PR TITLE
feat: release pipeline and shell installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write  # required to create and upload to a GitHub Release
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            asset_name: spudplate-linux-x86_64
+          - os: macos-14
+            asset_name: spudplate-darwin-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build --config Release
+
+      - name: Strip
+        run: strip build/spudplate
+
+      - name: Stage binary
+        run: cp build/spudplate ${{ matrix.asset_name }}
+
+      - name: Checksum
+        run: shasum -a 256 ${{ matrix.asset_name }} > ${{ matrix.asset_name }}.sha256
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: |
+            ${{ matrix.asset_name }}
+            ${{ matrix.asset_name }}.sha256
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Stage release assets
+        run: |
+          set -eu
+          mkdir -p release
+          find artifacts -type f -name 'spudplate-*' ! -name '*.sha256' -exec cp {} release/ \;
+          (cd release && find ../artifacts -name '*.sha256' -exec cat {} \;) > release/SHA256SUMS
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release/*
+          prerelease: true
+          generate_release_notes: true
+          body: |
+            **Pre-1.0 release.** The CLI surface is reasonably stable but breaking changes are expected before `v1.0`.
+
+            Install with:
+            ```
+            curl -fsSL https://raw.githubusercontent.com/spuddydev/spudplate/main/install.sh | sh
+            ```
+
+            Or download a binary directly from the assets below and put it on your `PATH`. Verify with `shasum -a 256 -c SHA256SUMS`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,18 @@ target_include_directories(spudplate_lib PUBLIC include)
 add_executable(spudplate src/main.cpp)
 target_link_libraries(spudplate PRIVATE spudplate_lib)
 
+# Install rule — `cmake --install build` drops the binary at the configured
+# prefix (default `/usr/local`). `GNUInstallDirs` resolves
+# `CMAKE_INSTALL_BINDIR` so distro packagers and the release workflow get the
+# expected layout.
+include(GNUInstallDirs)
+install(TARGETS spudplate RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 # Testing
 include(FetchContent)
+# `INSTALL_GTEST OFF` keeps googletest's headers and static libraries out
+# of `cmake --install`, so the install only contains the spudplate binary.
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git

--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@
 
 Write a `.spud` file in spudlang, install it once, and run it whenever you want to scaffold a new project. The interpreter prompts the user and creates files and directories based on their answers.
 
+> **Pre-1.0.** spudplate works end to end but breaking changes are expected before `v1.0`. Pin to a specific release if you need stability.
+
+## Install
+
+One-liner (Linux x86_64, macOS arm64):
+
+```
+curl -fsSL https://raw.githubusercontent.com/spuddydev/spudplate/main/install.sh | sh
+```
+
+Drops the binary in `~/.local/bin`. Set `PREFIX=/usr/local` (and run with `sudo`) to install system-wide, or `VERSION=v0.1.0` to pin to a tag.
+
+Alternatives:
+- Download a binary from the [releases page](https://github.com/spuddydev/spudplate/releases) and put it on your `PATH`. `SHA256SUMS` is published alongside.
+- Build from source — see [Build](#build) below, then `sudo cmake --install build`.
+
 ## How it works
 
 1. Write a `.spud` file describing your template

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# spudplate installer — fetches the release binary for your OS/arch from
+# GitHub Releases, verifies its checksum, and drops it on your PATH.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/spuddydev/spudplate/main/install.sh | sh
+#
+# Environment overrides:
+#   PREFIX   install root (default $HOME/.local). Binary lands in $PREFIX/bin.
+#   VERSION  release tag to install (default: latest).
+#
+# Pre-1.0 software — breaking changes are expected before v1.0.
+
+set -eu
+
+REPO="spuddydev/spudplate"
+PREFIX="${PREFIX:-$HOME/.local}"
+VERSION="${VERSION:-latest}"
+
+err() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+info() {
+    printf '%s\n' "$*"
+}
+
+detect_target() {
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "$os" in
+        Linux)  os_tag=linux ;;
+        Darwin) os_tag=darwin ;;
+        *)      err "unsupported OS: $os" ;;
+    esac
+    case "$arch" in
+        x86_64|amd64)  arch_tag=x86_64 ;;
+        arm64|aarch64) arch_tag=arm64 ;;
+        *)             err "unsupported architecture: $arch" ;;
+    esac
+    if [ "$os_tag" = linux ] && [ "$arch_tag" != x86_64 ]; then
+        err "no Linux $arch_tag build yet — build from source: https://github.com/$REPO"
+    fi
+    if [ "$os_tag" = darwin ] && [ "$arch_tag" != arm64 ]; then
+        err "no macOS $arch_tag build yet — build from source: https://github.com/$REPO"
+    fi
+    target="spudplate-${os_tag}-${arch_tag}"
+}
+
+resolve_urls() {
+    if [ "$VERSION" = latest ]; then
+        base="https://github.com/$REPO/releases/latest/download"
+    else
+        base="https://github.com/$REPO/releases/download/$VERSION"
+    fi
+    binary_url="$base/$target"
+    sums_url="$base/SHA256SUMS"
+}
+
+download() {
+    url="$1"
+    out="$2"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$out" "$url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$out" "$url"
+    else
+        err "neither curl nor wget is installed"
+    fi
+}
+
+verify_checksum() {
+    file="$1"
+    sums="$2"
+    expected=$(awk -v t="$target" '$2 == t || $2 == "*"t { print $1; exit }' "$sums")
+    if [ -z "$expected" ]; then
+        err "no checksum entry for $target in SHA256SUMS"
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        actual=$(shasum -a 256 "$file" | awk '{ print $1 }')
+    elif command -v sha256sum >/dev/null 2>&1; then
+        actual=$(sha256sum "$file" | awk '{ print $1 }')
+    else
+        err "no shasum or sha256sum available to verify the download"
+    fi
+    if [ "$expected" != "$actual" ]; then
+        err "checksum mismatch: expected $expected, got $actual"
+    fi
+}
+
+main() {
+    detect_target
+    resolve_urls
+    info "spudplate installer"
+    info "  target:  $target"
+    info "  version: $VERSION"
+    info "  prefix:  $PREFIX"
+
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT INT TERM
+
+    info "downloading $binary_url"
+    download "$binary_url" "$tmp/$target"
+    info "downloading checksums"
+    download "$sums_url" "$tmp/SHA256SUMS"
+
+    verify_checksum "$tmp/$target" "$tmp/SHA256SUMS"
+
+    mkdir -p "$PREFIX/bin"
+    install_path="$PREFIX/bin/spudplate"
+    mv "$tmp/$target" "$install_path"
+    chmod +x "$install_path"
+
+    info ""
+    info "installed to $install_path"
+
+    case ":$PATH:" in
+        *":$PREFIX/bin:"*) ;;
+        *)
+            info ""
+            info "warning: $PREFIX/bin is not on your PATH"
+            info "add this line to your shell config (~/.bashrc, ~/.zshrc, etc.):"
+            info "  export PATH=\"$PREFIX/bin:\$PATH\""
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Make spudplate easy to install on a fresh machine via `curl ... | sh`, plus the supporting CMake install rule and tagged-release workflow

## Changes
- `CMakeLists.txt` adds an `install(TARGETS spudplate)` rule resolved through `GNUInstallDirs`. `cmake --install build --prefix /tmp/foo` drops the binary at `/tmp/foo/bin/spudplate` and nothing else (googletest's install rules are suppressed via `INSTALL_GTEST OFF` so the install prefix stays clean).
- `.github/workflows/release.yml` triggers on `v*` tag pushes, builds Release binaries on `ubuntu-22.04` and `macos-14`, strips them, names them `spudplate-linux-x86_64` and `spudplate-darwin-arm64`, computes SHA-256 checksums, and uploads everything as a pre-release on GitHub with a combined `SHA256SUMS` file.
- `install.sh` is a POSIX shell installer that detects OS and arch, downloads the matching binary plus `SHA256SUMS`, verifies the checksum, drops the binary at `$PREFIX/bin` (default `~/.local/bin`), and warns if that directory is not on `PATH`. Supports `PREFIX` and `VERSION` env overrides; works with either curl or wget; verified clean by shellcheck.
- README adds an Install section with the one-liner, plus a pre-1.0 disclaimer at the top so users know to expect breaking changes.

## How to ship the first release
1. Land this PR on `main`.
2. Tag a commit on `main`: `git tag v0.1.0 && git push origin v0.1.0`.
3. The release workflow builds and publishes the assets.
4. Anyone can then run `curl -fsSL https://raw.githubusercontent.com/spuddydev/spudplate/main/install.sh | sh`.

## Test plan
- Existing 501 tests still pass locally
- `cmake --install build --prefix /tmp/foo` produces only `/tmp/foo/bin/spudplate`
- `shellcheck install.sh` is clean
- Workflow YAML is syntactically valid GitHub Actions; first real run will be triggered by the v0.1.0 tag after merge