### PR TITLE
feat: spudplate version and self update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DSPUDPLATE_VERSION="${GITHUB_REF_NAME}"
 
       - name: Build
         run: cmake --build build --config Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,26 @@
 cmake_minimum_required(VERSION 3.20)
-project(spudplate LANGUAGES CXX)
+project(spudplate VERSION 0.1.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Allow the release workflow (or developers) to override the version with
+# `-DSPUDPLATE_VERSION=v0.2.0` so the binary reports the exact tag it was
+# built from. Falls back to the project version otherwise.
+if(NOT DEFINED SPUDPLATE_VERSION)
+    set(SPUDPLATE_VERSION "${PROJECT_VERSION}")
+endif()
+# Strip a leading `v` so `cmake -DSPUDPLATE_VERSION=v0.1.0` and
+# `cmake -DSPUDPLATE_VERSION=0.1.0` produce the same baked string.
+string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
+
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
                           src/interpreter.cpp src/cli.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
+target_compile_definitions(spudplate_lib PUBLIC
+    SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")
 
 # Executable
 add_executable(spudplate src/main.cpp)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ spudplate list                          # list installed templates
 spudplate inspect my_template           # print the source
 spudplate uninstall my_template         # remove
 
+spudplate version                       # print the spudplate version
+spudplate update                        # fetch and install the latest spudplate release
+
 spudplate export my_template -o my_template.spudpack
 ```
 
-`install` prompts before overwriting an existing template. Pass `--yes` to skip the prompt (useful for scripts and CI).
+`install` prompts before overwriting an existing template. Pass `--yes` to skip the prompt (useful for scripts and CI). `update` fetches the latest release of spudplate itself by re-running the install script.
 
 The install root is `$SPUDPLATE_HOME` if set, otherwise `$XDG_DATA_HOME/spudplate` (default `~/.local/share/spudplate` on most systems).
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -33,7 +33,8 @@ void print_usage(std::ostream& err) {
         << "  list                            list installed templates\n"
         << "  inspect <name>                  print the source of an installed template\n"
         << "  uninstall <name>                remove an installed template\n"
-        << "  version                         print the spudplate version\n";
+        << "  version                         print the spudplate version\n"
+        << "  update [--yes]                  fetch and install the latest spudplate release\n";
 }
 
 // Resolve the directory templates are installed into. Honours, in order:
@@ -233,6 +234,53 @@ int cmd_version(std::ostream& out) {
     return 0;
 }
 
+int cmd_update(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    bool skip_confirm = false;
+    int positional_start = 2;
+    while (positional_start < argc) {
+        std::string arg{argv[positional_start]};
+        if (arg == "--yes" || arg == "-y") {
+            skip_confirm = true;
+            ++positional_start;
+        } else {
+            break;
+        }
+    }
+    if (argc - positional_start != 0) {
+        print_usage(err);
+        return 1;
+    }
+
+    out << "current version: v" << SPUDPLATE_VERSION_STRING << "\n";
+    if (!skip_confirm) {
+        if (!confirm_yes_no(
+                out, "this will download and install the latest spudplate "
+                     "from github. continue? [y/N] ")) {
+            out << "aborted\n";
+            return 0;
+        }
+    }
+
+    // The default command is the same one the README documents. Tests and
+    // anyone with their own mirror can override it via the environment.
+    const char* override_cmd = std::getenv("SPUDPLATE_UPDATE_COMMAND");
+    std::string cmd =
+        override_cmd != nullptr && *override_cmd != '\0'
+            ? std::string{override_cmd}
+            : std::string{
+                  "curl -fsSL "
+                  "https://raw.githubusercontent.com/spuddydev/spudplate/"
+                  "main/install.sh | sh"};
+    out << "running: " << cmd << "\n";
+    int status = std::system(cmd.c_str());
+    if (status != 0) {
+        err << "update command failed (status " << status << ")\n";
+        return 1;
+    }
+    out << "done. run 'spudplate version' to confirm.\n";
+    return 0;
+}
+
 int cmd_validate(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     if (argc - 2 != 1) {
         print_usage(err);
@@ -418,6 +466,9 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     std::string subcommand{argv[1]};
     if (subcommand == "version" || subcommand == "--version") {
         return cmd_version(out);
+    }
+    if (subcommand == "update") {
+        return cmd_update(argc, argv, out, err);
     }
     if (subcommand == "run") {
         return cmd_run(argc, argv, out, err, prompter);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -32,7 +32,8 @@ void print_usage(std::ostream& err) {
         << "  validate <file.spud>            parse and validate without installing\n"
         << "  list                            list installed templates\n"
         << "  inspect <name>                  print the source of an installed template\n"
-        << "  uninstall <name>                remove an installed template\n";
+        << "  uninstall <name>                remove an installed template\n"
+        << "  version                         print the spudplate version\n";
 }
 
 // Resolve the directory templates are installed into. Honours, in order:
@@ -227,6 +228,11 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     return 0;
 }
 
+int cmd_version(std::ostream& out) {
+    out << "spudplate v" << SPUDPLATE_VERSION_STRING << "\n";
+    return 0;
+}
+
 int cmd_validate(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     if (argc - 2 != 1) {
         print_usage(err);
@@ -410,6 +416,9 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
         return 1;
     }
     std::string subcommand{argv[1]};
+    if (subcommand == "version" || subcommand == "--version") {
+        return cmd_version(out);
+    }
     if (subcommand == "run") {
         return cmd_run(argc, argv, out, err, prompter);
     }

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -558,6 +558,67 @@ TEST(CliTest, ValidateSemanticErrorExitsThree) {
     EXPECT_EQ(code, 3);
 }
 
+// --- version / update ---
+
+TEST(CliTest, VersionPrintsBakedString) {
+    Argv args({"spudplate", "version"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("spudplate v"), std::string::npos);
+}
+
+TEST(CliTest, VersionFlagAcceptsDoubleDash) {
+    Argv args({"spudplate", "--version"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("spudplate v"), std::string::npos);
+}
+
+TEST(CliTest, UpdateWithYesRunsOverrideCommand) {
+    ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
+    override.set("true");  // /bin/true succeeds, no network access
+    Argv args({"spudplate", "update", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("done"), std::string::npos);
+    EXPECT_NE(out.str().find("running: true"), std::string::npos);
+}
+
+TEST(CliTest, UpdateFailingCommandExitsOne) {
+    ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
+    override.set("false");  // /bin/false exits non-zero
+    Argv args({"spudplate", "update", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("update command failed"), std::string::npos);
+}
+
+TEST(CliTest, UpdateDeclinedPromptAbortsCleanly) {
+    ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
+    // Set to a command that would fail loudly so the test catches any
+    // accidental fall-through to execution.
+    override.set("false");
+    Argv args({"spudplate", "update"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("aborted"), std::string::npos);
+}
+
 TEST(CliTest, ValidateMissingFileExitsFive) {
     TmpDir td;
     Argv args({"spudplate", "validate", (td.path() / "absent.spud").string()});


### PR DESCRIPTION
## Summary
Add a `version` command, bake the version into the binary at build time, and add an `update` command that re-runs the install script to upgrade spudplate itself

## Changes
- `CMakeLists.txt` declares `project(spudplate VERSION 0.1.0)` and exposes `SPUDPLATE_VERSION_STRING` as a public compile definition. The release workflow passes `-DSPUDPLATE_VERSION="${GITHUB_REF_NAME}"` so each release binary reports the exact tag it was built from. A leading `v` is stripped so `v0.1.0` and `0.1.0` produce the same string.
- `spudplate version` and `spudplate --version` print `spudplate vX.Y.Z`.
- `spudplate update [--yes]` prints the current version, asks for confirmation (unless `--yes`), then runs the install one-liner via `system()`. The default command is the README's `curl ... | sh`; `SPUDPLATE_UPDATE_COMMAND` overrides it for tests and mirrors. Failed exit status surfaces as exit 1; declined prompt aborts cleanly.
- Usage line and README updated.

## Test plan
- All 512 (5 new) tests pass locally
- Version covered: `version` and `--version` both print
- Update covered: `--yes` runs the override command and prints `done`; failing command surfaces as exit 1; declined prompt aborts and never invokes the command (verified by setting the override to `false`)