### PR TITLE
feat: bundle template assets at install time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,8 @@ enable_testing()
 
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
-               tests/cli_test.cpp tests/serializer_test.cpp)
+               tests/cli_test.cpp tests/serializer_test.cpp
+               tests/asset_bundler_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
 
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
-                          src/interpreter.cpp src/cli.cpp src/serializer.cpp)
+                          src/interpreter.cpp src/cli.cpp src/serializer.cpp
+                          src/asset_bundler.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 target_compile_definitions(spudplate_lib PUBLIC
     SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")

--- a/include/spudplate/asset_bundler.h
+++ b/include/spudplate/asset_bundler.h
@@ -1,0 +1,73 @@
+#ifndef SPUDPLATE_ASSET_BUNDLER_H
+#define SPUDPLATE_ASSET_BUNDLER_H
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "spudplate/ast.h"
+
+namespace spudplate {
+
+/**
+ * @brief Thrown when the bundler cannot resolve an asset reference at install
+ * time.
+ *
+ * Carries the offending node's source position so callers can prefix the
+ * usual `<file>:<line>:<col>:` diagnostic.
+ */
+class BundleError : public std::runtime_error {
+  public:
+    BundleError(const std::string& message, int line, int column)
+        : std::runtime_error(message), line_(line), column_(column) {}
+
+    [[nodiscard]] int line() const { return line_; }
+    [[nodiscard]] int column() const { return column_; }
+
+  private:
+    int line_;
+    int column_;
+};
+
+/**
+ * @brief Summary of work performed by `bundle_assets`.
+ *
+ * `copied_files` lists every regular file written under `<dest>/assets/`,
+ * relative to `dest`. Useful for tests and for surfacing what landed in the
+ * spudpack to the user.
+ */
+struct BundleReport {
+    std::vector<std::filesystem::path> copied_files;
+};
+
+/**
+ * @brief Walk `program`, locate every `from`/`copy` source path, copy the
+ * referenced files into `<dest>/assets/<...>` preserving directory structure.
+ *
+ * @param program     Parsed and validated program.
+ * @param source_root Directory the `.spud` source lived in; relative `from`
+ *                    paths resolve against this.
+ * @param dest        The spudpack directory (assets are written under
+ *                    `dest/assets/`).
+ *
+ * Each asset reference is classified by the static prefix of its `PathExpr`:
+ *
+ * - All segments literal — bundle that exact file or directory recursively.
+ * - Literal prefix followed by `{var}` or `{expr}` — bundle the deepest
+ *   directory the literal prefix points into.
+ * - First segment dynamic, or no `/` in the literal prefix — `BundleError`
+ *   ("asset path has no static prefix; templates installed via spudpack
+ *   must root assets under a literal path").
+ *
+ * Throws `BundleError` on a missing source file, on path-traversal attempts,
+ * or on paths with no static prefix. The caller is responsible for cleaning
+ * up `dest` if a partial bundle was written before the throw.
+ */
+BundleReport bundle_assets(const Program& program,
+                           const std::filesystem::path& source_root,
+                           const std::filesystem::path& dest);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_ASSET_BUNDLER_H

--- a/src/asset_bundler.cpp
+++ b/src/asset_bundler.cpp
@@ -1,0 +1,13 @@
+#include "spudplate/asset_bundler.h"
+
+#include <stdexcept>
+
+namespace spudplate {
+
+BundleReport bundle_assets(const Program& /*program*/,
+                           const std::filesystem::path& /*source_root*/,
+                           const std::filesystem::path& /*dest*/) {
+    throw std::logic_error("bundle_assets: not implemented yet");
+}
+
+}  // namespace spudplate

--- a/src/asset_bundler.cpp
+++ b/src/asset_bundler.cpp
@@ -1,22 +1,25 @@
 #include "spudplate/asset_bundler.h"
 
+#include <algorithm>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <variant>
+#include <vector>
 
 namespace spudplate {
 
 namespace {
 
 // Result of pulling a leading literal run off a `PathExpr`. The bundler
-// either copies an exact file/directory (fully_static), the deepest static
-// directory the path roots into (prefix_dir), or refuses with an error
-// (no_prefix).
+// either copies an exact file/directory (FullyStatic), the deepest static
+// directory the path roots into (PrefixDir), or refuses with an error
+// (NoPrefix).
 enum class PrefixKind { FullyStatic, PrefixDir, NoPrefix };
 
 struct StaticPrefix {
     PrefixKind kind;
-    std::string value;  ///< Concatenated literal text, with no trailing `/` trimmed.
+    std::string value;
 };
 
 // Walk `segments` collecting leading `PathLiteral::value` text. Stops at the
@@ -25,9 +28,9 @@ struct StaticPrefix {
 // Classification:
 //   - All segments literal → FullyStatic, value = full path text.
 //   - Some literals then a non-literal segment → PrefixDir, value trimmed at
-//     the last `/` (so `base/{x}/main.cpp` yields `base`). If no `/` in the
-//     literal run (e.g. `foo{x}.cpp`), classify as NoPrefix — the dynamic
-//     part is mid-filename and the bundler can't choose a directory to walk.
+//     the last `/`. If no `/` in the literal run (e.g. `foo{x}.cpp`),
+//     classify as NoPrefix — the dynamic part is mid-filename and the
+//     bundler can't choose a directory to walk.
 //   - First segment is non-literal (or no segments) → NoPrefix.
 StaticPrefix classify_path(const PathExpr& path) {
     std::string literal;
@@ -35,8 +38,6 @@ StaticPrefix classify_path(const PathExpr& path) {
     for (const auto& seg : path.segments) {
         if (std::holds_alternative<PathLiteral>(seg)) {
             if (saw_dynamic) {
-                // Mixed run: trailing literals after a dynamic segment don't
-                // extend the static prefix, just stop counting.
                 break;
             }
             literal += std::get<PathLiteral>(seg).value;
@@ -58,12 +59,170 @@ StaticPrefix classify_path(const PathExpr& path) {
     return {PrefixKind::PrefixDir, literal.substr(0, last_slash)};
 }
 
+// One asset reference found in the program: the source path string (relative
+// to `source_root`), the line/column of the offending node for diagnostics.
+struct AssetRef {
+    std::string relative;
+    int line;
+    int column;
+};
+
+void collect_paths(const std::vector<StmtPtr>& stmts,
+                   std::vector<AssetRef>& out) {
+    for (const auto& sp : stmts) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, MkdirStmt>) {
+                    if (s.from_source.has_value()) {
+                        out.push_back({{}, s.from_source->line, s.from_source->column});
+                        auto p = classify_path(*s.from_source);
+                        out.back().relative = p.value;
+                        out.back().line = s.from_source->line;
+                        out.back().column = s.from_source->column;
+                        if (p.kind == PrefixKind::NoPrefix) {
+                            out.back().relative.clear();  // sentinel: rejected
+                        }
+                    }
+                } else if constexpr (std::is_same_v<T, FileStmt>) {
+                    if (std::holds_alternative<FileFromSource>(s.source)) {
+                        const auto& fs = std::get<FileFromSource>(s.source);
+                        auto p = classify_path(fs.path);
+                        AssetRef ref{p.value, fs.path.line, fs.path.column};
+                        if (p.kind == PrefixKind::NoPrefix) {
+                            ref.relative.clear();
+                        }
+                        out.push_back(std::move(ref));
+                    }
+                } else if constexpr (std::is_same_v<T, CopyStmt>) {
+                    auto p = classify_path(s.source);
+                    AssetRef ref{p.value, s.source.line, s.source.column};
+                    if (p.kind == PrefixKind::NoPrefix) {
+                        ref.relative.clear();
+                    }
+                    out.push_back(std::move(ref));
+                } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                    collect_paths(s.body, out);
+                }
+            },
+            sp->data);
+    }
+}
+
+// Refuse `relative` if it escapes `source_root` once concatenated. Catches
+// `from ../etc/passwd` and friends. We canonicalise the path expression
+// against the source root and require the canonical form is still inside.
+std::filesystem::path resolve_inside_root(
+    const std::filesystem::path& source_root,
+    const std::string& relative, int line, int column) {
+    std::filesystem::path joined = source_root / relative;
+    auto canonical = std::filesystem::weakly_canonical(joined);
+    auto root_canonical = std::filesystem::weakly_canonical(source_root);
+    auto rel = canonical.lexically_relative(root_canonical);
+    auto rel_str = rel.generic_string();
+    if (rel_str.empty() || rel_str == "." ||
+        rel_str.rfind("..", 0) == 0) {
+        throw BundleError(
+            "asset path '" + relative + "' escapes the source directory",
+            line, column);
+    }
+    return canonical;
+}
+
+void copy_recursive(const std::filesystem::path& src,
+                    const std::filesystem::path& dest,
+                    BundleReport& report,
+                    const std::filesystem::path& dest_root) {
+    namespace fs = std::filesystem;
+    if (fs::is_regular_file(src)) {
+        fs::create_directories(dest.parent_path());
+        fs::copy_file(src, dest, fs::copy_options::overwrite_existing);
+        report.copied_files.push_back(
+            fs::relative(dest, dest_root));
+        return;
+    }
+    if (!fs::is_directory(src)) {
+        return;  // skip symlinks, devices, missing entries handled by caller
+    }
+    fs::create_directories(dest);
+    for (const auto& entry : fs::recursive_directory_iterator(src)) {
+        if (!entry.is_regular_file()) {
+            continue;
+        }
+        auto rel = fs::relative(entry.path(), src);
+        auto out = dest / rel;
+        fs::create_directories(out.parent_path());
+        fs::copy_file(entry.path(), out, fs::copy_options::overwrite_existing);
+        report.copied_files.push_back(fs::relative(out, dest_root));
+    }
+}
+
 }  // namespace
 
-BundleReport bundle_assets(const Program& /*program*/,
-                           const std::filesystem::path& /*source_root*/,
-                           const std::filesystem::path& /*dest*/) {
-    throw std::logic_error("bundle_assets: not implemented yet");
+BundleReport bundle_assets(const Program& program,
+                           const std::filesystem::path& source_root,
+                           const std::filesystem::path& dest) {
+    namespace fs = std::filesystem;
+
+    std::vector<AssetRef> refs;
+    collect_paths(program.statements, refs);
+
+    // First pass: surface rejection errors with source positions intact.
+    for (const auto& ref : refs) {
+        if (ref.relative.empty()) {
+            throw BundleError(
+                "asset path has no static prefix; templates installed via "
+                "spudpack must root assets under a literal path",
+                ref.line, ref.column);
+        }
+    }
+
+    // Two-tier dedup. Sort relative paths so shorter prefixes come first;
+    // skip any path that's already covered by a previously bundled prefix.
+    std::sort(refs.begin(), refs.end(),
+              [](const AssetRef& a, const AssetRef& b) {
+                  return a.relative < b.relative;
+              });
+
+    BundleReport report;
+    fs::path assets_root = dest / "assets";
+    fs::create_directories(assets_root);
+
+    std::vector<std::string> bundled_prefixes;
+    std::set<fs::path> bundled_canonicals;
+
+    for (const auto& ref : refs) {
+        bool covered = false;
+        for (const auto& prev : bundled_prefixes) {
+            if (ref.relative == prev ||
+                (ref.relative.size() > prev.size() &&
+                 ref.relative.rfind(prev + "/", 0) == 0)) {
+                covered = true;
+                break;
+            }
+        }
+        if (covered) {
+            continue;
+        }
+
+        auto src = resolve_inside_root(source_root, ref.relative, ref.line,
+                                       ref.column);
+        if (!fs::exists(src)) {
+            throw BundleError(
+                "asset source '" + ref.relative + "' does not exist",
+                ref.line, ref.column);
+        }
+        if (bundled_canonicals.count(src)) {
+            continue;
+        }
+        bundled_canonicals.insert(src);
+
+        auto out = assets_root / ref.relative;
+        copy_recursive(src, out, report, dest);
+        bundled_prefixes.push_back(ref.relative);
+    }
+
+    return report;
 }
 
 }  // namespace spudplate

--- a/src/asset_bundler.cpp
+++ b/src/asset_bundler.cpp
@@ -1,8 +1,64 @@
 #include "spudplate/asset_bundler.h"
 
 #include <stdexcept>
+#include <string>
+#include <variant>
 
 namespace spudplate {
+
+namespace {
+
+// Result of pulling a leading literal run off a `PathExpr`. The bundler
+// either copies an exact file/directory (fully_static), the deepest static
+// directory the path roots into (prefix_dir), or refuses with an error
+// (no_prefix).
+enum class PrefixKind { FullyStatic, PrefixDir, NoPrefix };
+
+struct StaticPrefix {
+    PrefixKind kind;
+    std::string value;  ///< Concatenated literal text, with no trailing `/` trimmed.
+};
+
+// Walk `segments` collecting leading `PathLiteral::value` text. Stops at the
+// first non-literal segment.
+//
+// Classification:
+//   - All segments literal → FullyStatic, value = full path text.
+//   - Some literals then a non-literal segment → PrefixDir, value trimmed at
+//     the last `/` (so `base/{x}/main.cpp` yields `base`). If no `/` in the
+//     literal run (e.g. `foo{x}.cpp`), classify as NoPrefix — the dynamic
+//     part is mid-filename and the bundler can't choose a directory to walk.
+//   - First segment is non-literal (or no segments) → NoPrefix.
+StaticPrefix classify_path(const PathExpr& path) {
+    std::string literal;
+    bool saw_dynamic = false;
+    for (const auto& seg : path.segments) {
+        if (std::holds_alternative<PathLiteral>(seg)) {
+            if (saw_dynamic) {
+                // Mixed run: trailing literals after a dynamic segment don't
+                // extend the static prefix, just stop counting.
+                break;
+            }
+            literal += std::get<PathLiteral>(seg).value;
+        } else {
+            saw_dynamic = true;
+            break;
+        }
+    }
+    if (literal.empty()) {
+        return {PrefixKind::NoPrefix, {}};
+    }
+    if (!saw_dynamic) {
+        return {PrefixKind::FullyStatic, literal};
+    }
+    auto last_slash = literal.find_last_of('/');
+    if (last_slash == std::string::npos) {
+        return {PrefixKind::NoPrefix, {}};
+    }
+    return {PrefixKind::PrefixDir, literal.substr(0, last_slash)};
+}
+
+}  // namespace
 
 BundleReport bundle_assets(const Program& /*program*/,
                            const std::filesystem::path& /*source_root*/,

--- a/tests/asset_bundler_test.cpp
+++ b/tests/asset_bundler_test.cpp
@@ -1,0 +1,178 @@
+#include "spudplate/asset_bundler.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+
+using namespace spudplate;
+namespace fs = std::filesystem;
+
+namespace {
+
+class TmpDir {
+  public:
+    TmpDir() {
+        std::random_device rd;
+        std::stringstream ss;
+        ss << "spudplate-bundler-" << std::hex << rd() << rd();
+        path_ = fs::temp_directory_path() / ss.str();
+        fs::create_directories(path_);
+    }
+    TmpDir(const TmpDir&) = delete;
+    TmpDir& operator=(const TmpDir&) = delete;
+    ~TmpDir() {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+
+    [[nodiscard]] const fs::path& path() const { return path_; }
+
+  private:
+    fs::path path_;
+};
+
+void write_file(const fs::path& p, const std::string& content) {
+    fs::create_directories(p.parent_path());
+    std::ofstream out(p);
+    out << content;
+}
+
+Program parse(const std::string& src) {
+    Parser parser(Lexer{src});
+    return parser.parse();
+}
+
+}  // namespace
+
+TEST(BundlerTest, FullyStaticPathCopiesExactFile) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path() / "base" / "main.cpp", "int main(){}\n");
+
+    auto p = parse("file project/main.cpp from base/main.cpp\n");
+    auto report = bundle_assets(p, source_root.path(), dest.path());
+
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "base" / "main.cpp"));
+    EXPECT_EQ(report.copied_files.size(), 1u);
+}
+
+TEST(BundlerTest, StaticPrefixBundlesEntirePrefixDir) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path() / "base" / "a.cpp", "a\n");
+    write_file(source_root.path() / "base" / "sub" / "b.cpp", "b\n");
+
+    // base/{module}/main.cpp — prefix is `base`, bundle the whole dir.
+    auto p = parse(
+        "ask module \"?\" string default \"x\"\n"
+        "file project/main.cpp from base/{module}/main.cpp\n");
+    auto report = bundle_assets(p, source_root.path(), dest.path());
+
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "base" / "a.cpp"));
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "base" / "sub" / "b.cpp"));
+}
+
+TEST(BundlerTest, NoStaticPrefixThrows) {
+    TmpDir source_root;
+    TmpDir dest;
+    auto p = parse(
+        "ask root \"?\" string default \"a\"\n"
+        "file project/main.cpp from {root}/main.cpp\n");
+    EXPECT_THROW(bundle_assets(p, source_root.path(), dest.path()),
+                 BundleError);
+}
+
+TEST(BundlerTest, DynamicMidFilenameWithoutSlashThrows) {
+    TmpDir source_root;
+    TmpDir dest;
+    auto p = parse(
+        "ask x \"?\" string default \"a\"\n"
+        "file out.cpp from foo{x}.cpp\n");
+    EXPECT_THROW(bundle_assets(p, source_root.path(), dest.path()),
+                 BundleError);
+}
+
+TEST(BundlerTest, MissingSourceThrows) {
+    TmpDir source_root;
+    TmpDir dest;
+    auto p = parse("file dst from missing.cpp\n");
+    EXPECT_THROW(bundle_assets(p, source_root.path(), dest.path()),
+                 BundleError);
+}
+
+TEST(BundlerTest, PathTraversalThrows) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path().parent_path() / "outside.cpp", "x\n");
+    auto p = parse("file dst from ../outside.cpp\n");
+    EXPECT_THROW(bundle_assets(p, source_root.path(), dest.path()),
+                 BundleError);
+}
+
+TEST(BundlerTest, MkdirFromAndCopyAreBundled) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path() / "templates" / "x.cpp", "x\n");
+    write_file(source_root.path() / "extras" / "y.cpp", "y\n");
+
+    auto p = parse(
+        "mkdir templates from templates as t\n"
+        "copy extras into t\n");
+    bundle_assets(p, source_root.path(), dest.path());
+
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "templates" / "x.cpp"));
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "extras" / "y.cpp"));
+}
+
+TEST(BundlerTest, RepeatBodyAssetsAreBundled) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path() / "base" / "a.cpp", "a\n");
+
+    auto p = parse(
+        "ask n \"?\" int default 1\n"
+        "repeat n as i\n"
+        "  file out_{i}.cpp from base/a.cpp\n"
+        "end\n");
+    bundle_assets(p, source_root.path(), dest.path());
+
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "base" / "a.cpp"));
+}
+
+TEST(BundlerTest, DuplicatePathsAreDeduped) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path() / "base" / "a.cpp", "a\n");
+
+    auto p = parse(
+        "file out_a from base/a.cpp\n"
+        "file out_b from base/a.cpp\n");
+    auto report = bundle_assets(p, source_root.path(), dest.path());
+
+    EXPECT_EQ(report.copied_files.size(), 1u);
+}
+
+TEST(BundlerTest, PrefixCoversNestedReferences) {
+    TmpDir source_root;
+    TmpDir dest;
+    write_file(source_root.path() / "base" / "x" / "a.cpp", "a\n");
+    write_file(source_root.path() / "base" / "y" / "b.cpp", "b\n");
+
+    // First reference bundles the whole `base/` tree; second one is covered.
+    auto p = parse(
+        "ask m \"?\" string default \"x\"\n"
+        "file out_a from base/{m}/a.cpp\n"
+        "file out_b from base/y/b.cpp\n");
+    auto report = bundle_assets(p, source_root.path(), dest.path());
+
+    // Both files end up under assets/base/, but only the prefix walk runs.
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "base" / "x" / "a.cpp"));
+    EXPECT_TRUE(fs::exists(dest.path() / "assets" / "base" / "y" / "b.cpp"));
+}


