### PR TITLE
feat: spudpack codec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
                           src/interpreter.cpp src/cli.cpp src/crc32.cpp
-                          src/binary_serializer.cpp)
+                          src/binary_serializer.cpp src/spudpack.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 target_compile_definitions(spudplate_lib PUBLIC
     SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,8 @@ enable_testing()
 add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
                tests/cli_test.cpp tests/crc32_test.cpp
-               tests/test_helpers.cpp tests/binary_serializer_test.cpp)
+               tests/test_helpers.cpp tests/binary_serializer_test.cpp
+               tests/spudpack_test.cpp)
 target_include_directories(spudplate_tests PRIVATE tests)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)

--- a/include/spudplate/spudpack.h
+++ b/include/spudplate/spudpack.h
@@ -1,0 +1,111 @@
+#ifndef SPUDPLATE_SPUDPACK_H
+#define SPUDPLATE_SPUDPACK_H
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace spudplate {
+
+/**
+ * @brief One bundled asset entry inside a spudpack.
+ *
+ * `path` is normalised — forward-slash separators, no leading `/`, no `.` or
+ * `..` segments, no embedded NUL. A trailing `/` means "empty leaf
+ * directory" and the corresponding `data` is empty.
+ */
+struct SpudpackAsset {
+    std::string path;
+    std::uint16_t mode;
+    std::vector<std::uint8_t> data;
+};
+
+/**
+ * @brief A decoded spudpack — the source text, the opaque compiled program,
+ * and every bundled asset.
+ *
+ * `program_bytes` is held opaquely; this header does not include the
+ * binary-serializer header so the codec stays decoupled from the AST.
+ * Decoding `program_bytes` into a `Program` is the caller's job.
+ */
+struct Spudpack {
+    std::string source;
+    std::vector<std::uint8_t> program_bytes;
+    std::vector<SpudpackAsset> assets;
+};
+
+/**
+ * @brief Raised on any encode or decode failure.
+ *
+ * `offset()` carries the byte offset at which decoding gave up when the
+ * failure was decoder-side; encoder-side failures leave it empty.
+ */
+class SpudpackError : public std::runtime_error {
+  public:
+    SpudpackError(std::string message, std::optional<std::size_t> offset = std::nullopt);
+    std::optional<std::size_t> offset() const noexcept { return offset_; }
+
+  private:
+    std::optional<std::size_t> offset_;
+};
+
+/**
+ * @brief Encode a `Spudpack` into a tightly packed byte stream.
+ *
+ * Layout: magic `"SPUD"` (4 bytes), version `u8 = 1`, flags `u8 = 0`,
+ * `varint`+`bytes` source, `varint`+`bytes` program, `varint` asset_count,
+ * per asset (`varint`+`bytes` path, `u16 LE` mode, `varint`+`bytes` data),
+ * `varint` dep_count `= 0`, `u32 LE` CRC32 over `[0, size-4)`.
+ */
+std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack);
+
+/**
+ * @brief Decode a byte stream into a `Spudpack`.
+ *
+ * Validates magic, version, flags, every varint length against the input
+ * bounds, the per-asset cap (256 MiB), the total file cap (2 GiB), the
+ * asset-count cap (`1 << 20`), each asset path against the normalisation
+ * rules, mode bits against `0o7777`, dep count `= 0`, and the trailing
+ * CRC32. Every failure throws `SpudpackError` with the byte offset at
+ * which decoding gave up.
+ */
+Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size);
+
+/**
+ * @brief Write a `Spudpack` to disk.
+ *
+ * **Not atomic** — callers that need atomic install must write to a
+ * temporary path and rename themselves.
+ */
+void spudpack_write_file(const std::filesystem::path& path, const Spudpack& pack);
+
+/** @brief Read and decode a spudpack file. */
+Spudpack spudpack_read_file(const std::filesystem::path& path);
+
+/**
+ * @brief Normalise an asset path string.
+ *
+ * Strips a leading `./`, collapses `//` runs, rejects `..` segments and
+ * embedded NUL, and rejects absolute paths. The result is forward-slash
+ * separated, has no leading `/`, no `.` or `..` segments, and no embedded
+ * NUL. A trailing `/` is preserved if present in the input. Throws
+ * `SpudpackError` (without an offset) on inputs that cannot be normalised.
+ */
+std::string normalize_asset_path(std::string_view raw);
+
+/**
+ * @brief Predicate form of `normalize_asset_path`.
+ *
+ * Returns true iff the input is already in the form `normalize_asset_path`
+ * would produce. Used by the codec decoder to validate asset entries.
+ */
+bool is_normalized_asset_path(std::string_view path) noexcept;
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_SPUDPACK_H

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -32,6 +32,40 @@ constexpr std::size_t kMaxAssetCount = std::size_t{1} << 20;
 // to give us forward room without accepting nonsense.
 constexpr std::uint16_t kModeMask = 07777;
 
