### PR TITLE
feat: install overwrite prompt and validate

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ To share a template, export it as a `.spudpack` (a signed zip) and the recipient
 
 ```
 spudplate install my_template.spud      # validate, store under the install root
+spudplate install --yes my_template.spud  # overwrite an existing install without prompting
+spudplate validate my_template.spud     # parse and validate without installing (also: `check`)
 spudplate run my_template               # run by installed name
 spudplate run path/to/file.spud         # or run a file directly
 spudplate list                          # list installed templates
@@ -42,6 +44,8 @@ spudplate uninstall my_template         # remove
 
 spudplate export my_template -o my_template.spudpack
 ```
+
+`install` prompts before overwriting an existing template. Pass `--yes` to skip the prompt (useful for scripts and CI).
 
 The install root is `$SPUDPLATE_HOME` if set, otherwise `$XDG_DATA_HOME/spudplate` (default `~/.local/share/spudplate` on most systems).
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -29,6 +29,7 @@ void print_usage(std::ostream& err) {
         << "  run [--dry-run] [--yes] <name|file.spud>\n"
         << "                                  run an installed template by name,\n"
         << "                                  or run a .spud file directly\n"
+        << "  validate <file.spud>            parse and validate without installing\n"
         << "  list                            list installed templates\n"
         << "  inspect <name>                  print the source of an installed template\n"
         << "  uninstall <name>                remove an installed template\n";
@@ -226,6 +227,31 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     return 0;
 }
 