### PR DESCRIPTION
## Summary
Add an asset bundler module that walks a parsed program, finds every `from`/`copy` source path, and copies the referenced files into a self-contained `assets/` tree. With this in place an installed template no longer depends on the original source directory at run time.

## Changes
- `include/spudplate/asset_bundler.h` exposes `bundle_assets(Program, source_root, dest)` returning a `BundleReport` listing every file copied. `BundleError` carries a line and column for the usual `<file>:<line>:<col>:` diagnostic prefix.
- Path classifier extracts the longest leading literal from a `PathExpr`. Paths fall into three buckets: fully static (copy that exact file or directory), literal prefix followed by a dynamic segment (bundle the deepest static directory), or no usable prefix at all (rejected with a clear error). A literal prefix with no `/` (`foo{x}.cpp`) also rejects, since there is no directory to walk.
- Walk visits every `MkdirStmt.from_source`, `FileFromSource`, and `CopyStmt.source`, including statements nested inside `repeat` blocks.
- Path-traversal guard via `weakly_canonical` and `lexically_relative`. Anything that resolves outside the source root is refused.
- Two-tier dedup: paths are sorted so a bundled prefix covers later nested references, and a per-file canonical set skips duplicate copies.

## Test plan
- All 552 (10 new) tests pass locally
- Bundler covered: fully static path, static-prefix dynamic path, no-static-prefix rejection, mid-filename dynamic rejection, missing source, path traversal, `mkdir from` and `copy` (alongside `file from`), assets nested in `repeat`, duplicate path dedup, prefix covering nested references