+// LEB128 unsigned varint writer. The reader (added with the decoder) caps
+// length at 10 bytes; the writer's longest encoding for a 64-bit value is
+// also 10 bytes, so the cap stays consistent on both sides.
+void write_varint(std::vector<std::uint8_t>& out, std::uint64_t value) {
+    while (value >= 0x80) {
+        out.push_back(static_cast<std::uint8_t>((value & 0x7F) | 0x80));
+        value >>= 7;
+    }
+    out.push_back(static_cast<std::uint8_t>(value));
+}
+
+void write_u16_le(std::vector<std::uint8_t>& out, std::uint16_t value) {
+    out.push_back(static_cast<std::uint8_t>(value & 0xFF));
+    out.push_back(static_cast<std::uint8_t>((value >> 8) & 0xFF));
+}
+
+void write_u32_le(std::vector<std::uint8_t>& out, std::uint32_t value) {
+    out.push_back(static_cast<std::uint8_t>(value & 0xFF));
+    out.push_back(static_cast<std::uint8_t>((value >> 8) & 0xFF));
+    out.push_back(static_cast<std::uint8_t>((value >> 16) & 0xFF));
+    out.push_back(static_cast<std::uint8_t>((value >> 24) & 0xFF));
+}
+
+void write_bytes(std::vector<std::uint8_t>& out, const void* data, std::size_t size) {
+    const auto* p = static_cast<const std::uint8_t*>(data);
+    out.insert(out.end(), p, p + size);
+}
+
+void write_length_prefixed(std::vector<std::uint8_t>& out, const void* data,
+                           std::size_t size) {
+    write_varint(out, static_cast<std::uint64_t>(size));
+    write_bytes(out, data, size);
+}
+
 }  // namespace
 
 SpudpackError::SpudpackError(std::string message, std::optional<std::size_t> offset)
@@ -106,8 +140,54 @@ std::string normalize_asset_path(std::string_view raw) {
     return out;
 }
 
-std::vector<std::uint8_t> spudpack_encode(const Spudpack&) {
-    throw SpudpackError("spudpack_encode not yet implemented");
+std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack) {
+    if (pack.assets.size() > kMaxAssetCount) {
+        throw SpudpackError("spudpack asset_count exceeds maximum");
+    }
+
+    std::vector<std::uint8_t> out;
+    out.reserve(pack.source.size() + pack.program_bytes.size() + 64);
+
+    write_bytes(out, kMagic.data(), kMagic.size());
+    out.push_back(kVersion);
+    out.push_back(kFlags);
+
+    write_length_prefixed(out, pack.source.data(), pack.source.size());
+    write_length_prefixed(out, pack.program_bytes.data(), pack.program_bytes.size());
+
+    write_varint(out, static_cast<std::uint64_t>(pack.assets.size()));
+    for (const SpudpackAsset& asset : pack.assets) {
+        if (!is_normalized_asset_path(asset.path)) {
+            throw SpudpackError("spudpack asset path is not normalised: " + asset.path);
+        }
+        if (asset.data.size() > kMaxAssetBytes) {
+            throw SpudpackError("spudpack asset exceeds 256MiB cap: " + asset.path);
+        }
+        if (!asset.path.empty() && asset.path.back() == '/' && !asset.data.empty()) {
+            throw SpudpackError(
+                "spudpack empty-leaf path carries data: " + asset.path);
+        }
+        if ((asset.mode & ~kModeMask) != 0) {
+            throw SpudpackError(
+                "spudpack asset mode has reserved bits set: " + asset.path);
+        }
+        write_length_prefixed(out, asset.path.data(), asset.path.size());
+        write_u16_le(out, asset.mode);
+        write_length_prefixed(out, asset.data.data(), asset.data.size());
+    }
+
+    // dep_count: spudpack v1 does not bundle dependencies. Reserved as a
+    // varint (rather than a fixed byte) so a future version that wants
+    // hundreds of deps does not need a layout change.
+    write_varint(out, 0);
+
+    if (out.size() + 4 > kMaxTotalBytes) {
+        throw SpudpackError("spudpack exceeds 2GiB total cap");
+    }
+
+    std::uint32_t crc = crc32(out.data(), out.size());
+    write_u32_le(out, crc);
+    return out;
 }
 
 Spudpack spudpack_decode(const std::uint8_t*, std::size_t) {

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -66,6 +66,95 @@ void write_length_prefixed(std::vector<std::uint8_t>& out, const void* data,
     write_bytes(out, data, size);
 }
 
+class Reader {
+  public:
+    Reader(const std::uint8_t* data, std::size_t size) noexcept
+        : data_(data), size_(size) {}
+
+    std::size_t offset() const noexcept { return offset_; }
+    std::size_t remaining() const noexcept { return size_ - offset_; }
+
+    std::uint8_t read_u8() {
+        if (remaining() < 1) {
+            throw SpudpackError("spudpack truncated", offset_);
+        }
+        return data_[offset_++];
+    }
+
+    std::uint16_t read_u16_le() {
+        if (remaining() < 2) {
+            throw SpudpackError("spudpack truncated", offset_);
+        }
+        std::uint16_t v = static_cast<std::uint16_t>(data_[offset_]) |
+                          static_cast<std::uint16_t>(data_[offset_ + 1]) << 8;
+        offset_ += 2;
+        return v;
+    }
+
+    std::uint32_t read_u32_le() {
+        if (remaining() < 4) {
+            throw SpudpackError("spudpack truncated", offset_);
+        }
+        std::uint32_t v = static_cast<std::uint32_t>(data_[offset_]) |
+                          static_cast<std::uint32_t>(data_[offset_ + 1]) << 8 |
+                          static_cast<std::uint32_t>(data_[offset_ + 2]) << 16 |
+                          static_cast<std::uint32_t>(data_[offset_ + 3]) << 24;
+        offset_ += 4;
+        return v;
+    }
+
+    // LEB128 unsigned varint, capped at 10 bytes. Throws SpudpackError so
+    // overlong varints encountered while decoding the spudpack envelope
+    // do not surface as binary-serializer errors.
+    std::uint64_t read_varint() {
+        std::size_t start = offset_;
+        std::uint64_t result = 0;
+        int shift = 0;
+        for (int i = 0; i < 10; ++i) {
+            if (remaining() < 1) {
+                throw SpudpackError("spudpack truncated", offset_);
+            }
+            std::uint8_t b = data_[offset_++];
+            result |= static_cast<std::uint64_t>(b & 0x7F) << shift;
+            if ((b & 0x80) == 0) return result;
+            shift += 7;
+        }
+        throw SpudpackError("spudpack varint exceeds 10 bytes", start);
+    }
+
+    // Read a varint length and validate it against the remaining input
+    // before any allocation. The sum-overflow guard catches a hand-crafted
+    // header claiming `length = SIZE_MAX`, which would otherwise wrap to a
+    // small value during arithmetic.
+    std::size_t read_checked_length() {
+        std::size_t at = offset_;
+        std::uint64_t len = read_varint();
+        if (len > std::numeric_limits<std::size_t>::max()) {
+            throw SpudpackError("spudpack length overflow", at);
+        }
+        std::size_t lz = static_cast<std::size_t>(len);
+        if (offset_ > size_ || lz > size_ - offset_) {
+            throw SpudpackError("spudpack truncated", at);
+        }
+        return lz;
+    }
+
+    void read_bytes_into(std::string& out, std::size_t n) {
+        out.assign(reinterpret_cast<const char*>(data_ + offset_), n);
+        offset_ += n;
+    }
+
+    void read_bytes_into(std::vector<std::uint8_t>& out, std::size_t n) {
+        out.assign(data_ + offset_, data_ + offset_ + n);
+        offset_ += n;
+    }
+
+  private:
+    const std::uint8_t* data_;
+    std::size_t size_;
+    std::size_t offset_ = 0;
+};
+
 }  // namespace
 
 SpudpackError::SpudpackError(std::string message, std::optional<std::size_t> offset)