+int cmd_validate(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    if (argc - 2 != 1) {
+        print_usage(err);
+        return 1;
+    }
+    std::filesystem::path source_path{argv[2]};
+    std::ifstream in(source_path);
+    if (!in) {
+        err << source_path.string() << ": cannot open: " << std::strerror(errno)
+            << "\n";
+        return 5;
+    }
+    std::stringstream buffer;
+    buffer << in.rdbuf();
+    std::string source = buffer.str();
+
+    int exit_code = 0;
+    if (!validate_template_source(source, source_path.string(), err,
+                                  exit_code)) {
+        return exit_code;
+    }
+    out << "ok\n";
+    return 0;
+}
+
 int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     if (argc != 2) {
         print_usage(err);
@@ -389,6 +415,9 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     }
     if (subcommand == "install") {
         return cmd_install(argc, argv, out, err);
+    }
+    if (subcommand == "validate" || subcommand == "check") {
+        return cmd_validate(argc, argv, out, err);
     }
     if (subcommand == "list") {
         return cmd_list(argc, argv, out, err);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,11 +1,13 @@
 #include "spudplate/cli.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <system_error>
@@ -22,7 +24,8 @@ namespace {
 
 void print_usage(std::ostream& err) {
     err << "usage: spudplate <command> [args...]\n"
-        << "  install <file.spud>             validate and store a template\n"
+        << "  install [--yes] <file.spud>     validate and store a template;\n"
+        << "                                  prompts before overwriting an existing one\n"
         << "  run [--dry-run] [--yes] <name|file.spud>\n"
         << "                                  run an installed template by name,\n"
         << "                                  or run a .spud file directly\n"
@@ -111,13 +114,41 @@ bool validate_template_source(const std::string& source,
     return true;
 }
 
+// Read a single line from stdin and return true if it parses as
+// affirmative (`y`, `yes`, case-insensitive). Empty input returns false so
+// the prompt's `[y/N]` default is "no".
+bool confirm_yes_no(std::ostream& out, const std::string& prompt) {
+    out << prompt << std::flush;
+    std::string line;
+    if (!std::getline(std::cin, line)) {
+        return false;
+    }
+    std::string lc;
+    lc.reserve(line.size());
+    for (char c : line) {
+        lc.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    }
+    return lc == "y" || lc == "yes";
+}
+
 int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
-    if (argc - 2 != 1) {
+    bool skip_confirm = false;
+    int positional_start = 2;
+    while (positional_start < argc) {
+        std::string arg{argv[positional_start]};
+        if (arg == "--yes" || arg == "-y") {
+            skip_confirm = true;
+            ++positional_start;
+        } else {
+            break;
+        }
+    }
+    if (argc - positional_start != 1) {
         print_usage(err);
         return 1;
     }
 
-    std::filesystem::path source_path{argv[2]};
+    std::filesystem::path source_path{argv[positional_start]};
     std::ifstream in(source_path);
     if (!in) {
         err << source_path.string() << ": cannot open: " << std::strerror(errno)
@@ -148,11 +179,24 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     }
 
     std::filesystem::path target_dir = home / name;
-    if (std::filesystem::exists(target_dir)) {
-        err << name
-            << ": already installed (use 'spudplate uninstall " << name
-            << "' first)\n";
-        return 1;
+    bool overwriting = std::filesystem::exists(target_dir);
+    if (overwriting && !skip_confirm) {
+        if (!confirm_yes_no(
+                out, "this will overwrite the existing '" + name +
+                         "' template. continue? [y/N] ")) {
+            out << "aborted\n";
+            return 0;
+        }
+    }
+    if (overwriting) {
+        std::error_code rm_ec;
+        std::filesystem::remove_all(target_dir, rm_ec);
+        if (rm_ec) {
+            err << target_dir.string()
+                << ": cannot remove existing install: " << rm_ec.message()
+                << "\n";
+            return 1;
+        }
     }
 
     std::error_code ec;
@@ -177,7 +221,8 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         return 1;
     }
 
-    out << "installed " << name << " to " << target_dir.string() << "\n";
+    out << (overwriting ? "reinstalled " : "installed ") << name << " to "
+        << target_dir.string() << "\n";
     return 0;
 }
 

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -277,23 +277,61 @@ TEST(CliTest, InstallSuccessStoresTemplate) {
     EXPECT_NE(out.str().find("installed demo"), std::string::npos);
 }
 
-TEST(CliTest, InstallRejectsDuplicate) {
+TEST(CliTest, InstallWithYesOverwritesExisting) {
     TmpDir td;
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
     write_file(src, "mkdir foo\n");
-    Argv args({"spudplate", "install", src.string()});
-    std::stringstream out1;
-    std::stringstream err1;
+    {
+        Argv args({"spudplate", "install", src.string()});
+        std::stringstream o;
+        std::stringstream e;
+        ScriptedPrompter p({});
+        ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
+    }
+    // Rewrite the source so we can detect that the new content landed.
+    write_file(src, "mkdir bar\n");
+    Argv args({"spudplate", "install", "--yes", src.string()});
+    std::stringstream out;
+    std::stringstream err;
     ScriptedPrompter prompter({});
-    ASSERT_EQ(cli_main(args.argc(), args.argv(), out1, err1, prompter), 0)
-        << err1.str();
-    std::stringstream out2;
-    std::stringstream err2;
-    int code = cli_main(args.argc(), args.argv(), out2, err2, prompter);
-    EXPECT_EQ(code, 1);
-    EXPECT_NE(err2.str().find("already installed"), std::string::npos);
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("reinstalled demo"), std::string::npos);
+    std::ifstream installed(home / "demo" / "template.spud");
+    std::stringstream contents;
+    contents << installed.rdbuf();
+    EXPECT_EQ(contents.str(), "mkdir bar\n");
+}
+
+TEST(CliTest, InstallDeclinedPromptLeavesExistingUnchanged) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    auto src = td.path() / "demo.spud";
+    write_file(src, "mkdir foo\n");
+    {
+        Argv args({"spudplate", "install", src.string()});
+        std::stringstream o;
+        std::stringstream e;
+        ScriptedPrompter p({});
+        ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
+    }
+    // No `--yes` and no stdin available — confirm() returns false and the
+    // command aborts cleanly with exit 0.
+    write_file(src, "mkdir bar\n");
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("aborted"), std::string::npos);
+    std::ifstream installed(home / "demo" / "template.spud");
+    std::stringstream contents;
+    contents << installed.rdbuf();
+    EXPECT_EQ(contents.str(), "mkdir foo\n");
 }
 
 TEST(CliTest, InstallRejectsBrokenTemplateAndLeavesNoTrace) {

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -501,6 +501,73 @@ TEST(CliTest, UninstallRemovesTemplate) {
     EXPECT_FALSE(std::filesystem::exists(home / "demo"));
 }
 
+// --- validate ---
+
+TEST(CliTest, ValidateOkExitsZero) {
+    TmpDir td;
+    auto src = td.path() / "ok.spud";
+    write_file(src, "ask name \"Project name?\" string\nmkdir {name}\n");
+    Argv args({"spudplate", "validate", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("ok"), std::string::npos);
+}
+
+TEST(CliTest, CheckIsAliasForValidate) {
+    TmpDir td;
+    auto src = td.path() / "ok.spud";
+    write_file(src, "mkdir foo\n");
+    Argv args({"spudplate", "check", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+}
+
+TEST(CliTest, ValidateParseErrorExitsTwo) {
+    TmpDir td;
+    auto src = td.path() / "broken.spud";
+    write_file(src, "ask\n");
+    Argv args({"spudplate", "validate", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 2);
+}
+
+TEST(CliTest, ValidateSemanticErrorExitsThree) {
+    TmpDir td;
+    auto src = td.path() / "bad.spud";
+    // Reference an undeclared name from outside a popped repeat scope.
+    write_file(src,
+               "let n = 1\n"
+               "repeat n as i\n"
+               "  let local = 0\n"
+               "end\n"
+               "mkdir {local}\n");
+    Argv args({"spudplate", "validate", src.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 3);
+}
+
+TEST(CliTest, ValidateMissingFileExitsFive) {
+    TmpDir td;
+    Argv args({"spudplate", "validate", (td.path() / "absent.spud").string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+}
+
 TEST(CliTest, UninstallUnknownExitsFive) {
     TmpDir td;
     auto home = td.path() / "home";


### PR DESCRIPTION
## Summary
Replace install's duplicate-rejection with a y/N overwrite prompt, and add a `validate` (alias `check`) subcommand for parse+validate without installing

## Changes
- `install` no longer errors when a template name is already installed. Without `--yes` it prompts `this will overwrite the existing 'foo' template. continue? [y/N] ` and aborts cleanly on `n`/empty/EOF. With `--yes` (or `-y`) it overwrites silently. The success message reads `reinstalled foo to ...` when overwriting.
- New `validate <file.spud>` subcommand (also accessible as `check`) parses and validates the source without copying it anywhere. Prints `ok` on success; the existing exit codes for parse error (2), semantic error (3), and missing file (5) apply.
- Usage text and README updated to cover both.

## Test plan
- All 507 (5 new validate, 2 new install-overwrite, 1 reworked) tests pass locally
- Install overwrite covered: `--yes` overwrites and writes new content; declined prompt (no stdin) leaves the original untouched
- Validate covered: ok, `check` alias, parse error, semantic error, missing file