### PR TITLE
feat: binary serialiser and crc32 helper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ enable_testing()
 
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
-               tests/cli_test.cpp)
+               tests/cli_test.cpp tests/crc32_test.cpp)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
 
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
-                          src/interpreter.cpp src/cli.cpp src/crc32.cpp)
+                          src/interpreter.cpp src/cli.cpp src/crc32.cpp
+                          src/binary_serializer.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 target_compile_definitions(spudplate_lib PUBLIC
     SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ enable_testing()
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
                tests/cli_test.cpp tests/crc32_test.cpp
-               tests/test_helpers.cpp)
+               tests/test_helpers.cpp tests/binary_serializer_test.cpp)
 target_include_directories(spudplate_tests PRIVATE tests)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
 
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
-                          src/interpreter.cpp src/cli.cpp)
+                          src/interpreter.cpp src/cli.cpp src/crc32.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 target_compile_definitions(spudplate_lib PUBLIC
     SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,9 @@ enable_testing()
 
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
-               tests/cli_test.cpp tests/crc32_test.cpp)
+               tests/cli_test.cpp tests/crc32_test.cpp
+               tests/test_helpers.cpp)
+target_include_directories(spudplate_tests PRIVATE tests)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)
 gtest_discover_tests(spudplate_tests)

--- a/include/spudplate/binary_serializer.h
+++ b/include/spudplate/binary_serializer.h
@@ -1,0 +1,117 @@
+#ifndef SPUDPLATE_BINARY_SERIALIZER_H
+#define SPUDPLATE_BINARY_SERIALIZER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "spudplate/ast.h"
+
+namespace spudplate {
+
+/**
+ * @brief Tag values used on the wire to identify each AST variant arm.
+ *
+ * Each enum value equals the corresponding `std::variant::index()` for the
+ * variant declared in `ast.h`. The variant declaration order is therefore
+ * load-bearing for wire compatibility — adding a new arm is fine, but
+ * reordering existing arms silently breaks every previously-produced
+ * `.spp` file. Round-trip tests in `tests/binary_serializer_test.cpp`
+ * exercise every arm by name to guard against accidental reordering.
+ */
+enum class ExprTag : std::uint8_t {
+    StringLiteral = 0,
+    IntegerLiteral = 1,
+    BoolLiteral = 2,
+    Identifier = 3,
+    Unary = 4,
+    Binary = 5,
+    FunctionCall = 6,
+    TemplateString = 7,
+};
+
+/** @brief Tag values for `StmtData` arms. See `ExprTag`. */
+enum class StmtTag : std::uint8_t {
+    Ask = 0,
+    Let = 1,
+    Assign = 2,
+    Mkdir = 3,
+    File = 4,
+    Repeat = 5,
+    Copy = 6,
+    Include = 7,
+    Run = 8,
+};
+
+/** @brief Tag values for `PathSegment` arms. See `ExprTag`. */
+enum class PathSegTag : std::uint8_t {
+    Literal = 0,
+    Var = 1,
+    Interp = 2,
+};
+
+/** @brief Tag values for `FileSource` arms. See `ExprTag`. */
+enum class FileSrcTag : std::uint8_t {
+    From = 0,
+    Content = 1,
+};
+
+/** @brief Sub-tag for `TemplateStringExpr.parts` entries. */
+enum class TemplatePartTag : std::uint8_t {
+    Literal = 0,
+    Expression = 1,
+};
+
+/** @brief Raised when an AST cannot be encoded (e.g. invalid operator token). */
+class BinarySerializeError : public std::runtime_error {
+  public:
+    using std::runtime_error::runtime_error;
+};
+
+/**
+ * @brief Raised when the byte stream cannot be decoded.
+ *
+ * Carries the byte offset at which decoding gave up so a hex-dumped
+ * payload can be inspected at the right location.
+ */
+class BinaryDeserializeError : public std::runtime_error {
+  public:
+    BinaryDeserializeError(std::string message, std::size_t offset);
+
+    /** @brief Byte offset within the decoded buffer where the failure occurred. */
+    std::size_t offset() const noexcept { return offset_; }
+
+  private:
+    std::size_t offset_;
+};
+
+/**
+ * @brief Encode a parsed `Program` to a tightly packed byte stream.
+ *
+ * The output is opaque to the caller. The encoding mirrors the AST
+ * declared in `ast.h` field-for-field: each variant arm gets a one-byte
+ * tag (`variant::index()`), strings and byte vectors are length-prefixed
+ * with LEB128 varints, optionals are a one-byte present-flag plus the
+ * payload, signed integer fields are zigzag-encoded inside the varint.
+ *
+ * Throws `BinarySerializeError` only for inputs that violate the AST's
+ * own contract — e.g. a `UnaryExpr.op` outside the language's operator
+ * subset.
+ */
+std::vector<std::uint8_t> serialize_program(const Program& program);
+
+/**
+ * @brief Decode a byte stream back into a `Program`.
+ *
+ * Throws `BinaryDeserializeError` with a byte offset on:
+ *   - truncated input mid-tag, mid-varint, or mid-payload
+ *   - varints longer than 10 bytes
+ *   - tag values outside the legal range for their position
+ */
+Program deserialize_program(const std::uint8_t* data, std::size_t size);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_BINARY_SERIALIZER_H

--- a/include/spudplate/crc32.h
+++ b/include/spudplate/crc32.h
@@ -1,0 +1,28 @@
+#ifndef SPUDPLATE_CRC32_H
+#define SPUDPLATE_CRC32_H
+
+#include <cstddef>
+#include <cstdint>
+
+namespace spudplate {
+
+/**
+ * @brief CRC-32/ISO-HDLC checksum.
+ *
+ * Polynomial 0xEDB88320 (reflected), init 0xFFFFFFFF, xorout 0xFFFFFFFF.
+ * Calling with the default seed produces the standard digest used by zlib,
+ * gzip, png, and friends. Test vectors:
+ *
+ * - `crc32(nullptr, 0)` returns 0
+ * - `crc32("123456789", 9)` returns 0xCBF43926
+ *
+ * The seed parameter lets callers fold a checksum across non-contiguous
+ * buffers without re-walking previously-checked bytes; pass the previous
+ * return value as the next seed.
+ */
+std::uint32_t crc32(const std::uint8_t* data, std::size_t size,
+                    std::uint32_t seed = 0) noexcept;
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_CRC32_H

--- a/src/binary_serializer.cpp
+++ b/src/binary_serializer.cpp
@@ -1,0 +1,771 @@
+#include "spudplate/binary_serializer.h"
+
+#include <cstring>
+#include <type_traits>
+#include <variant>
+
+namespace spudplate {
+
+BinaryDeserializeError::BinaryDeserializeError(std::string message,
+                                               std::size_t offset)
+    : std::runtime_error(std::move(message)), offset_(offset) {}
+
+namespace {
+
+// Maximum bytes a LEB128-encoded uint64 can occupy. Anything longer
+// indicates either a malicious payload or a bug in the encoder.
+constexpr std::size_t kVarintMaxBytes = 10;
+
+// Static asserts pin the count of each variant — adding a new arm fails
+// the build until the encode/decode tables grow with it. Reordering
+// existing arms is not caught by arity alone; the round-trip tests are
+// the second line of defence there.
+static_assert(std::variant_size_v<ExprData> == 8);
+static_assert(std::variant_size_v<StmtData> == 9);
+static_assert(std::variant_size_v<PathSegment> == 3);
+static_assert(std::variant_size_v<FileSource> == 2);
+
+// ----- Writer -------------------------------------------------------------
+
+class Writer {
+  public:
+    void write_u8(std::uint8_t v) { buf_.push_back(v); }
+
+    void write_varint(std::uint64_t v) {
+        while (v >= 0x80U) {
+            buf_.push_back(static_cast<std::uint8_t>(v | 0x80U));
+            v >>= 7;
+        }
+        buf_.push_back(static_cast<std::uint8_t>(v));
+    }
+
+    void write_zigzag(std::int64_t v) {
+        // Standard zigzag: maps -1,1,-2,2 → 1,2,3,4 so small magnitudes
+        // share the cheap end of the varint range.
+        const std::uint64_t z = (static_cast<std::uint64_t>(v) << 1) ^
+                                static_cast<std::uint64_t>(v >> 63);
+        write_varint(z);
+    }
+
+    void write_bool(bool v) { write_u8(v ? 1 : 0); }
+
+    void write_string(const std::string& s) {
+        write_varint(s.size());
+        buf_.insert(buf_.end(), s.begin(), s.end());
+    }
+
+    std::vector<std::uint8_t> take() && { return std::move(buf_); }
+
+  private:
+    std::vector<std::uint8_t> buf_;
+};
+
+// ----- Reader -------------------------------------------------------------
+
+class Reader {
+  public:
+    Reader(const std::uint8_t* data, std::size_t size)
+        : data_(data), size_(size) {}
+
+    std::size_t pos() const noexcept { return pos_; }
+    std::size_t remaining() const noexcept { return size_ - pos_; }
+
+    std::uint8_t read_u8() {
+        require(1, "unexpected end of input");
+        return data_[pos_++];
+    }
+
+    std::uint64_t read_varint() {
+        std::uint64_t result = 0;
+        std::size_t bytes = 0;
+        const std::size_t start = pos_;
+        while (true) {
+            if (bytes == kVarintMaxBytes) {
+                throw BinaryDeserializeError("varint exceeds 10-byte cap",
+                                             start);
+            }
+            require(1, "truncated varint");
+            const std::uint8_t b = data_[pos_++];
+            result |= static_cast<std::uint64_t>(b & 0x7FU) << (7 * bytes);
+            ++bytes;
+            if ((b & 0x80U) == 0) break;
+        }
+        return result;
+    }
+
+    std::int64_t read_zigzag() {
+        const std::uint64_t z = read_varint();
+        return static_cast<std::int64_t>((z >> 1) ^ (~(z & 1U) + 1U));
+    }
+
+    bool read_bool() {
+        const std::uint8_t v = read_u8();
+        if (v > 1) {
+            throw BinaryDeserializeError("invalid bool tag", pos_ - 1);
+        }
+        return v != 0;
+    }
+
+    std::string read_string() {
+        const std::size_t start = pos_;
+        const std::uint64_t len = read_varint();
+        require_for_payload(len, start, "string length exceeds remaining input");
+        std::string s(reinterpret_cast<const char*>(data_ + pos_),
+                      static_cast<std::size_t>(len));
+        pos_ += static_cast<std::size_t>(len);
+        return s;
+    }
+
+  private:
+    void require(std::size_t n, const char* msg) {
+        if (pos_ + n > size_) {
+            throw BinaryDeserializeError(msg, pos_);
+        }
+    }
+
+    void require_for_payload(std::uint64_t len, std::size_t at,
+                             const char* msg) {
+        // Sum-overflow guard: detect SIZE_MAX-style hostile lengths
+        // before we use them as an offset.
+        if (len > size_ || pos_ + static_cast<std::size_t>(len) < pos_ ||
+            pos_ + static_cast<std::size_t>(len) > size_) {
+            throw BinaryDeserializeError(msg, at);
+        }
+    }
+
+    const std::uint8_t* data_;
+    std::size_t size_;
+    std::size_t pos_ = 0;
+};
+
+// ----- Token / VarType wire encoding --------------------------------------
+
+bool is_legal_unary_op(TokenType t) { return t == TokenType::NOT; }
+
+bool is_legal_binary_op(TokenType t) {
+    switch (t) {
+        case TokenType::PLUS:
+        case TokenType::MINUS:
+        case TokenType::STAR:
+        case TokenType::SLASH:
+        case TokenType::EQUALS:
+        case TokenType::NOT_EQUALS:
+        case TokenType::LESS:
+        case TokenType::GREATER:
+        case TokenType::LESS_EQUAL:
+        case TokenType::GREATER_EQUAL:
+        case TokenType::AND:
+        case TokenType::OR:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void write_var_type(Writer& w, VarType t) {
+    w.write_u8(static_cast<std::uint8_t>(t));
+}
+
+VarType read_var_type(Reader& r) {
+    const std::size_t at = r.pos();
+    const std::uint8_t v = r.read_u8();
+    switch (v) {
+        case static_cast<std::uint8_t>(VarType::String):
+            return VarType::String;
+        case static_cast<std::uint8_t>(VarType::Bool):
+            return VarType::Bool;
+        case static_cast<std::uint8_t>(VarType::Int):
+            return VarType::Int;
+        default:
+            throw BinaryDeserializeError("invalid VarType tag", at);
+    }
+}
+
+// ----- Forward decls of the recursive encoders/decoders -------------------
+
+void encode_expr(Writer& w, const Expr& e);
+void encode_path_expr(Writer& w, const PathExpr& p);
+void encode_path_segment(Writer& w, const PathSegment& s);
+void encode_file_source(Writer& w, const FileSource& fs);
+void encode_stmt(Writer& w, const Stmt& s);
+
+ExprPtr decode_expr(Reader& r);
+PathExpr decode_path_expr(Reader& r);
+PathSegment decode_path_segment(Reader& r);
+FileSource decode_file_source(Reader& r);
+StmtPtr decode_stmt(Reader& r);
+
+// ----- Optional / vector helpers ------------------------------------------
+
+void encode_opt_expr(Writer& w, const std::optional<ExprPtr>& opt) {
+    if (!opt.has_value()) {
+        w.write_bool(false);
+        return;
+    }
+    w.write_bool(true);
+    encode_expr(w, **opt);
+}
+
+std::optional<ExprPtr> decode_opt_expr(Reader& r) {
+    if (!r.read_bool()) return std::nullopt;
+    return decode_expr(r);
+}
+
+void encode_opt_path_expr(Writer& w, const std::optional<PathExpr>& opt) {
+    if (!opt.has_value()) {
+        w.write_bool(false);
+        return;
+    }
+    w.write_bool(true);
+    encode_path_expr(w, *opt);
+}
+
+std::optional<PathExpr> decode_opt_path_expr(Reader& r) {
+    if (!r.read_bool()) return std::nullopt;
+    return decode_path_expr(r);
+}
+
+void encode_opt_string(Writer& w, const std::optional<std::string>& opt) {
+    if (!opt.has_value()) {
+        w.write_bool(false);
+        return;
+    }
+    w.write_bool(true);
+    w.write_string(*opt);
+}
+
+std::optional<std::string> decode_opt_string(Reader& r) {
+    if (!r.read_bool()) return std::nullopt;
+    return r.read_string();
+}
+
+void encode_opt_int(Writer& w, const std::optional<int>& opt) {
+    if (!opt.has_value()) {
+        w.write_bool(false);
+        return;
+    }
+    w.write_bool(true);
+    w.write_zigzag(*opt);
+}
+
+std::optional<int> decode_opt_int(Reader& r) {
+    if (!r.read_bool()) return std::nullopt;
+    const std::int64_t v = r.read_zigzag();
+    return static_cast<int>(v);
+}
+
+void encode_expr_vector(Writer& w, const std::vector<ExprPtr>& v) {
+    w.write_varint(v.size());
+    for (const auto& e : v) {
+        encode_expr(w, *e);
+    }
+}
+
+std::vector<ExprPtr> decode_expr_vector(Reader& r) {
+    const std::uint64_t n = r.read_varint();
+    std::vector<ExprPtr> v;
+    v.reserve(static_cast<std::size_t>(n));
+    for (std::uint64_t i = 0; i < n; ++i) {
+        v.push_back(decode_expr(r));
+    }
+    return v;
+}
+
+// ----- Path expressions ---------------------------------------------------
+
+void encode_path_segment(Writer& w, const PathSegment& s) {
+    w.write_u8(static_cast<std::uint8_t>(s.index()));
+    std::visit(
+        [&](const auto& seg) {
+            using T = std::decay_t<decltype(seg)>;
+            if constexpr (std::is_same_v<T, PathLiteral>) {
+                w.write_string(seg.value);
+            } else if constexpr (std::is_same_v<T, PathVar>) {
+                w.write_string(seg.name);
+            } else {
+                static_assert(std::is_same_v<T, PathInterp>);
+                encode_expr(w, *seg.expression);
+            }
+            w.write_zigzag(seg.line);
+            w.write_zigzag(seg.column);
+        },
+        s);
+}
+
+PathSegment decode_path_segment(Reader& r) {
+    const std::size_t at = r.pos();
+    const std::uint8_t tag = r.read_u8();
+    switch (static_cast<PathSegTag>(tag)) {
+        case PathSegTag::Literal: {
+            std::string value = r.read_string();
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return PathLiteral{
+                .value = std::move(value), .line = line, .column = column};
+        }
+        case PathSegTag::Var: {
+            std::string name = r.read_string();
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return PathVar{
+                .name = std::move(name), .line = line, .column = column};
+        }
+        case PathSegTag::Interp: {
+            ExprPtr expr = decode_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return PathInterp{
+                .expression = std::move(expr), .line = line, .column = column};
+        }
+    }
+    throw BinaryDeserializeError("invalid PathSegment tag", at);
+}
+
+void encode_path_expr(Writer& w, const PathExpr& p) {
+    w.write_varint(p.segments.size());
+    for (const auto& s : p.segments) {
+        encode_path_segment(w, s);
+    }
+    w.write_zigzag(p.line);
+    w.write_zigzag(p.column);
+}
+
+PathExpr decode_path_expr(Reader& r) {
+    PathExpr p;
+    const std::uint64_t n = r.read_varint();
+    p.segments.reserve(static_cast<std::size_t>(n));
+    for (std::uint64_t i = 0; i < n; ++i) {
+        p.segments.push_back(decode_path_segment(r));
+    }
+    p.line = static_cast<int>(r.read_zigzag());
+    p.column = static_cast<int>(r.read_zigzag());
+    return p;
+}
+
+// ----- File sources -------------------------------------------------------
+
+void encode_file_source(Writer& w, const FileSource& fs) {
+    w.write_u8(static_cast<std::uint8_t>(fs.index()));
+    std::visit(
+        [&](const auto& src) {
+            using T = std::decay_t<decltype(src)>;
+            if constexpr (std::is_same_v<T, FileFromSource>) {
+                encode_path_expr(w, src.path);
+                w.write_bool(src.verbatim);
+            } else {
+                static_assert(std::is_same_v<T, FileContentSource>);
+                encode_expr(w, *src.value);
+            }
+        },
+        fs);
+}
+
+FileSource decode_file_source(Reader& r) {
+    const std::size_t at = r.pos();
+    const std::uint8_t tag = r.read_u8();
+    switch (static_cast<FileSrcTag>(tag)) {
+        case FileSrcTag::From: {
+            PathExpr path = decode_path_expr(r);
+            const bool verbatim = r.read_bool();
+            return FileFromSource{.path = std::move(path), .verbatim = verbatim};
+        }
+        case FileSrcTag::Content: {
+            return FileContentSource{.value = decode_expr(r)};
+        }
+    }
+    throw BinaryDeserializeError("invalid FileSource tag", at);
+}
+
+// ----- Expressions --------------------------------------------------------
+
+void encode_expr(Writer& w, const Expr& e) {
+    w.write_u8(static_cast<std::uint8_t>(e.data.index()));
+    std::visit(
+        [&](const auto& node) {
+            using T = std::decay_t<decltype(node)>;
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                w.write_string(node.value);
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                w.write_zigzag(node.value);
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                w.write_bool(node.value);
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                w.write_string(node.name);
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                if (!is_legal_unary_op(node.op)) {
+                    throw BinarySerializeError(
+                        "invalid op tag for UnaryExpr");
+                }
+                w.write_u8(static_cast<std::uint8_t>(node.op));
+                encode_expr(w, *node.operand);
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                if (!is_legal_binary_op(node.op)) {
+                    throw BinarySerializeError(
+                        "invalid op tag for BinaryExpr");
+                }
+                w.write_u8(static_cast<std::uint8_t>(node.op));
+                encode_expr(w, *node.left);
+                encode_expr(w, *node.right);
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                w.write_string(node.name);
+                encode_expr_vector(w, node.arguments);
+            } else {
+                static_assert(std::is_same_v<T, TemplateStringExpr>);
+                w.write_varint(node.parts.size());
+                for (const auto& part : node.parts) {
+                    if (std::holds_alternative<std::string>(part)) {
+                        w.write_u8(static_cast<std::uint8_t>(
+                            TemplatePartTag::Literal));
+                        w.write_string(std::get<std::string>(part));
+                    } else {
+                        w.write_u8(static_cast<std::uint8_t>(
+                            TemplatePartTag::Expression));
+                        encode_expr(w, *std::get<ExprPtr>(part));
+                    }
+                }
+            }
+            w.write_zigzag(node.line);
+            w.write_zigzag(node.column);
+        },
+        e.data);
+}
+
+ExprPtr decode_expr(Reader& r) {
+    const std::size_t at = r.pos();
+    const std::uint8_t tag = r.read_u8();
+    auto wrap = [](auto&& data) {
+        auto e = std::make_unique<Expr>();
+        e->data = std::move(data);
+        return e;
+    };
+    switch (static_cast<ExprTag>(tag)) {
+        case ExprTag::StringLiteral: {
+            std::string value = r.read_string();
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(StringLiteralExpr{
+                .value = std::move(value), .line = line, .column = column});
+        }
+        case ExprTag::IntegerLiteral: {
+            const std::int64_t value = r.read_zigzag();
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(IntegerLiteralExpr{.value = static_cast<int>(value),
+                                           .line = line,
+                                           .column = column});
+        }
+        case ExprTag::BoolLiteral: {
+            const bool value = r.read_bool();
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(BoolLiteralExpr{
+                .value = value, .line = line, .column = column});
+        }
+        case ExprTag::Identifier: {
+            std::string name = r.read_string();
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(IdentifierExpr{
+                .name = std::move(name), .line = line, .column = column});
+        }
+        case ExprTag::Unary: {
+            const std::size_t op_at = r.pos();
+            const auto op = static_cast<TokenType>(r.read_u8());
+            if (!is_legal_unary_op(op)) {
+                throw BinaryDeserializeError("invalid op tag for UnaryExpr",
+                                             op_at);
+            }
+            ExprPtr operand = decode_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(UnaryExpr{.op = op,
+                                  .operand = std::move(operand),
+                                  .line = line,
+                                  .column = column});
+        }
+        case ExprTag::Binary: {
+            const std::size_t op_at = r.pos();
+            const auto op = static_cast<TokenType>(r.read_u8());
+            if (!is_legal_binary_op(op)) {
+                throw BinaryDeserializeError("invalid op tag for BinaryExpr",
+                                             op_at);
+            }
+            ExprPtr left = decode_expr(r);
+            ExprPtr right = decode_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(BinaryExpr{.op = op,
+                                   .left = std::move(left),
+                                   .right = std::move(right),
+                                   .line = line,
+                                   .column = column});
+        }
+        case ExprTag::FunctionCall: {
+            std::string name = r.read_string();
+            std::vector<ExprPtr> args = decode_expr_vector(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(FunctionCallExpr{.name = std::move(name),
+                                         .arguments = std::move(args),
+                                         .line = line,
+                                         .column = column});
+        }
+        case ExprTag::TemplateString: {
+            const std::uint64_t n = r.read_varint();
+            std::vector<std::variant<std::string, ExprPtr>> parts;
+            parts.reserve(static_cast<std::size_t>(n));
+            for (std::uint64_t i = 0; i < n; ++i) {
+                const std::size_t sub_at = r.pos();
+                const std::uint8_t sub = r.read_u8();
+                switch (static_cast<TemplatePartTag>(sub)) {
+                    case TemplatePartTag::Literal:
+                        parts.emplace_back(r.read_string());
+                        break;
+                    case TemplatePartTag::Expression:
+                        parts.emplace_back(decode_expr(r));
+                        break;
+                    default:
+                        throw BinaryDeserializeError(
+                            "invalid TemplateString sub-tag", sub_at);
+                }
+            }
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(TemplateStringExpr{.parts = std::move(parts),
+                                           .line = line,
+                                           .column = column});
+        }
+    }
+    throw BinaryDeserializeError("invalid Expr tag", at);
+}
+
+// ----- Statements ---------------------------------------------------------
+
+void encode_stmt(Writer& w, const Stmt& s) {
+    w.write_u8(static_cast<std::uint8_t>(s.data.index()));
+    std::visit(
+        [&](const auto& node) {
+            using T = std::decay_t<decltype(node)>;
+            if constexpr (std::is_same_v<T, AskStmt>) {
+                w.write_string(node.name);
+                w.write_string(node.prompt);
+                write_var_type(w, node.var_type);
+                encode_opt_expr(w, node.default_value);
+                encode_expr_vector(w, node.options);
+                encode_opt_expr(w, node.when_clause);
+            } else if constexpr (std::is_same_v<T, LetStmt>) {
+                w.write_string(node.name);
+                encode_expr(w, *node.value);
+            } else if constexpr (std::is_same_v<T, AssignStmt>) {
+                w.write_string(node.name);
+                encode_expr(w, *node.value);
+            } else if constexpr (std::is_same_v<T, MkdirStmt>) {
+                encode_path_expr(w, node.path);
+                encode_opt_string(w, node.alias);
+                w.write_bool(node.mkdir_p);
+                encode_opt_path_expr(w, node.from_source);
+                w.write_bool(node.verbatim);
+                encode_opt_int(w, node.mode);
+                encode_opt_expr(w, node.when_clause);
+            } else if constexpr (std::is_same_v<T, FileStmt>) {
+                encode_path_expr(w, node.path);
+                encode_opt_string(w, node.alias);
+                encode_file_source(w, node.source);
+                w.write_bool(node.append);
+                encode_opt_int(w, node.mode);
+                encode_opt_expr(w, node.when_clause);
+            } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                w.write_string(node.collection_var);
+                w.write_string(node.iterator_var);
+                w.write_varint(node.body.size());
+                for (const auto& sp : node.body) {
+                    encode_stmt(w, *sp);
+                }
+                encode_opt_expr(w, node.when_clause);
+            } else if constexpr (std::is_same_v<T, CopyStmt>) {
+                encode_path_expr(w, node.source);
+                encode_path_expr(w, node.destination);
+                w.write_bool(node.verbatim);
+                encode_opt_expr(w, node.when_clause);
+            } else if constexpr (std::is_same_v<T, IncludeStmt>) {
+                w.write_string(node.name);
+                encode_opt_expr(w, node.when_clause);
+            } else {
+                static_assert(std::is_same_v<T, RunStmt>);
+                encode_expr(w, *node.command);
+                encode_opt_path_expr(w, node.cwd);
+                encode_opt_expr(w, node.when_clause);
+            }
+            w.write_zigzag(node.line);
+            w.write_zigzag(node.column);
+        },
+        s.data);
+}
+
+StmtPtr decode_stmt(Reader& r) {
+    const std::size_t at = r.pos();
+    const std::uint8_t tag = r.read_u8();
+    auto wrap = [](auto&& data) {
+        auto s = std::make_unique<Stmt>();
+        s->data = std::move(data);
+        return s;
+    };
+    switch (static_cast<StmtTag>(tag)) {
+        case StmtTag::Ask: {
+            std::string name = r.read_string();
+            std::string prompt = r.read_string();
+            VarType var_type = read_var_type(r);
+            auto default_value = decode_opt_expr(r);
+            auto options = decode_expr_vector(r);
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(AskStmt{.name = std::move(name),
+                                .prompt = std::move(prompt),
+                                .var_type = var_type,
+                                .default_value = std::move(default_value),
+                                .options = std::move(options),
+                                .when_clause = std::move(when_clause),
+                                .line = line,
+                                .column = column});
+        }
+        case StmtTag::Let: {
+            std::string name = r.read_string();
+            ExprPtr value = decode_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(LetStmt{.name = std::move(name),
+                                .value = std::move(value),
+                                .line = line,
+                                .column = column});
+        }
+        case StmtTag::Assign: {
+            std::string name = r.read_string();
+            ExprPtr value = decode_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(AssignStmt{.name = std::move(name),
+                                   .value = std::move(value),
+                                   .line = line,
+                                   .column = column});
+        }
+        case StmtTag::Mkdir: {
+            PathExpr path = decode_path_expr(r);
+            auto alias = decode_opt_string(r);
+            const bool mkdir_p = r.read_bool();
+            auto from_source = decode_opt_path_expr(r);
+            const bool verbatim = r.read_bool();
+            auto mode = decode_opt_int(r);
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(MkdirStmt{.path = std::move(path),
+                                  .alias = std::move(alias),
+                                  .mkdir_p = mkdir_p,
+                                  .from_source = std::move(from_source),
+                                  .verbatim = verbatim,
+                                  .mode = mode,
+                                  .when_clause = std::move(when_clause),
+                                  .line = line,
+                                  .column = column});
+        }
+        case StmtTag::File: {
+            PathExpr path = decode_path_expr(r);
+            auto alias = decode_opt_string(r);
+            FileSource source = decode_file_source(r);
+            const bool append = r.read_bool();
+            auto mode = decode_opt_int(r);
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(FileStmt{.path = std::move(path),
+                                 .alias = std::move(alias),
+                                 .source = std::move(source),
+                                 .append = append,
+                                 .mode = mode,
+                                 .when_clause = std::move(when_clause),
+                                 .line = line,
+                                 .column = column});
+        }
+        case StmtTag::Repeat: {
+            std::string collection_var = r.read_string();
+            std::string iterator_var = r.read_string();
+            const std::uint64_t n = r.read_varint();
+            std::vector<StmtPtr> body;
+            body.reserve(static_cast<std::size_t>(n));
+            for (std::uint64_t i = 0; i < n; ++i) {
+                body.push_back(decode_stmt(r));
+            }
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(RepeatStmt{.collection_var = std::move(collection_var),
+                                   .iterator_var = std::move(iterator_var),
+                                   .body = std::move(body),
+                                   .when_clause = std::move(when_clause),
+                                   .line = line,
+                                   .column = column});
+        }
+        case StmtTag::Copy: {
+            PathExpr source = decode_path_expr(r);
+            PathExpr destination = decode_path_expr(r);
+            const bool verbatim = r.read_bool();
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(CopyStmt{.source = std::move(source),
+                                 .destination = std::move(destination),
+                                 .verbatim = verbatim,
+                                 .when_clause = std::move(when_clause),
+                                 .line = line,
+                                 .column = column});
+        }
+        case StmtTag::Include: {
+            std::string name = r.read_string();
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(IncludeStmt{.name = std::move(name),
+                                    .when_clause = std::move(when_clause),
+                                    .line = line,
+                                    .column = column});
+        }
+        case StmtTag::Run: {
+            ExprPtr command = decode_expr(r);
+            auto cwd = decode_opt_path_expr(r);
+            auto when_clause = decode_opt_expr(r);
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(RunStmt{.command = std::move(command),
+                                .cwd = std::move(cwd),
+                                .when_clause = std::move(when_clause),
+                                .line = line,
+                                .column = column});
+        }
+    }
+    throw BinaryDeserializeError("invalid Stmt tag", at);
+}
+
+}  // namespace
+
+std::vector<std::uint8_t> serialize_program(const Program& program) {
+    Writer w;
+    w.write_varint(program.statements.size());
+    for (const auto& sp : program.statements) {
+        encode_stmt(w, *sp);
+    }
+    return std::move(w).take();
+}
+
+Program deserialize_program(const std::uint8_t* data, std::size_t size) {
+    Reader r(data, size);
+    Program p;
+    const std::uint64_t n = r.read_varint();
+    p.statements.reserve(static_cast<std::size_t>(n));
+    for (std::uint64_t i = 0; i < n; ++i) {
+        p.statements.push_back(decode_stmt(r));
+    }
+    return p;
+}
+
+}  // namespace spudplate

--- a/src/crc32.cpp
+++ b/src/crc32.cpp
@@ -1,0 +1,39 @@
+// Sarwate table-driven CRC-32/ISO-HDLC. Public-domain reference: see e.g.
+// the CRC-32 entry on Wikipedia (Sarwate 1988). The polynomial is the
+// standard reflected form 0xEDB88320; the seed/xorout convention matches
+// zlib so the well-known test vectors hold.
+
+#include "spudplate/crc32.h"
+
+#include <array>
+
+namespace spudplate {
+
+namespace {
+
+constexpr std::array<std::uint32_t, 256> make_table() noexcept {
+    std::array<std::uint32_t, 256> t{};
+    for (std::uint32_t i = 0; i < 256; ++i) {
+        std::uint32_t c = i;
+        for (int k = 0; k < 8; ++k) {
+            c = (c & 1U) ? (0xEDB88320U ^ (c >> 1)) : (c >> 1);
+        }
+        t[i] = c;
+    }
+    return t;
+}
+
+constexpr auto kTable = make_table();
+
+}  // namespace
+
+std::uint32_t crc32(const std::uint8_t* data, std::size_t size,
+                    std::uint32_t seed) noexcept {
+    std::uint32_t c = seed ^ 0xFFFFFFFFU;
+    for (std::size_t i = 0; i < size; ++i) {
+        c = kTable[(c ^ data[i]) & 0xFFU] ^ (c >> 8);
+    }
+    return c ^ 0xFFFFFFFFU;
+}
+
+}  // namespace spudplate

--- a/tests/binary_serializer_test.cpp
+++ b/tests/binary_serializer_test.cpp
@@ -1,0 +1,480 @@
+#include "spudplate/binary_serializer.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "spudplate/ast.h"
+#include "spudplate/token.h"
+#include "test_helpers.h"
+
+namespace spudplate {
+namespace {
+
+// ----- Tiny AST builders --------------------------------------------------
+
+ExprPtr make_expr(ExprData data) {
+    auto e = std::make_unique<Expr>();
+    e->data = std::move(data);
+    return e;
+}
+
+ExprPtr str_lit(std::string v, int line = 1, int col = 1) {
+    return make_expr(StringLiteralExpr{
+        .value = std::move(v), .line = line, .column = col});
+}
+
+ExprPtr int_lit(int v, int line = 1, int col = 1) {
+    return make_expr(
+        IntegerLiteralExpr{.value = v, .line = line, .column = col});
+}
+
+ExprPtr bool_lit(bool v, int line = 1, int col = 1) {
+    return make_expr(BoolLiteralExpr{.value = v, .line = line, .column = col});
+}
+
+ExprPtr ident(std::string name, int line = 1, int col = 1) {
+    return make_expr(IdentifierExpr{
+        .name = std::move(name), .line = line, .column = col});
+}
+
+StmtPtr make_stmt(StmtData data) {
+    auto s = std::make_unique<Stmt>();
+    s->data = std::move(data);
+    return s;
+}
+
+Program program_with(std::vector<StmtPtr> stmts) {
+    Program p;
+    p.statements = std::move(stmts);
+    return p;
+}
+
+void expect_round_trip(const Program& original) {
+    auto bytes = serialize_program(original);
+    auto recovered = deserialize_program(bytes.data(), bytes.size());
+    EXPECT_TRUE(test::programs_equal(original, recovered));
+}
+
+// ----- Expression-arm round trips -----------------------------------------
+
+TEST(BinarySerializer, RoundTripStringLiteral) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "greeting",
+        .value = str_lit("hello world", 3, 7),
+        .line = 3,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripIntegerLiteralIncludingNegative) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "count",
+        .value = int_lit(-42, 1, 1),
+        .line = 1,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripBoolLiteral) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "flag", .value = bool_lit(true), .line = 1, .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripIdentifier) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "alias",
+        .value = ident("name", 2, 5),
+        .line = 2,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripUnary) {
+    auto unary = make_expr(UnaryExpr{
+        .op = TokenType::NOT,
+        .operand = ident("flag"),
+        .line = 1,
+        .column = 1});
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "result", .value = std::move(unary), .line = 1, .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripBinary) {
+    auto bin = make_expr(BinaryExpr{
+        .op = TokenType::PLUS,
+        .left = int_lit(1),
+        .right = int_lit(2),
+        .line = 1,
+        .column = 1});
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "sum", .value = std::move(bin), .line = 1, .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripFunctionCallEmptyAndNonEmptyArgs) {
+    auto empty = make_expr(FunctionCallExpr{
+        .name = "trim", .arguments = {}, .line = 1, .column = 1});
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "a", .value = std::move(empty), .line = 1, .column = 1}));
+
+    std::vector<ExprPtr> args;
+    args.push_back(str_lit("Hello"));
+    args.push_back(str_lit(" "));
+    args.push_back(str_lit("-"));
+    auto call = make_expr(FunctionCallExpr{
+        .name = "replace",
+        .arguments = std::move(args),
+        .line = 2,
+        .column = 1});
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "b", .value = std::move(call), .line = 2, .column = 1}));
+
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripTemplateStringBothSubTags) {
+    std::vector<std::variant<std::string, ExprPtr>> parts;
+    parts.emplace_back(std::string{"week_"});
+    parts.emplace_back(ident("n"));
+    parts.emplace_back(std::string{"_done"});
+    auto tpl = make_expr(TemplateStringExpr{
+        .parts = std::move(parts), .line = 4, .column = 9});
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "label", .value = std::move(tpl), .line = 4, .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+// ----- Path segments and PathExpr round trips -----------------------------
+
+TEST(BinarySerializer, RoundTripPathSegmentsAllThreeKinds) {
+    PathExpr path;
+    path.segments.emplace_back(
+        PathLiteral{.value = "static/", .line = 5, .column = 7});
+    path.segments.emplace_back(PathVar{.name = "modulepath", .line = 5, .column = 14});
+    path.segments.emplace_back(PathInterp{
+        .expression = ident("n", 5, 25), .line = 5, .column = 25});
+    path.line = 5;
+    path.column = 7;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(MkdirStmt{.path = std::move(path),
+                                        .alias = std::nullopt,
+                                        .mkdir_p = true,
+                                        .from_source = std::nullopt,
+                                        .verbatim = false,
+                                        .mode = std::nullopt,
+                                        .when_clause = std::nullopt,
+                                        .line = 5,
+                                        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+// ----- Statement-arm round trips ------------------------------------------
+
+TEST(BinarySerializer, RoundTripAskAllOptionalsAbsent) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(AskStmt{.name = "title",
+                                      .prompt = "Title?",
+                                      .var_type = VarType::String,
+                                      .default_value = std::nullopt,
+                                      .options = {},
+                                      .when_clause = std::nullopt,
+                                      .line = 1,
+                                      .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripAskAllOptionalsPresent) {
+    std::vector<ExprPtr> options;
+    options.push_back(str_lit("pdf"));
+    options.push_back(str_lit("html"));
+    options.push_back(str_lit("latex"));
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(AskStmt{
+        .name = "format",
+        .prompt = "Format?",
+        .var_type = VarType::String,
+        .default_value = str_lit("pdf"),
+        .options = std::move(options),
+        .when_clause = ident("use_docs"),
+        .line = 1,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripLetAndAssign) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{
+        .name = "counter", .value = int_lit(0), .line = 1, .column = 1}));
+    stmts.push_back(make_stmt(AssignStmt{
+        .name = "counter",
+        .value = make_expr(BinaryExpr{.op = TokenType::PLUS,
+                                       .left = ident("counter"),
+                                       .right = int_lit(1),
+                                       .line = 2,
+                                       .column = 11}),
+        .line = 2,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripMkdirNoOptionals) {
+    PathExpr p;
+    p.segments.emplace_back(
+        PathLiteral{.value = "src/modules", .line = 1, .column = 7});
+    p.line = 1;
+    p.column = 7;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(MkdirStmt{.path = std::move(p),
+                                        .alias = std::nullopt,
+                                        .mkdir_p = true,
+                                        .from_source = std::nullopt,
+                                        .verbatim = false,
+                                        .mode = std::nullopt,
+                                        .when_clause = std::nullopt,
+                                        .line = 1,
+                                        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripMkdirAllOptionalsPresent) {
+    PathExpr p;
+    p.segments.emplace_back(
+        PathLiteral{.value = "src/modules", .line = 1, .column = 7});
+    p.line = 1;
+    p.column = 7;
+    PathExpr from;
+    from.segments.emplace_back(
+        PathLiteral{.value = "templates/modules", .line = 1, .column = 26});
+    from.line = 1;
+    from.column = 26;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(MkdirStmt{
+        .path = std::move(p),
+        .alias = std::string{"modulepath"},
+        .mkdir_p = true,
+        .from_source = std::move(from),
+        .verbatim = true,
+        .mode = 0755,
+        .when_clause = ident("use_modules"),
+        .line = 1,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripFileWithFromSource) {
+    PathExpr dst;
+    dst.segments.emplace_back(
+        PathLiteral{.value = "src/main.cpp", .line = 1, .column = 6});
+    dst.line = 1;
+    dst.column = 6;
+    PathExpr src;
+    src.segments.emplace_back(
+        PathLiteral{.value = "templates/main.cpp", .line = 1, .column = 24});
+    src.line = 1;
+    src.column = 24;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(FileStmt{
+        .path = std::move(dst),
+        .alias = std::nullopt,
+        .source = FileFromSource{.path = std::move(src), .verbatim = false},
+        .append = false,
+        .mode = std::nullopt,
+        .when_clause = std::nullopt,
+        .line = 1,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripFileWithContentSource) {
+    PathExpr dst;
+    dst.segments.emplace_back(
+        PathLiteral{.value = "README.md", .line = 1, .column = 6});
+    dst.line = 1;
+    dst.column = 6;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(FileStmt{
+        .path = std::move(dst),
+        .alias = std::string{"readme"},
+        .source = FileContentSource{.value = str_lit("# Hello")},
+        .append = true,
+        .mode = 0644,
+        .when_clause = ident("use_readme"),
+        .line = 1,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripRepeatWithNestedStmts) {
+    PathExpr p;
+    p.segments.emplace_back(PathLiteral{.value = "week_", .line = 2, .column = 7});
+    p.segments.emplace_back(
+        PathInterp{.expression = ident("i"), .line = 2, .column = 12});
+    p.line = 2;
+    p.column = 7;
+
+    std::vector<StmtPtr> body;
+    body.push_back(make_stmt(MkdirStmt{.path = std::move(p),
+                                       .alias = std::nullopt,
+                                       .mkdir_p = true,
+                                       .from_source = std::nullopt,
+                                       .verbatim = false,
+                                       .mode = std::nullopt,
+                                       .when_clause = std::nullopt,
+                                       .line = 2,
+                                       .column = 1}));
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(RepeatStmt{
+        .collection_var = "num_weeks",
+        .iterator_var = "i",
+        .body = std::move(body),
+        .when_clause = std::nullopt,
+        .line = 1,
+        .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripCopy) {
+    PathExpr src;
+    src.segments.emplace_back(
+        PathLiteral{.value = "templates/", .line = 1, .column = 6});
+    src.line = 1;
+    src.column = 6;
+    PathExpr dst;
+    dst.segments.emplace_back(PathVar{.name = "modulepath", .line = 1, .column = 22});
+    dst.line = 1;
+    dst.column = 22;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(CopyStmt{.source = std::move(src),
+                                       .destination = std::move(dst),
+                                       .verbatim = true,
+                                       .when_clause = ident("use_modules"),
+                                       .line = 1,
+                                       .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripIncludeAndRunWithCwd) {
+    PathExpr cwd;
+    cwd.segments.emplace_back(PathVar{.name = "modulepath", .line = 2, .column = 14});
+    cwd.line = 2;
+    cwd.column = 14;
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(IncludeStmt{.name = "claude_setup",
+                                          .when_clause = ident("use_claude"),
+                                          .line = 1,
+                                          .column = 1}));
+    stmts.push_back(make_stmt(RunStmt{.command = str_lit("git init"),
+                                      .cwd = std::move(cwd),
+                                      .when_clause = std::nullopt,
+                                      .line = 2,
+                                      .column = 1}));
+    stmts.push_back(make_stmt(RunStmt{.command = str_lit("ls"),
+                                      .cwd = std::nullopt,
+                                      .when_clause = std::nullopt,
+                                      .line = 3,
+                                      .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+// ----- Truncation and varint cap ------------------------------------------
+
+TEST(BinarySerializer, TruncatedInputThrowsAtKnownOffsets) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{.name = "x",
+                                      .value = str_lit("hello"),
+                                      .line = 1,
+                                      .column = 1}));
+    auto bytes = serialize_program(program_with(std::move(stmts)));
+
+    // Walk every prefix length shorter than the full payload; every one
+    // must throw with an offset inside the truncated range.
+    for (std::size_t cut = 0; cut < bytes.size(); ++cut) {
+        EXPECT_THROW(deserialize_program(bytes.data(), cut),
+                     BinaryDeserializeError);
+    }
+}
+
+TEST(BinarySerializer, VarintLongerThanTenBytesThrows) {
+    // Eleven 0x80 bytes form a varint that never terminates within the
+    // 10-byte cap. The decoder is supposed to bail before reading more.
+    std::vector<std::uint8_t> bytes(11, 0x80);
+    bytes.push_back(0x01);
+    EXPECT_THROW(deserialize_program(bytes.data(), bytes.size()),
+                 BinaryDeserializeError);
+}
+
+TEST(BinarySerializer, InvalidUnaryOpRejected) {
+    // Hand-craft: program with one Let whose value is a Unary with op=PLUS.
+    // PLUS is a binary op — not legal in a unary slot. Encoder must throw.
+    auto bad = make_expr(UnaryExpr{.op = TokenType::PLUS,
+                                   .operand = ident("flag"),
+                                   .line = 1,
+                                   .column = 1});
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{.name = "broken",
+                                      .value = std::move(bad),
+                                      .line = 1,
+                                      .column = 1}));
+    EXPECT_THROW(serialize_program(program_with(std::move(stmts))),
+                 BinarySerializeError);
+}
+
+TEST(BinarySerializer, InvalidBinaryOpRejected) {
+    auto bad = make_expr(BinaryExpr{.op = TokenType::NOT,
+                                    .left = int_lit(1),
+                                    .right = int_lit(2),
+                                    .line = 1,
+                                    .column = 1});
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(LetStmt{.name = "broken",
+                                      .value = std::move(bad),
+                                      .line = 1,
+                                      .column = 1}));
+    EXPECT_THROW(serialize_program(program_with(std::move(stmts))),
+                 BinarySerializeError);
+}
+
+TEST(BinarySerializer, EmptyProgramRoundTrips) {
+    expect_round_trip(program_with({}));
+}
+
+TEST(BinarySerializer, DeserializeErrorCarriesOffset) {
+    // Single byte 0xFF: invalid as a varint (would need continuation), but
+    // legal as a single 7-bit value of 127 — actually 0xFF has the high bit
+    // set so it expects a continuation, which is missing. That throws as a
+    // truncated varint at offset 1.
+    std::vector<std::uint8_t> bytes{0xFFU};
+    try {
+        deserialize_program(bytes.data(), bytes.size());
+        FAIL() << "expected BinaryDeserializeError";
+    } catch (const BinaryDeserializeError& e) {
+        EXPECT_EQ(e.offset(), 1u);
+    }
+}
+
+}  // namespace
+}  // namespace spudplate

--- a/tests/crc32_test.cpp
+++ b/tests/crc32_test.cpp
@@ -1,0 +1,42 @@
+#include "spudplate/crc32.h"
+
+#include <cstdint>
+#include <cstring>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+const std::uint8_t* as_bytes(const char* s) {
+    return reinterpret_cast<const std::uint8_t*>(s);
+}
+
+}  // namespace
+
+TEST(Crc32, EmptyInputIsZero) {
+    EXPECT_EQ(spudplate::crc32(nullptr, 0), 0u);
+}
+
+TEST(Crc32, IsoHdlcCheckVector) {
+    // The canonical CRC-32/ISO-HDLC check value for the ASCII string
+    // "123456789" — used by every reference implementation.
+    const char* s = "123456789";
+    EXPECT_EQ(spudplate::crc32(as_bytes(s), 9), 0xCBF43926u);
+}
+
+TEST(Crc32, SeedFoldingMatchesContiguousCall) {
+    const char* full = "abcdefgh";
+    const std::uint32_t whole = spudplate::crc32(as_bytes(full), 8);
+
+    // Same buffer walked in two halves with the seed parameter folding the
+    // running digest forward must produce the identical result.
+    const std::uint32_t first = spudplate::crc32(as_bytes(full), 4);
+    const std::uint32_t both = spudplate::crc32(as_bytes(full + 4), 4, first);
+    EXPECT_EQ(whole, both);
+}
+
+TEST(Crc32, SingleZeroByteIsKnownValue) {
+    // crc32 of one 0x00 byte is the standard 0xD202EF8D.
+    const std::uint8_t z = 0;
+    EXPECT_EQ(spudplate::crc32(&z, 1), 0xD202EF8Du);
+}

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -1,0 +1,249 @@
+#include "test_helpers.h"
+
+#include <variant>
+
+namespace spudplate::test {
+
+namespace {
+
+bool optional_expr_equal(const std::optional<ExprPtr>& a,
+                         const std::optional<ExprPtr>& b);
+bool optional_path_expr_equal(const std::optional<PathExpr>& a,
+                              const std::optional<PathExpr>& b);
+
+bool ptr_expr_equal(const ExprPtr& a, const ExprPtr& b) {
+    if (!a || !b) return !a && !b;
+    return exprs_equal(*a, *b);
+}
+
+bool template_part_equal(const std::variant<std::string, ExprPtr>& a,
+                         const std::variant<std::string, ExprPtr>& b) {
+    if (a.index() != b.index()) return false;
+    if (std::holds_alternative<std::string>(a)) {
+        return std::get<std::string>(a) == std::get<std::string>(b);
+    }
+    return ptr_expr_equal(std::get<ExprPtr>(a), std::get<ExprPtr>(b));
+}
+
+bool string_expr_vector_equal(const std::vector<ExprPtr>& a,
+                              const std::vector<ExprPtr>& b) {
+    if (a.size() != b.size()) return false;
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        if (!ptr_expr_equal(a[i], b[i])) return false;
+    }
+    return true;
+}
+
+bool path_segment_equal(const PathSegment& a, const PathSegment& b) {
+    if (a.index() != b.index()) return false;
+    return std::visit(
+        [&](const auto& av) -> bool {
+            using T = std::decay_t<decltype(av)>;
+            const auto& bv = std::get<T>(b);
+            if constexpr (std::is_same_v<T, PathLiteral>) {
+                return av.value == bv.value && av.line == bv.line &&
+                       av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, PathVar>) {
+                return av.name == bv.name && av.line == bv.line &&
+                       av.column == bv.column;
+            } else {
+                static_assert(std::is_same_v<T, PathInterp>);
+                return ptr_expr_equal(av.expression, bv.expression) &&
+                       av.line == bv.line && av.column == bv.column;
+            }
+        },
+        a);
+}
+
+bool optional_expr_equal(const std::optional<ExprPtr>& a,
+                         const std::optional<ExprPtr>& b) {
+    if (a.has_value() != b.has_value()) return false;
+    if (!a.has_value()) return true;
+    return ptr_expr_equal(*a, *b);
+}
+
+bool optional_path_expr_equal(const std::optional<PathExpr>& a,
+                              const std::optional<PathExpr>& b) {
+    if (a.has_value() != b.has_value()) return false;
+    if (!a.has_value()) return true;
+    return path_exprs_equal(*a, *b);
+}
+
+}  // namespace
+
+bool exprs_equal(const Expr& a, const Expr& b) {
+    if (a.data.index() != b.data.index()) return false;
+    return std::visit(
+        [&](const auto& av) -> bool {
+            using T = std::decay_t<decltype(av)>;
+            const auto& bv = std::get<T>(b.data);
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                return av.value == bv.value && av.line == bv.line &&
+                       av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                return av.value == bv.value && av.line == bv.line &&
+                       av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                return av.value == bv.value && av.line == bv.line &&
+                       av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                return av.name == bv.name && av.line == bv.line &&
+                       av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                return av.op == bv.op &&
+                       ptr_expr_equal(av.operand, bv.operand) &&
+                       av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                return av.op == bv.op && ptr_expr_equal(av.left, bv.left) &&
+                       ptr_expr_equal(av.right, bv.right) &&
+                       av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                return av.name == bv.name &&
+                       string_expr_vector_equal(av.arguments, bv.arguments) &&
+                       av.line == bv.line && av.column == bv.column;
+            } else {
+                static_assert(std::is_same_v<T, TemplateStringExpr>);
+                if (av.parts.size() != bv.parts.size()) return false;
+                for (std::size_t i = 0; i < av.parts.size(); ++i) {
+                    if (!template_part_equal(av.parts[i], bv.parts[i])) {
+                        return false;
+                    }
+                }
+                return av.line == bv.line && av.column == bv.column;
+            }
+        },
+        a.data);
+}
+
+bool path_exprs_equal(const PathExpr& a, const PathExpr& b) {
+    if (a.segments.size() != b.segments.size()) return false;
+    if (a.line != b.line || a.column != b.column) return false;
+    for (std::size_t i = 0; i < a.segments.size(); ++i) {
+        if (!path_segment_equal(a.segments[i], b.segments[i])) return false;
+    }
+    return true;
+}
+
+bool file_sources_equal(const FileSource& a, const FileSource& b) {
+    if (a.index() != b.index()) return false;
+    if (std::holds_alternative<FileFromSource>(a)) {
+        const auto& av = std::get<FileFromSource>(a);
+        const auto& bv = std::get<FileFromSource>(b);
+        return path_exprs_equal(av.path, bv.path) && av.verbatim == bv.verbatim;
+    }
+    const auto& av = std::get<FileContentSource>(a);
+    const auto& bv = std::get<FileContentSource>(b);
+    return ptr_expr_equal(av.value, bv.value);
+}
+
+bool stmts_equal(const Stmt& a, const Stmt& b) {
+    if (a.data.index() != b.data.index()) return false;
+    return std::visit(
+        [&](const auto& av) -> bool {
+            using T = std::decay_t<decltype(av)>;
+            const auto& bv = std::get<T>(b.data);
+            if constexpr (std::is_same_v<T, AskStmt>) {
+                if (av.name != bv.name || av.prompt != bv.prompt ||
+                    av.var_type != bv.var_type) {
+                    return false;
+                }
+                if (!optional_expr_equal(av.default_value, bv.default_value)) {
+                    return false;
+                }
+                if (!string_expr_vector_equal(av.options, bv.options)) {
+                    return false;
+                }
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, LetStmt>) {
+                return av.name == bv.name &&
+                       ptr_expr_equal(av.value, bv.value) &&
+                       av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, AssignStmt>) {
+                return av.name == bv.name &&
+                       ptr_expr_equal(av.value, bv.value) &&
+                       av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, MkdirStmt>) {
+                if (!path_exprs_equal(av.path, bv.path)) return false;
+                if (av.alias != bv.alias) return false;
+                if (av.mkdir_p != bv.mkdir_p) return false;
+                if (!optional_path_expr_equal(av.from_source, bv.from_source)) {
+                    return false;
+                }
+                if (av.verbatim != bv.verbatim) return false;
+                if (av.mode != bv.mode) return false;
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, FileStmt>) {
+                if (!path_exprs_equal(av.path, bv.path)) return false;
+                if (av.alias != bv.alias) return false;
+                if (!file_sources_equal(av.source, bv.source)) return false;
+                if (av.append != bv.append) return false;
+                if (av.mode != bv.mode) return false;
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                if (av.collection_var != bv.collection_var ||
+                    av.iterator_var != bv.iterator_var) {
+                    return false;
+                }
+                if (av.body.size() != bv.body.size()) return false;
+                for (std::size_t i = 0; i < av.body.size(); ++i) {
+                    if (!av.body[i] || !bv.body[i]) {
+                        if (av.body[i] || bv.body[i]) return false;
+                        continue;
+                    }
+                    if (!stmts_equal(*av.body[i], *bv.body[i])) return false;
+                }
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, CopyStmt>) {
+                if (!path_exprs_equal(av.source, bv.source)) return false;
+                if (!path_exprs_equal(av.destination, bv.destination)) {
+                    return false;
+                }
+                if (av.verbatim != bv.verbatim) return false;
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else if constexpr (std::is_same_v<T, IncludeStmt>) {
+                if (av.name != bv.name) return false;
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else {
+                static_assert(std::is_same_v<T, RunStmt>);
+                if (!ptr_expr_equal(av.command, bv.command)) return false;
+                if (!optional_path_expr_equal(av.cwd, bv.cwd)) return false;
+                if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
+                    return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            }
+        },
+        a.data);
+}
+
+bool programs_equal(const Program& a, const Program& b) {
+    if (a.statements.size() != b.statements.size()) return false;
+    for (std::size_t i = 0; i < a.statements.size(); ++i) {
+        if (!a.statements[i] || !b.statements[i]) {
+            if (a.statements[i] || b.statements[i]) return false;
+            continue;
+        }
+        if (!stmts_equal(*a.statements[i], *b.statements[i])) return false;
+    }
+    return true;
+}
+
+}  // namespace spudplate::test

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,0 +1,22 @@
+#ifndef SPUDPLATE_TESTS_TEST_HELPERS_H
+#define SPUDPLATE_TESTS_TEST_HELPERS_H
+
+#include "spudplate/ast.h"
+
+namespace spudplate::test {
+
+// Structural equality for AST nodes, used by round-trip assertions in the
+// binary-serializer tests. Compares every field including line/column. The
+// helpers are deliberately test-only — adding `operator==` to `ast.h` would
+// pin equality semantics into the public surface, which prior attempts
+// (PR #50, since reverted) showed to be more trouble than it is worth.
+
+bool programs_equal(const Program& a, const Program& b);
+bool stmts_equal(const Stmt& a, const Stmt& b);
+bool exprs_equal(const Expr& a, const Expr& b);
+bool path_exprs_equal(const PathExpr& a, const PathExpr& b);
+bool file_sources_equal(const FileSource& a, const FileSource& b);
+
+}  // namespace spudplate::test
+
+#endif  // SPUDPLATE_TESTS_TEST_HELPERS_H


### PR DESCRIPTION
## Summary
Add a binary encoder and decoder for parsed programs plus a CRC32 helper. Both are foundations for the upcoming single-file install format. The encoding is opaque to callers, varint and zigzag based, and round-trips every AST shape with line and column intact.

## Changes
- `include/spudplate/crc32.h`, `src/crc32.cpp` — Sarwate table-driven CRC-32/ISO-HDLC. `crc32(data, size, seed=0)` produces the standard digest; non-zero seed allows folding chunks together for streaming.
- `include/spudplate/binary_serializer.h`, `src/binary_serializer.cpp` — `serialize_program` and `deserialize_program`. LEB128 varints capped at 10 bytes on the wire, signed AST fields zigzag-encoded inside the varint. Per-variant tags (`ExprTag`, `StmtTag`, `PathSegTag`, `FileSrcTag`) equal the variant index, pinned by `static_assert` on `std::variant_size_v`. `BinaryDeserializeError` carries the byte offset where decoding gave up. Token op fields are whitelisted per arm (unary accepts only `NOT`; binary accepts only the legal operator subset).
- `tests/test_helpers.{h,cpp}` — `programs_equal` and siblings for structural AST equality including line and column. Free functions, linked into the test binary only, no `operator==` on AST types.
- `tests/crc32_test.cpp` — empty input, `123456789` check vector (`0xCBF43926`), seed folding, single zero byte.
- `tests/binary_serializer_test.cpp` — round-trip every expression, statement, path-segment, and file-source arm; both states for every optional; both template-string sub-tags; truncation at every prefix length surfaces an offset-bearing error; over-long varint and out-of-range op tag rejected.

## Test plan
- All 541 (29 new) tests pass locally
- Round-trip covered: every AST variant exercised by name to guard against silent reordering of variant arms
- Error paths covered: truncation at byte 0 through `payload.size() - 1`, varint > 10 bytes, unary-position `PLUS`, binary-position `NOT`, invalid `VarType`