@@ -190,8 +279,103 @@ std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack) {
     return out;
 }
 
-Spudpack spudpack_decode(const std::uint8_t*, std::size_t) {
-    throw SpudpackError("spudpack_decode not yet implemented");
+Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size) {
+    if (size > kMaxTotalBytes) {
+        throw SpudpackError("spudpack exceeds 2GiB total cap", 0);
+    }
+    if (size < kMagic.size() + 2 + 4) {
+        // Need at least magic + version + flags + 4-byte CRC trailer.
+        throw SpudpackError("spudpack truncated", 0);
+    }
+
+    Reader r(data, size - 4);  // CRC trailer is verified separately
+
+    if (std::memcmp(data, kMagic.data(), kMagic.size()) != 0) {
+        throw SpudpackError("not a spudpack", 0);
+    }
+    r.read_u8(); r.read_u8(); r.read_u8(); r.read_u8();  // skip magic
+
+    std::uint8_t version = r.read_u8();
+    if (version != kVersion) {
+        throw SpudpackError(
+            "unsupported spudpack version " + std::to_string(version), 4);
+    }
+    std::uint8_t flags = r.read_u8();
+    if (flags != kFlags) {
+        throw SpudpackError(
+            "unsupported spudpack flags " + std::to_string(flags), 5);
+    }
+
+    Spudpack pack;
+
+    std::size_t source_len = r.read_checked_length();
+    r.read_bytes_into(pack.source, source_len);
+
+    std::size_t program_len = r.read_checked_length();
+    r.read_bytes_into(pack.program_bytes, program_len);
+
+    std::size_t asset_count_at = r.offset();
+    std::uint64_t asset_count_raw = r.read_varint();
+    if (asset_count_raw > kMaxAssetCount) {
+        throw SpudpackError(
+            "spudpack asset_count exceeds maximum", asset_count_at);
+    }
+    std::size_t asset_count = static_cast<std::size_t>(asset_count_raw);
+    pack.assets.reserve(asset_count);
+
+    for (std::size_t i = 0; i < asset_count; ++i) {
+        SpudpackAsset asset;
+
+        std::size_t path_at = r.offset();
+        std::size_t path_len = r.read_checked_length();
+        r.read_bytes_into(asset.path, path_len);
+        if (!is_normalized_asset_path(asset.path)) {
+            throw SpudpackError(
+                "spudpack asset path is not normalised", path_at);
+        }
+
+        std::size_t mode_at = r.offset();
+        asset.mode = r.read_u16_le();
+        if ((asset.mode & ~kModeMask) != 0) {
+            throw SpudpackError(
+                "spudpack asset mode has reserved bits set", mode_at);
+        }
+
+        std::size_t data_len_at = r.offset();
+        std::size_t data_len = r.read_checked_length();
+        if (data_len > kMaxAssetBytes) {
+            throw SpudpackError(
+                "spudpack asset exceeds 256MiB cap", data_len_at);
+        }
+        if (!asset.path.empty() && asset.path.back() == '/' && data_len != 0) {
+            throw SpudpackError(
+                "spudpack empty-leaf path carries data", path_at);
+        }
+        r.read_bytes_into(asset.data, data_len);
+
+        pack.assets.push_back(std::move(asset));
+    }
+
+    std::size_t dep_at = r.offset();
+    std::uint64_t dep_count = r.read_varint();
+    if (dep_count != 0) {
+        throw SpudpackError("spudpack v1 does not support deps", dep_at);
+    }
+
+    if (r.remaining() != 0) {
+        throw SpudpackError("spudpack has trailing bytes", r.offset());
+    }
+
+    std::uint32_t want_crc = crc32(data, size - 4);
+    std::uint32_t got_crc = static_cast<std::uint32_t>(data[size - 4]) |
+                            static_cast<std::uint32_t>(data[size - 3]) << 8 |
+                            static_cast<std::uint32_t>(data[size - 2]) << 16 |
+                            static_cast<std::uint32_t>(data[size - 1]) << 24;
+    if (want_crc != got_crc) {
+        throw SpudpackError("spudpack CRC mismatch", size - 4);
+    }
+
+    return pack;
 }
 
 void spudpack_write_file(const std::filesystem::path&, const Spudpack&) {

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -1,0 +1,125 @@
+#include "spudplate/spudpack.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <utility>
+
+#include "spudplate/crc32.h"
+
+namespace spudplate {
+
+namespace {
+
+// Wire constants. v1 of the on-disk format uses magic "SPUD" followed by a
+// version byte (must be 1), a flags byte (must be 0), and the rest of the
+// fields described in the header doc comment.
+constexpr std::array<std::uint8_t, 4> kMagic = {'S', 'P', 'U', 'D'};
+constexpr std::uint8_t kVersion = 1;
+constexpr std::uint8_t kFlags = 0;
+
+// Per-asset and per-file caps. Both apply to declared lengths inside the
+// stream and are checked before any allocation so a malformed header
+// cannot trigger a multi-gigabyte `vector::reserve`.
+constexpr std::size_t kMaxAssetBytes = std::size_t{256} * 1024 * 1024;
+constexpr std::size_t kMaxTotalBytes = std::size_t{2} * 1024 * 1024 * 1024;
+constexpr std::size_t kMaxAssetCount = std::size_t{1} << 20;
+
+// Producer convention: spudplate's own bundler masks asset modes to 0o0777
+// before encode. The decoder additionally rejects anything outside 0o7777
+// to give us forward room without accepting nonsense.
+constexpr std::uint16_t kModeMask = 07777;
+
+}  // namespace
+
+SpudpackError::SpudpackError(std::string message, std::optional<std::size_t> offset)
+    : std::runtime_error(std::move(message)), offset_(offset) {}
+
+bool is_normalized_asset_path(std::string_view path) noexcept {
+    if (path.empty()) return false;
+    if (path.front() == '/') return false;
+    if (path.find('\0') != std::string_view::npos) return false;
+
+    // Trailing slash is permitted on empty-leaf directory entries. Strip it
+    // for the segment scan so the predicate matches encoded entries with or
+    // without it.
+    std::string_view body = path;
+    if (body.size() > 1 && body.back() == '/') body.remove_suffix(1);
+
+    std::size_t i = 0;
+    while (i < body.size()) {
+        std::size_t j = body.find('/', i);
+        if (j == std::string_view::npos) j = body.size();
+        std::string_view seg = body.substr(i, j - i);
+        if (seg.empty()) return false;       // double slash
+        if (seg == ".") return false;        // current-dir segment
+        if (seg == "..") return false;       // parent-dir segment
+        i = j + 1;
+    }
+    return true;
+}
+
+std::string normalize_asset_path(std::string_view raw) {
+    if (raw.empty()) {
+        throw SpudpackError("asset path is empty");
+    }
+    if (raw.find('\0') != std::string_view::npos) {
+        throw SpudpackError("asset path contains embedded NUL");
+    }
+    if (raw.front() == '/') {
+        throw SpudpackError("asset path is absolute");
+    }
+
+    bool trailing_slash = raw.size() > 1 && raw.back() == '/';
+    std::string_view body = raw;
+    if (trailing_slash) body.remove_suffix(1);
+
+    // Strip a single leading "./" so "./a/b" normalises to "a/b". Mid-path
+    // "." segments are dropped during the segment walk below.
+    if (body.size() >= 2 && body[0] == '.' && body[1] == '/') {
+        body.remove_prefix(2);
+    }
+
+    std::string out;
+    out.reserve(body.size());
+    std::size_t i = 0;
+    while (i < body.size()) {
+        std::size_t j = body.find('/', i);
+        if (j == std::string_view::npos) j = body.size();
+        std::string_view seg = body.substr(i, j - i);
+        i = j + 1;
+        if (seg.empty()) continue;          // collapse "//" runs
+        if (seg == ".") continue;           // drop "." segments
+        if (seg == "..") {
+            throw SpudpackError("asset path contains '..' segment");
+        }
+        if (!out.empty()) out.push_back('/');
+        out.append(seg);
+    }
+
+    if (out.empty()) {
+        throw SpudpackError("asset path normalises to empty");
+    }
+    if (trailing_slash) out.push_back('/');
+    return out;
+}
+
+std::vector<std::uint8_t> spudpack_encode(const Spudpack&) {
+    throw SpudpackError("spudpack_encode not yet implemented");
+}
+
+Spudpack spudpack_decode(const std::uint8_t*, std::size_t) {
+    throw SpudpackError("spudpack_decode not yet implemented");
+}
+
+void spudpack_write_file(const std::filesystem::path&, const Spudpack&) {
+    throw SpudpackError("spudpack_write_file not yet implemented");
+}
+
+Spudpack spudpack_read_file(const std::filesystem::path&) {
+    throw SpudpackError("spudpack_read_file not yet implemented");
+}
+
+}  // namespace spudplate

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -378,12 +378,39 @@ Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size) {
     return pack;
 }
 
