### PR TITLE
fix: stop publishing releases as prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: release/*
-          prerelease: true
           generate_release_notes: true
           body: |
             **Pre-1.0 release.** The CLI surface is reasonably stable but breaking changes are expected before `v1.0`.


### PR DESCRIPTION
## Summary
Drop the `prerelease: true` flag from the release workflow so the install one-liner can resolve `releases/latest/download/...`

## Background
GitHub's `releases/latest` redirect excludes prereleases. v0.1.0 was marked as prerelease, so the install.sh hit 404 when it tried to fetch the binary from `/releases/latest/download/spudplate-darwin-arm64`. The pre-1.0 disclaimer belongs in the README, not the release prerelease flag.

I unmarked v0.1.0 manually via `gh release edit v0.1.0 --prerelease=false` so the existing release works. This PR fixes the workflow so future tags don't reintroduce the bug.

## Test plan
- After merge, next tagged release will publish as a normal release and the install one-liner will resolve immediately