-void spudpack_write_file(const std::filesystem::path&, const Spudpack&) {
-    throw SpudpackError("spudpack_write_file not yet implemented");
+void spudpack_write_file(const std::filesystem::path& path, const Spudpack& pack) {
+    std::vector<std::uint8_t> bytes = spudpack_encode(pack);
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        throw SpudpackError("could not open spudpack for writing: " +
+                            path.string());
+    }
+    out.write(reinterpret_cast<const char*>(bytes.data()),
+              static_cast<std::streamsize>(bytes.size()));
+    if (!out) {
+        throw SpudpackError("could not write spudpack: " + path.string());
+    }
 }
 
-Spudpack spudpack_read_file(const std::filesystem::path&) {
-    throw SpudpackError("spudpack_read_file not yet implemented");
+Spudpack spudpack_read_file(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        throw SpudpackError("could not open spudpack: " + path.string());
+    }
+    std::vector<std::uint8_t> buf;
+    in.seekg(0, std::ios::end);
+    auto end = in.tellg();
+    if (end < 0) {
+        throw SpudpackError("could not size spudpack: " + path.string());
+    }
+    buf.resize(static_cast<std::size_t>(end));
+    in.seekg(0, std::ios::beg);
+    in.read(reinterpret_cast<char*>(buf.data()),
+            static_cast<std::streamsize>(buf.size()));
+    if (in.gcount() != static_cast<std::streamsize>(buf.size())) {
+        throw SpudpackError("could not read spudpack: " + path.string());
+    }
+    return spudpack_decode(buf.data(), buf.size());
 }
 
 }  // namespace spudplate

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -17,6 +17,7 @@
 #include "spudplate/lexer.h"
 #include "spudplate/parser.h"
 #include "spudplate/token.h"
+#include "test_helpers.h"
 
 using spudplate::AliasMap;
 using spudplate::BinaryExpr;
@@ -138,35 +139,7 @@ PathExpr path(std::vector<PathSegment> segs) {
     return PathExpr{.segments = std::move(segs), .line = 1, .column = 1};
 }
 
-// Per-test scratch directory. Created on construction with a randomised name
-// under the system temp dir; the previous working directory is restored and
-// the directory is wiped on destruction. Tests that touch the filesystem
-// `chdir` into one of these so `mkdir foo` etc. resolve under it.
-class TmpDir {
-  public:
-    TmpDir() {
-        prev_ = std::filesystem::current_path();
-        std::random_device rd;
-        std::stringstream ss;
-        ss << "spudplate-test-" << std::hex << rd() << rd();
-        path_ = std::filesystem::temp_directory_path() / ss.str();
-        std::filesystem::create_directories(path_);
-        std::filesystem::current_path(path_);
-    }
-    TmpDir(const TmpDir&) = delete;
-    TmpDir& operator=(const TmpDir&) = delete;
-    ~TmpDir() {
-        std::error_code ec;
-        std::filesystem::current_path(prev_, ec);
-        std::filesystem::remove_all(path_, ec);
-    }
-
-    [[nodiscard]] const std::filesystem::path& path() const { return path_; }
-
-  private:
-    std::filesystem::path path_;
-    std::filesystem::path prev_;
-};
+using spudplate::test::TmpDir;
 
 std::string read_file(const std::filesystem::path& p) {
     std::ifstream in(p);

--- a/tests/spudpack_test.cpp
+++ b/tests/spudpack_test.cpp
@@ -1,0 +1,331 @@
+#include "spudplate/spudpack.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "spudplate/crc32.h"
+#include "test_helpers.h"
+
+using spudplate::Spudpack;
+using spudplate::SpudpackAsset;
+using spudplate::SpudpackError;
+using spudplate::is_normalized_asset_path;
+using spudplate::normalize_asset_path;
+using spudplate::spudpack_decode;
+using spudplate::spudpack_encode;
+using spudplate::spudpack_read_file;
+using spudplate::spudpack_write_file;
+using spudplate::test::TmpDir;
+
+namespace {
+
+Spudpack make_simple() {
+    Spudpack p;
+    p.source = "ask name \"Name?\" string\n";
+    p.program_bytes = {1, 2, 3, 4, 5};
+    p.assets.push_back({"templates/main.cpp", 0644,
+                        {'#', 'i', 'n', 'c', 'l', 'u', 'd', 'e'}});
+    p.assets.push_back({"assets/logo.png", 0444, {0x89, 'P', 'N', 'G'}});
+    return p;
+}
+
+void rewrite_crc(std::vector<std::uint8_t>& bytes) {
+    std::uint32_t crc =
+        spudplate::crc32(bytes.data(), bytes.size() - 4);
+    bytes[bytes.size() - 4] = static_cast<std::uint8_t>(crc & 0xFF);
+    bytes[bytes.size() - 3] = static_cast<std::uint8_t>((crc >> 8) & 0xFF);
+    bytes[bytes.size() - 2] = static_cast<std::uint8_t>((crc >> 16) & 0xFF);
+    bytes[bytes.size() - 1] = static_cast<std::uint8_t>((crc >> 24) & 0xFF);
+}
+
+}  // namespace
+
+// --- normalize_asset_path / is_normalized_asset_path -----------------------
+
+TEST(SpudpackPath, NormalizeStripsLeadingDotSlash) {
+    EXPECT_EQ(normalize_asset_path("./a/b"), "a/b");
+}
+
+TEST(SpudpackPath, NormalizeCollapsesDoubleSlash) {
+    EXPECT_EQ(normalize_asset_path("a//b"), "a/b");
+}
+
+TEST(SpudpackPath, NormalizeRejectsAbsolute) {
+    EXPECT_THROW(normalize_asset_path("/a"), SpudpackError);
+}
+
+TEST(SpudpackPath, NormalizeRejectsParentSegment) {
+    EXPECT_THROW(normalize_asset_path("a/../b"), SpudpackError);
+}
+
+TEST(SpudpackPath, NormalizeRejectsEmbeddedNul) {
+    std::string raw("a\0b", 3);
+    EXPECT_THROW(normalize_asset_path(raw), SpudpackError);
+}
+
+TEST(SpudpackPath, NormalizePreservesTrailingSlash) {
+    EXPECT_EQ(normalize_asset_path("foo/bar/"), "foo/bar/");
+}
+
+TEST(SpudpackPath, NormalizeDropsCurrentDirSegments) {
+    EXPECT_EQ(normalize_asset_path("a/./b"), "a/b");
+}
+
+TEST(SpudpackPath, IsNormalizedRejectsDotSegments) {
+    EXPECT_FALSE(is_normalized_asset_path("a/./b"));
+    EXPECT_FALSE(is_normalized_asset_path("a/../b"));
+    EXPECT_FALSE(is_normalized_asset_path("/a"));
+    EXPECT_FALSE(is_normalized_asset_path("a//b"));
+    EXPECT_TRUE(is_normalized_asset_path("a/b"));
+    EXPECT_TRUE(is_normalized_asset_path("a/b/"));
+}
+
+// --- round-trip ------------------------------------------------------------
+
+TEST(SpudpackCodec, RoundTripEmpty) {
+    Spudpack in;
+    auto bytes = spudpack_encode(in);
+    Spudpack out = spudpack_decode(bytes.data(), bytes.size());
+    EXPECT_EQ(out.source, "");
+    EXPECT_TRUE(out.program_bytes.empty());
+    EXPECT_TRUE(out.assets.empty());
+}
+
+TEST(SpudpackCodec, RoundTripSimple) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    Spudpack out = spudpack_decode(bytes.data(), bytes.size());
+    EXPECT_EQ(out.source, in.source);
+    EXPECT_EQ(out.program_bytes, in.program_bytes);
+    ASSERT_EQ(out.assets.size(), 2u);
+    EXPECT_EQ(out.assets[0].path, in.assets[0].path);
+    EXPECT_EQ(out.assets[0].mode, in.assets[0].mode);
+    EXPECT_EQ(out.assets[0].data, in.assets[0].data);
+    EXPECT_EQ(out.assets[1].path, in.assets[1].path);
+    EXPECT_EQ(out.assets[1].mode, in.assets[1].mode);
+    EXPECT_EQ(out.assets[1].data, in.assets[1].data);
+}
+
+TEST(SpudpackCodec, RoundTripEmptyLeafDir) {
+    Spudpack in;
+    in.assets.push_back({"empty/", 0755, {}});
+    auto bytes = spudpack_encode(in);
+    Spudpack out = spudpack_decode(bytes.data(), bytes.size());
+    ASSERT_EQ(out.assets.size(), 1u);
+    EXPECT_EQ(out.assets[0].path, "empty/");
+    EXPECT_EQ(out.assets[0].mode, 0755);
+    EXPECT_TRUE(out.assets[0].data.empty());
+}
+
+TEST(SpudpackCodec, RoundTripSetuidModeWithinSevenSevenSeven) {
+    Spudpack in;
+    in.assets.push_back({"bin/run", 04755, {0xFE, 0xED}});
+    auto bytes = spudpack_encode(in);
+    Spudpack out = spudpack_decode(bytes.data(), bytes.size());
+    ASSERT_EQ(out.assets.size(), 1u);
+    EXPECT_EQ(out.assets[0].mode, 04755);
+}
+
+// --- decoder error paths ---------------------------------------------------
+
+TEST(SpudpackCodec, BadMagic) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    bytes[0] = 'X';
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("not a spudpack"), std::string::npos);
+        ASSERT_TRUE(e.offset().has_value());
+        EXPECT_EQ(*e.offset(), 0u);
+    }
+}
+
+TEST(SpudpackCodec, UnsupportedVersionZero) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    bytes[4] = 0;
+    rewrite_crc(bytes);
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("unsupported spudpack version"),
+                  std::string::npos);
+        ASSERT_TRUE(e.offset().has_value());
+        EXPECT_EQ(*e.offset(), 4u);
+    }
+}
+
+TEST(SpudpackCodec, UnsupportedVersionTwo) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    bytes[4] = 2;
+    rewrite_crc(bytes);
+    EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
+}
+
+TEST(SpudpackCodec, CrcMismatchDetected) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    // Flip a byte inside the source field, leaving the trailer alone.
+    bytes[10] ^= 0xFF;
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("CRC mismatch"), std::string::npos);
+        ASSERT_TRUE(e.offset().has_value());
+        EXPECT_EQ(*e.offset(), bytes.size() - 4);
+    }
+}
+
+TEST(SpudpackCodec, DepCountNonZeroRejected) {
+    // Hand-craft a minimal valid header with dep_count = 1.
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(1);  // version
+    bytes.push_back(0);  // flags
+    bytes.push_back(0);  // source_len = 0
+    bytes.push_back(0);  // program_len = 0
+    bytes.push_back(0);  // asset_count = 0
+    bytes.push_back(1);  // dep_count = 1 (illegal in v1)
+    bytes.insert(bytes.end(), 4, 0);
+    rewrite_crc(bytes);
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("does not support deps"),
+                  std::string::npos);
+    }
+}
+
+TEST(SpudpackCodec, EncodeRejectsNonNormalizedPath) {
+    Spudpack in;
+    in.assets.push_back({"a/../b", 0644, {1}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsEmbeddedNulInPath) {
+    Spudpack in;
+    in.assets.push_back({std::string("a\0b", 3), 0644, {1}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsLeadingSlash) {
+    Spudpack in;
+    in.assets.push_back({"/etc/passwd", 0644, {1}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsTrailingSlashWithData) {
+    Spudpack in;
+    in.assets.push_back({"foo/", 0755, {1, 2}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsModeAboveSevenSevenSeven) {
+    Spudpack in;
+    in.assets.push_back({"foo", static_cast<std::uint16_t>(0xF000), {1}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, DecodeRejectsHugeSourceLength) {
+    // Hand-craft: claim source_len = SIZE_MAX-1 via 10-byte varint. The
+    // length validation must throw before any allocation.
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(1);
+    bytes.push_back(0);
+    // 10-byte varint with the largest representable u64 minus 1.
+    for (int i = 0; i < 9; ++i) bytes.push_back(0xFF);
+    bytes.push_back(0x7F);
+    bytes.insert(bytes.end(), 4, 0);
+    EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
+}
+
+TEST(SpudpackCodec, DecodeRejectsHugeAssetCount) {
+    // Hand-craft: source/program/asset_count where asset_count = (1 << 24).
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(1);
+    bytes.push_back(0);
+    bytes.push_back(0);  // source_len = 0
+    bytes.push_back(0);  // program_len = 0
+    // varint 1<<24 = 16777216 -> 0x80 0x80 0x80 0x08
+    bytes.push_back(0x80);
+    bytes.push_back(0x80);
+    bytes.push_back(0x80);
+    bytes.push_back(0x08);
+    bytes.insert(bytes.end(), 4, 0);
+    rewrite_crc(bytes);
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("asset_count exceeds maximum"),
+                  std::string::npos);
+    }
+}
+
+TEST(SpudpackCodec, DecodeRejectsModeWithReservedBits) {
+    // Build a spudpack with one asset, then overwrite the encoded mode
+    // field with 0xFFFF (which has bits above 0o7777). Re-CRC so the only
+    // failure is the mode check.
+    Spudpack in;
+    in.assets.push_back({"foo", 0644, {1, 2, 3}});
+    auto bytes = spudpack_encode(in);
+
+    // Locate the mode field. After magic(4)+version(1)+flags(1)+source_len(1
+    // varint byte = 0)+program_len(1 = 0)+asset_count(1 = 1)+path_len(1)+
+    // path("foo" = 3 bytes), the next 2 bytes are the mode.
+    std::size_t mode_off = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 3;
+    bytes[mode_off] = 0xFF;
+    bytes[mode_off + 1] = 0xFF;
+    rewrite_crc(bytes);
+
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("reserved bits"), std::string::npos);
+    }
+}
+
+TEST(SpudpackCodec, TruncatedFileBeforeTrailer) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    bytes.resize(bytes.size() / 2);
+    EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
+}
+
+TEST(SpudpackCodec, TruncatedAtMagic) {
+    std::vector<std::uint8_t> bytes(3, 0);
+    EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
+}
+
+// --- file IO ---------------------------------------------------------------
+
+TEST(SpudpackFile, RoundTripWriteRead) {
+    TmpDir tmp;
+    Spudpack in = make_simple();
+    auto file = tmp.path() / "demo.spp";
+    spudpack_write_file(file, in);
+    Spudpack out = spudpack_read_file(file);
+    EXPECT_EQ(out.source, in.source);
+    EXPECT_EQ(out.program_bytes, in.program_bytes);
+    ASSERT_EQ(out.assets.size(), in.assets.size());
+}
+
+TEST(SpudpackFile, ReadMissingFileThrows) {
+    TmpDir tmp;
+    EXPECT_THROW(spudpack_read_file(tmp.path() / "does_not_exist.spp"),
+                 SpudpackError);
+}

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -1,5 +1,7 @@
 #include "test_helpers.h"
 
+#include <random>
+#include <sstream>
 #include <variant>
 
 namespace spudplate::test {
@@ -244,6 +246,22 @@ bool programs_equal(const Program& a, const Program& b) {
         if (!stmts_equal(*a.statements[i], *b.statements[i])) return false;
     }
     return true;
+}
+
+TmpDir::TmpDir(bool chdir) : chdir_(chdir) {
+    if (chdir_) prev_ = std::filesystem::current_path();
+    std::random_device rd;
+    std::stringstream ss;
+    ss << "spudplate-test-" << std::hex << rd() << rd();
+    path_ = std::filesystem::temp_directory_path() / ss.str();
+    std::filesystem::create_directories(path_);
+    if (chdir_) std::filesystem::current_path(path_);
+}
+
+TmpDir::~TmpDir() {
+    std::error_code ec;
+    if (chdir_) std::filesystem::current_path(prev_, ec);
+    std::filesystem::remove_all(path_, ec);
 }
 
 }  // namespace spudplate::test

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,6 +1,8 @@
 #ifndef SPUDPLATE_TESTS_TEST_HELPERS_H
 #define SPUDPLATE_TESTS_TEST_HELPERS_H
 
+#include <filesystem>
+
 #include "spudplate/ast.h"
 
 namespace spudplate::test {
@@ -16,6 +18,25 @@ bool stmts_equal(const Stmt& a, const Stmt& b);
 bool exprs_equal(const Expr& a, const Expr& b);
 bool path_exprs_equal(const PathExpr& a, const PathExpr& b);
 bool file_sources_equal(const FileSource& a, const FileSource& b);
+
+// Per-test scratch directory. Created on construction with a randomised name
+// under the system temp dir; the previous working directory is restored and
+// the directory is wiped on destruction. `chdir`-into-the-tempdir is opt-in
+// — pass `chdir = false` for tests that should keep the caller's cwd.
+class TmpDir {
+  public:
+    explicit TmpDir(bool chdir = true);
+    TmpDir(const TmpDir&) = delete;
+    TmpDir& operator=(const TmpDir&) = delete;
+    ~TmpDir();
+
+    [[nodiscard]] const std::filesystem::path& path() const { return path_; }
+
+  private:
+    std::filesystem::path path_;
+    std::filesystem::path prev_;
+    bool chdir_;
+};
 
 }  // namespace spudplate::test
 


### PR DESCRIPTION
## Summary
Add a single-file binary container for installed templates. A spudpack carries the original source text, the opaque compiled program, and every bundled asset. CRC-protected, length-prefixed, and validated end-to-end so a malformed file is rejected before any allocation.

## Changes
- `include/spudplate/spudpack.h`, `src/spudpack.cpp` — `Spudpack`, `SpudpackAsset`, `SpudpackError` (carries an optional byte offset). Encode and decode functions plus `spudpack_write_file` and `spudpack_read_file` (the file IO wrappers are deliberately non-atomic — atomic install is the caller's job).
- Wire layout: `"SPUD"` magic, version `1`, flags `0`, length-prefixed source and program bytes, asset count and per-asset records (path, mode `u16` LE, data), `dep_count = 0`, and a CRC32 trailer over `[0, size-4)`. All multi-byte integers little-endian. Lengths are LEB128 varints capped at 10 bytes and validated against the input bounds before any allocation.
- Asset path normalisation helper (`normalize_asset_path` and `is_normalized_asset_path`) — strips a leading `./`, collapses `//` runs, drops `.` segments, rejects `..` segments, embedded NUL bytes, and absolute paths. Trailing `/` is preserved and means "empty leaf directory" (zero data).
- Decoder validation: bad magic at offset 0, version not `1` at offset 4, flags not `0`, varint length overflow, sum-overflow against the remaining input, asset count cap of `1 << 20` (checked before reserve), per-asset cap of 256 MiB, total cap of 2 GiB, mode bits above `0o7777`, dep count not `0`, trailing bytes after the body, CRC mismatch at the trailer offset.
- `tests/test_helpers.{h,cpp}` — `TmpDir` hoisted out of `interpreter_test.cpp` so the new file IO tests (and future modules) can share it.
- `tests/spudpack_test.cpp` — 29 tests covering normalisation, round-trip (empty, simple, empty leaf, setuid mode), every documented decoder error path including hand-crafted oversize lengths and asset counts that must throw before allocation, and the file IO round-trip.

## Test plan
- All 570 (29 new) tests pass locally
- Round-trip covered: empty pack, simple pack with two assets, empty leaf directory entry, asset with `0o4755` mode (setuid bit set, within `0o7777`)
- Error paths covered: bad magic, version 0, version 2, CRC byte-flip, dep count 1, encoder rejection of `..`, embedded NUL, leading `/`, trailing `/` with data, mode above `0o7777`, decoder rejection of a hand-crafted huge `source_len` (must throw without allocation), asset count `1 << 24` (must throw without allocation), reserved-bit mode in a stored asset record, truncation mid-body and at magic