### PR TITLE
feat: bundler walks templates for source assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
                tests/cli_test.cpp tests/crc32_test.cpp
                tests/test_helpers.cpp tests/binary_serializer_test.cpp
-               tests/spudpack_test.cpp)
+               tests/spudpack_test.cpp tests/bundler_test.cpp)
 target_include_directories(spudplate_tests PRIVATE tests)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,8 @@ string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
 # Library
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
                           src/interpreter.cpp src/cli.cpp src/crc32.cpp
-                          src/binary_serializer.cpp src/spudpack.cpp)
+                          src/binary_serializer.cpp src/spudpack.cpp
+                          src/bundler.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 target_compile_definitions(spudplate_lib PUBLIC
     SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")

--- a/include/spudplate/bundler.h
+++ b/include/spudplate/bundler.h
@@ -1,0 +1,64 @@
+#ifndef SPUDPLATE_BUNDLER_H
+#define SPUDPLATE_BUNDLER_H
+
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "spudplate/ast.h"
+#include "spudplate/spudpack.h"
+
+namespace spudplate {
+
+/**
+ * @brief The set of assets a parsed program references on disk.
+ *
+ * Asset paths are normalised (forward-slash separators, no leading `/`,
+ * no `.` or `..` segments, no embedded NUL) and deduped by path — entries
+ * with the same normalised path are collapsed iff their bytes and mode
+ * match. A trailing `/` on a path means "empty leaf directory" and the
+ * data field is empty.
+ */
+struct BundleResult {
+    std::vector<SpudpackAsset> assets;
+};
+
+/**
+ * @brief Raised when a `from`/`copy` source path cannot be bundled.
+ *
+ * Carries the source line and column of the offending statement so the
+ * CLI can point a template author at the exact line.
+ */
+class BundleError : public std::runtime_error {
+  public:
+    BundleError(std::string message, int line, int column);
+    int line() const noexcept { return line_; }
+    int column() const noexcept { return column_; }
+
+  private:
+    int line_;
+    int column_;
+};
+
+/**
+ * @brief Walk a parsed program and collect every asset it references.
+ *
+ * `source_root` is the directory the source `.spud` lives in — relative
+ * source paths in `file ... from`, `mkdir ... from`, and `copy` resolve
+ * against it. The bundler dereferences symlinks, breaks loops on
+ * canonical directory paths, and rejects:
+ *   - source paths whose first segment is dynamic (interpolation or alias)
+ *   - dynamic segments that splice mid-filename
+ *   - `copy` sources that resolve to a regular file
+ *   - non-regular non-directory file types (fifo, socket, block, char)
+ *   - entries whose canonical target falls outside canonical source_root
+ *   - duplicates with the same normalised path but conflicting bytes or
+ *     mode
+ */
+BundleResult bundle_assets(const Program& program,
+                           const std::filesystem::path& source_root);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_BUNDLER_H

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -1,0 +1,21 @@
+#include "spudplate/bundler.h"
+
+#include <fstream>
+#include <system_error>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+
+namespace spudplate {
+
+namespace fs = std::filesystem;
+
+BundleError::BundleError(std::string message, int line, int column)
+    : std::runtime_error(std::move(message)), line_(line), column_(column) {}
+
+BundleResult bundle_assets(const Program&, const fs::path&) {
+    throw BundleError("bundle_assets not yet implemented", 0, 0);
+}
+
+}  // namespace spudplate

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -1,5 +1,6 @@
 #include "spudplate/bundler.h"
 
+#include <cstdio>
 #include <fstream>
 #include <system_error>
 #include <unordered_map>
@@ -14,8 +15,399 @@ namespace fs = std::filesystem;
 BundleError::BundleError(std::string message, int line, int column)
     : std::runtime_error(std::move(message)), line_(line), column_(column) {}
 
-BundleResult bundle_assets(const Program&, const fs::path&) {
-    throw BundleError("bundle_assets not yet implemented", 0, 0);
+namespace {
+
+// Result of classifying a source PathExpr. The bundler distinguishes the
+// two legal shapes — a fully-literal path (walk the exact target) and a
+// path with a static prefix that ends in `/` followed by dynamic segments
+// (walk the static-prefix directory). Anything else is a BundleError.
+struct ClassifiedSource {
+    enum class Shape {
+        Static,        ///< Every segment is a PathLiteral.
+        StaticPrefix,  ///< Some segments are dynamic; the literal prefix
+                       ///< ends with `/`.
+    };
+    Shape shape;
+    std::string literal_prefix;  ///< Concatenated leading PathLiteral values.
+};
+
+ClassifiedSource classify_source_path(const PathExpr& path) {
+    if (path.segments.empty()) {
+        throw BundleError("source path is empty", path.line, path.column);
+    }
+    if (!std::holds_alternative<PathLiteral>(path.segments.front())) {
+        throw BundleError(
+            "source path may not start with a dynamic segment",
+            path.line, path.column);
+    }
+
+    std::string literal;
+    bool has_dynamic = false;
+    for (const auto& seg : path.segments) {
+        if (has_dynamic) break;
+        if (std::holds_alternative<PathLiteral>(seg)) {
+            literal.append(std::get<PathLiteral>(seg).value);
+        } else {
+            has_dynamic = true;
+        }
+    }
+
+    if (!has_dynamic) {
+        return {ClassifiedSource::Shape::Static, std::move(literal)};
+    }
+    if (literal.empty() || literal.back() != '/') {
+        throw BundleError(
+            "dynamic segment must follow a '/'", path.line, path.column);
+    }
+    return {ClassifiedSource::Shape::StaticPrefix, std::move(literal)};
+}
+
+// Read a regular file's bytes off disk. Errors here are unusual — the
+// walker has already established the entry is a regular file — so they
+// surface as a BundleError pointing at the originating statement.
+std::vector<std::uint8_t> read_file_bytes(const fs::path& p, int line, int column) {
+    std::ifstream in(p, std::ios::binary);
+    if (!in) {
+        throw BundleError("could not read source: " + p.string(), line, column);
+    }
+    in.seekg(0, std::ios::end);
+    auto end = in.tellg();
+    if (end < 0) {
+        throw BundleError("could not size source: " + p.string(), line, column);
+    }
+    std::vector<std::uint8_t> out(static_cast<std::size_t>(end));
+    in.seekg(0, std::ios::beg);
+    in.read(reinterpret_cast<char*>(out.data()),
+            static_cast<std::streamsize>(out.size()));
+    if (in.gcount() != static_cast<std::streamsize>(out.size())) {
+        throw BundleError("short read on source: " + p.string(), line, column);
+    }
+    return out;
+}
+
+// File-permission bits on disk include setuid/setgid/sticky which spudplate
+// templates have no business carrying. Mask down to the standard 9 user/
+// group/other bits so a template author cannot quietly ship a setuid
+// payload, and so the codec's `mode & ~0o7777 == 0` check is satisfied
+// trivially on every producer-side asset.
+std::uint16_t disk_mode_to_asset_mode(fs::perms p) {
+    return static_cast<std::uint16_t>(static_cast<unsigned>(p) & 0777);
+}
+
+class Bundler {
+  public:
+    explicit Bundler(const fs::path& source_root)
+        : root_(fs::weakly_canonical(source_root)) {}
+
+    BundleResult run(const Program& program) {
+        for (const auto& stmt : program.statements) {
+            if (stmt) visit_stmt(*stmt);
+        }
+        BundleResult out;
+        out.assets.reserve(by_path_.size());
+        for (const auto& key : insertion_order_) {
+            out.assets.push_back(std::move(by_path_[key]));
+        }
+        return out;
+    }
+
+  private:
+    void visit_stmt(const Stmt& stmt) {
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, FileStmt>) {
+                    if (std::holds_alternative<FileFromSource>(s.source)) {
+                        const auto& src = std::get<FileFromSource>(s.source);
+                        process_file_source(src.path, s.line, s.column);
+                    }
+                } else if constexpr (std::is_same_v<T, MkdirStmt>) {
+                    if (s.from_source.has_value()) {
+                        process_dir_source(*s.from_source, s.line, s.column,
+                                           /*forbid_regular_file=*/false);
+                    }
+                } else if constexpr (std::is_same_v<T, CopyStmt>) {
+                    process_dir_source(s.source, s.line, s.column,
+                                       /*forbid_regular_file=*/true);
+                } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                    for (const auto& body : s.body) {
+                        if (body) visit_stmt(*body);
+                    }
+                }
+                // AskStmt, LetStmt, AssignStmt, IncludeStmt, RunStmt carry
+                // no asset references and are intentionally skipped.
+            },
+            stmt.data);
+    }
+
+    // `file ... from <path>` — the path may resolve to a regular file
+    // (whole-file embed) or to a directory whose contents are walked. The
+    // static-prefix-with-dynamic-suffix form means "the static prefix is a
+    // directory, and the runtime resolution picks one of the bundled files
+    // inside it" — same effect on bundling as the directory case.
+    void process_file_source(const PathExpr& path, int line, int column) {
+        auto cls = classify_source_path(path);
+        fs::path target = resolve_under_root(cls.literal_prefix, line, column);
+
+        if (cls.shape == ClassifiedSource::Shape::StaticPrefix) {
+            walk_dir_into_assets(target, cls.literal_prefix, line, column);
+            return;
+        }
+        std::error_code ec;
+        auto status = fs::symlink_status(target, ec);
+        if (ec || !fs::exists(status)) {
+            throw BundleError("source not found: " + target.string(), line, column);
+        }
+        auto resolved = fs::status(target, ec);
+        if (fs::is_regular_file(resolved)) {
+            record_file(target, cls.literal_prefix, line, column);
+        } else if (fs::is_directory(resolved)) {
+            walk_dir_into_assets(target, cls.literal_prefix, line, column);
+        } else {
+            throw BundleError("unsupported file type at " + target.string(),
+                              line, column);
+        }
+    }
+
+    // `mkdir ... from <path>` and `copy <path> into ...` — both must
+    // resolve to a directory. CopyStmt explicitly disallows a regular-file
+    // source per the language spec.
+    void process_dir_source(const PathExpr& path, int line, int column,
+                            bool forbid_regular_file) {
+        auto cls = classify_source_path(path);
+        fs::path target = resolve_under_root(cls.literal_prefix, line, column);
+
+        std::error_code ec;
+        auto resolved = fs::status(target, ec);
+        if (ec || !fs::exists(resolved)) {
+            throw BundleError("source not found: " + target.string(), line, column);
+        }
+        if (fs::is_regular_file(resolved)) {
+            if (forbid_regular_file) {
+                throw BundleError(
+                    "copy source must be a directory: " + target.string(),
+                    line, column);
+            }
+            // mkdir from <regular file> is a parser-rejected form in
+            // theory; treat it defensively the same way as CopyStmt.
+            throw BundleError(
+                "mkdir source must be a directory: " + target.string(),
+                line, column);
+        }
+        if (!fs::is_directory(resolved)) {
+            throw BundleError("unsupported file type at " + target.string(),
+                              line, column);
+        }
+        walk_dir_into_assets(target, cls.literal_prefix, line, column);
+    }
+
+    // Compose `<source_root>/<literal_prefix>` and verify the canonical
+    // form does not escape canonical source_root. Symlinks in the prefix
+    // that point outside the root are rejected here.
+    fs::path resolve_under_root(const std::string& literal_prefix, int line,
+                                int column) {
+        fs::path joined = root_ / literal_prefix;
+        std::error_code ec;
+        fs::path canon = fs::weakly_canonical(joined, ec);
+        if (ec) {
+            throw BundleError("could not resolve source: " + joined.string(),
+                              line, column);
+        }
+        if (!is_under(canon, root_)) {
+            throw BundleError("source path escapes source root", line, column);
+        }
+        return canon;
+    }
+
+    static bool is_under(const fs::path& candidate, const fs::path& root) {
+        auto cit = candidate.begin();
+        auto rit = root.begin();
+        for (; rit != root.end() && cit != candidate.end(); ++rit, ++cit) {
+            if (*cit != *rit) return false;
+        }
+        return rit == root.end();
+    }
+
+    // Walk a directory whose root corresponds to the asset-key prefix
+    // `key_prefix`. Each regular file becomes an asset under
+    // `key_prefix + relative_path`. Directories that turn out to be
+    // empty leaves are recorded with a trailing `/`.
+    void walk_dir_into_assets(const fs::path& dir, const std::string& raw_prefix,
+                              int line, int column) {
+        // The static-prefix classifier returns prefixes that already end
+        // with `/`, but the all-literal classifier returns the raw path
+        // (e.g. `src` for `from src`). Normalise once here so every
+        // downstream concatenation produces a well-formed key.
+        std::string key_prefix = raw_prefix;
+        if (!key_prefix.empty() && key_prefix.back() != '/') {
+            key_prefix.push_back('/');
+        }
+
+        std::error_code ec;
+        std::unordered_set<std::string> visited;
+
+        // Track which directories we've descended into so a symlink that
+        // points back at a parent does not trigger infinite recursion.
+        // recursive_directory_iterator with follow_directory_symlink does
+        // the *following* but does not break loops.
+        std::unordered_map<std::string, bool> dir_has_children;
+        auto canonical_key = [&ec](const fs::path& p) {
+            return fs::weakly_canonical(p, ec).string();
+        };
+
+        std::vector<std::pair<fs::path, std::string>> dir_keys;
+        dir_keys.emplace_back(dir, normalise_dir_key(key_prefix));
+
+        fs::recursive_directory_iterator it(
+            dir, fs::directory_options::follow_directory_symlink, ec);
+        if (ec) {
+            throw BundleError(
+                "could not walk source: " + dir.string(), line, column);
+        }
+        fs::recursive_directory_iterator end;
+
+        while (it != end) {
+            const fs::directory_entry& entry = *it;
+            const fs::path& p = entry.path();
+
+            // Source-root escape: a symlink can drop us outside the root.
+            // Check every entry, not just directories.
+            fs::path canon = fs::weakly_canonical(p, ec);
+            if (ec || !is_under(canon, root_)) {
+                throw BundleError("source path escapes source root", line, column);
+            }
+
+            // `fs::relative` calls `weakly_canonical` on both arguments,
+            // which silently dereferences symlinks. Use `lexically_relative`
+            // for the asset-key computation so a file symlink keeps its
+            // bundled-tree position instead of being relocated to its
+            // target. Symlink loops and source-root escape are caught
+            // separately above.
+            std::string rel = p.lexically_relative(dir).generic_string();
+            std::string key = key_prefix + rel;
+
+            auto status = entry.symlink_status(ec);
+            // Resolve through symlinks for the type decision so a symlink
+            // to a regular file is bundled as a regular file.
+            auto resolved = entry.status(ec);
+
+            if (fs::is_directory(resolved)) {
+                std::string canon_str = canon.string();
+                if (visited.count(canon_str)) {
+                    it.disable_recursion_pending();
+                    it.increment(ec);
+                    continue;
+                }
+                visited.insert(canon_str);
+                dir_has_children[normalise_dir_key(key)] = false;
+                // Mark every ancestor key as having a child so it is not
+                // recorded as an empty leaf.
+                mark_ancestors(key_prefix, key, dir_has_children);
+                it.increment(ec);
+                continue;
+            }
+
+            if (fs::is_regular_file(resolved)) {
+                // Mark ancestors so an enclosing directory with files is
+                // not falsely flagged as an empty leaf.
+                mark_ancestors(key_prefix, key, dir_has_children);
+                record_file(p, key, line, column);
+                it.increment(ec);
+                continue;
+            }
+
+            throw BundleError("unsupported file type at " + p.string(),
+                              line, column);
+        }
+
+        // After the walk, record a trailing-slash entry for every directory
+        // that has no children at all (no files anywhere underneath, no
+        // recorded sub-dirs of its own).
+        for (const auto& [dir_key, has_child] : dir_has_children) {
+            if (has_child) continue;
+            // The walker keys directories with a trailing slash already.
+            // Read the on-disk mode for the directory itself.
+            fs::path on_disk = dir / fs::path(dir_key.substr(key_prefix.size()));
+            std::error_code ec_mode;
+            auto perms = fs::status(on_disk, ec_mode).permissions();
+            std::uint16_t mode = ec_mode ? std::uint16_t{0755}
+                                         : disk_mode_to_asset_mode(perms);
+            insert_or_collide(dir_key, mode, /*data=*/{}, line, column);
+        }
+    }
+
+    // Trailing slash means "directory" in the asset key space.
+    static std::string normalise_dir_key(std::string key) {
+        if (!key.empty() && key.back() != '/') key.push_back('/');
+        return key;
+    }
+
+    // For an asset key like `prefix/sub/leaf.txt`, mark every prefix
+    // directory `prefix/sub/` as having a child so the empty-leaf scan
+    // skips it. We only walk back as far as `key_prefix`.
+    void mark_ancestors(const std::string& key_prefix, const std::string& key,
+                        std::unordered_map<std::string, bool>& has_children) {
+        std::size_t i = key.find('/', key_prefix.size());
+        while (i != std::string::npos) {
+            has_children[key.substr(0, i + 1)] = true;
+            i = key.find('/', i + 1);
+        }
+    }
+
+    // Read a regular file off disk, normalise its asset key, and insert
+    // (or collide-and-error) into the dedup map.
+    void record_file(const fs::path& p, const std::string& raw_key, int line,
+                     int column) {
+        auto bytes = read_file_bytes(p, line, column);
+        std::error_code ec;
+        auto perms = fs::status(p, ec).permissions();
+        std::uint16_t mode = ec ? std::uint16_t{0644}
+                                : disk_mode_to_asset_mode(perms);
+        insert_or_collide(raw_key, mode, std::move(bytes), line, column);
+    }
+
+    // Insert a normalised asset record. If the key is already present the
+    // bytes and mode must match — otherwise the bundler reports the more
+    // specific of the two diagnostics so a template author can see whether
+    // the conflict is content or permissions.
+    void insert_or_collide(const std::string& raw_key, std::uint16_t mode,
+                           std::vector<std::uint8_t> data, int line, int column) {
+        std::string key;
+        try {
+            key = normalize_asset_path(raw_key);
+        } catch (const SpudpackError& e) {
+            throw BundleError(
+                std::string("invalid asset path: ") + e.what(), line, column);
+        }
+        auto it = by_path_.find(key);
+        if (it == by_path_.end()) {
+            SpudpackAsset asset;
+            asset.path = key;
+            asset.mode = mode;
+            asset.data = std::move(data);
+            by_path_.emplace(key, std::move(asset));
+            insertion_order_.push_back(key);
+            return;
+        }
+        if (it->second.data != data) {
+            throw BundleError("conflicting bytes for asset " + key, line, column);
+        }
+        if (it->second.mode != mode) {
+            throw BundleError("conflicting mode for asset " + key, line, column);
+        }
+        // Identical record — fine; collapse silently.
+    }
+
+    fs::path root_;
+    std::unordered_map<std::string, SpudpackAsset> by_path_;
+    std::vector<std::string> insertion_order_;
+};
+
+}  // namespace
+
+BundleResult bundle_assets(const Program& program, const fs::path& source_root) {
+    Bundler b(source_root);
+    return b.run(program);
 }
 
 }  // namespace spudplate

--- a/tests/bundler_test.cpp
+++ b/tests/bundler_test.cpp
@@ -1,0 +1,248 @@
+#include "spudplate/bundler.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <fstream>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+#include "test_helpers.h"
+
+using spudplate::BundleError;
+using spudplate::BundleResult;
+using spudplate::Lexer;
+using spudplate::Parser;
+using spudplate::Program;
+using spudplate::SpudpackAsset;
+using spudplate::bundle_assets;
+using spudplate::test::TmpDir;
+
+namespace fs = std::filesystem;
+
+namespace {
+
+Program parse(const std::string& source) {
+    Lexer lexer(source);
+    Parser parser(std::move(lexer));
+    return parser.parse();
+}
+
+void write_file(const fs::path& p, const std::string& body) {
+    fs::create_directories(p.parent_path());
+    std::ofstream out(p, std::ios::binary);
+    out << body;
+}
+
+const SpudpackAsset* find_asset(const BundleResult& r, const std::string& path) {
+    auto it = std::find_if(r.assets.begin(), r.assets.end(),
+                           [&](const SpudpackAsset& a) { return a.path == path; });
+    return it == r.assets.end() ? nullptr : &*it;
+}
+
+}  // namespace
+
+// --- happy path ------------------------------------------------------------
+
+TEST(Bundler, FileFromRegularFile) {
+    TmpDir tmp;
+    write_file(tmp.path() / "tpl/main.cpp", "int main() {}\n");
+    Program p = parse("file out/main.cpp from tpl/main.cpp\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    ASSERT_EQ(r.assets.size(), 1u);
+    EXPECT_EQ(r.assets[0].path, "tpl/main.cpp");
+    EXPECT_EQ(std::string(r.assets[0].data.begin(), r.assets[0].data.end()),
+              "int main() {}\n");
+}
+
+TEST(Bundler, MkdirFromDirectoryWalksTree) {
+    TmpDir tmp;
+    write_file(tmp.path() / "src/main.cpp", "x\n");
+    write_file(tmp.path() / "src/util/util.cpp", "y\n");
+    Program p = parse("mkdir project from src\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_NE(find_asset(r, "src/main.cpp"), nullptr);
+    EXPECT_NE(find_asset(r, "src/util/util.cpp"), nullptr);
+}
+
+TEST(Bundler, CopySourceMustBeDirectory) {
+    TmpDir tmp;
+    write_file(tmp.path() / "regular.txt", "x\n");
+    fs::create_directories(tmp.path() / "dst");
+    Program p = parse("copy regular.txt into dst\n");
+
+    EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
+}
+
+TEST(Bundler, CopyDirectoryWalks) {
+    TmpDir tmp;
+    write_file(tmp.path() / "snippets/a.txt", "a\n");
+    write_file(tmp.path() / "snippets/b.txt", "b\n");
+    fs::create_directories(tmp.path() / "dst");
+    Program p = parse("copy snippets into dst\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_NE(find_asset(r, "snippets/a.txt"), nullptr);
+    EXPECT_NE(find_asset(r, "snippets/b.txt"), nullptr);
+}
+
+TEST(Bundler, RepeatBodyIsWalked) {
+    TmpDir tmp;
+    write_file(tmp.path() / "wk/body.txt", "tpl\n");
+    Program p = parse(
+        "ask weeks \"How many?\" int default 1\n"
+        "repeat weeks as i\n"
+        "  file out_{i}/body.txt from wk/body.txt\n"
+        "end\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_NE(find_asset(r, "wk/body.txt"), nullptr);
+}
+
+TEST(Bundler, NonAssetStatementsAreSkipped) {
+    TmpDir tmp;
+    Program p = parse(
+        "ask name \"Name?\" string\n"
+        "let upper_name = upper(name)\n"
+        "include foo when name == \"x\"\n"
+        "run \"echo hi\"\n"
+        "file inline.txt content \"hi\"\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_TRUE(r.assets.empty());
+}
+
+// --- path classification ---------------------------------------------------
+
+TEST(Bundler, RejectsLeadingDynamicSegment) {
+    TmpDir tmp;
+    Program p = parse(
+        "ask name \"Name?\" string\n"
+        "file out.txt from {name}/foo\n");
+    try {
+        bundle_assets(p, tmp.path());
+        FAIL() << "expected throw";
+    } catch (const BundleError& e) {
+        EXPECT_NE(std::string(e.what()).find("dynamic"), std::string::npos);
+        EXPECT_EQ(e.line(), 2);
+    }
+}
+
+TEST(Bundler, RejectsDynamicSegmentMidFilename) {
+    TmpDir tmp;
+    fs::create_directories(tmp.path() / "tpl");
+    Program p = parse(
+        "ask n \"n?\" int default 1\n"
+        "file out.txt from tpl/file_{n}\n");
+    // tpl/file_{n} — the literal prefix "tpl/file_" does not end with /,
+    // so this is the mid-filename-dynamic case.
+    EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
+}
+
+TEST(Bundler, AcceptsDynamicSuffixAfterTrailingSlash) {
+    TmpDir tmp;
+    write_file(tmp.path() / "tpl/a.txt", "a\n");
+    write_file(tmp.path() / "tpl/b.txt", "b\n");
+    Program p = parse(
+        "ask choice \"choice?\" string default \"a.txt\"\n"
+        "file out.txt from tpl/{choice}\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_NE(find_asset(r, "tpl/a.txt"), nullptr);
+    EXPECT_NE(find_asset(r, "tpl/b.txt"), nullptr);
+}
+
+// --- empty-leaf and dedup --------------------------------------------------
+
+TEST(Bundler, EmptyLeafDirRecorded) {
+    TmpDir tmp;
+    fs::create_directories(tmp.path() / "scaffold/logs");  // no files
+    Program p = parse("mkdir project from scaffold\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    const SpudpackAsset* a = find_asset(r, "scaffold/logs/");
+    ASSERT_NE(a, nullptr);
+    EXPECT_TRUE(a->data.empty());
+}
+
+TEST(Bundler, NestedEmptyOnlyDeepestRecorded) {
+    TmpDir tmp;
+    fs::create_directories(tmp.path() / "scaffold/a/b/c");  // chain of empties
+    Program p = parse("mkdir project from scaffold\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_NE(find_asset(r, "scaffold/a/b/c/"), nullptr);
+    EXPECT_EQ(find_asset(r, "scaffold/a/"), nullptr);
+    EXPECT_EQ(find_asset(r, "scaffold/a/b/"), nullptr);
+}
+
+TEST(Bundler, DuplicateAssetsCollapseWhenIdentical) {
+    TmpDir tmp;
+    write_file(tmp.path() / "shared/body.txt", "same\n");
+    Program p = parse(
+        "file out_a/body.txt from shared/body.txt\n"
+        "file out_b/body.txt from shared/body.txt\n");
+
+    BundleResult r = bundle_assets(p, tmp.path());
+    EXPECT_EQ(r.assets.size(), 1u);
+}
+
+// --- escape, file types ----------------------------------------------------
+
+TEST(Bundler, RejectsSourceOutsideRoot) {
+    TmpDir tmp;
+    fs::create_directories(tmp.path() / "child");
+    write_file(tmp.path() / "sibling.txt", "x\n");
+    Program p = parse("file out.txt from ../sibling.txt\n");
+
+    EXPECT_THROW(bundle_assets(p, tmp.path() / "child"), BundleError);
+}
+
+TEST(Bundler, RejectsFifo) {
+    TmpDir tmp;
+    fs::create_directories(tmp.path() / "src");
+    fs::path fifo = tmp.path() / "src" / "pipe";
+    if (mkfifo(fifo.c_str(), 0644) != 0) {
+        GTEST_SKIP() << "mkfifo failed; skipping fifo rejection test";
+    }
+    Program p = parse("mkdir project from src\n");
+    EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
+}
+
+// --- symlinks --------------------------------------------------------------
+
+TEST(Bundler, SymlinkToFileFollowed) {
+    TmpDir tmp;
+    write_file(tmp.path() / "real/file.txt", "hello\n");
+    fs::create_directories(tmp.path() / "tree");
+    fs::create_symlink(tmp.path() / "real" / "file.txt",
+                       tmp.path() / "tree" / "link.txt");
+
+    Program p = parse("mkdir project from tree\n");
+    BundleResult r = bundle_assets(p, tmp.path());
+    const SpudpackAsset* a = find_asset(r, "tree/link.txt");
+    ASSERT_NE(a, nullptr);
+    EXPECT_EQ(std::string(a->data.begin(), a->data.end()), "hello\n");
+}
+
+TEST(Bundler, SymlinkLoopBroken) {
+    TmpDir tmp;
+    fs::create_directories(tmp.path() / "loop/a");
+    fs::create_directory_symlink(tmp.path() / "loop", tmp.path() / "loop/a/back");
+
+    Program p = parse("mkdir project from loop\n");
+    // Should not infinite-recurse. The walker may produce zero assets (only
+    // the dir loop) or report an error — either way it must terminate.
+    try {
+        bundle_assets(p, tmp.path());
+    } catch (const BundleError&) {
+        // Acceptable — escaping or unsupported types may surface here.
+    }
+}


### PR DESCRIPTION
## Summary
Walk a parsed program and collect every asset it references on disk into a single deduped list. Templates that bundle their own source files via `file from`, `mkdir from`, or `copy` are now self-contained at the bundler boundary — the next layer up can hand the result straight to the spudpack codec.

## Changes
- `include/spudplate/bundler.h`, `src/bundler.cpp` — `bundle_assets(Program, source_root)` returning a `BundleResult`. `BundleError` carries the source line and column of the offending statement.
- Visits every statement, recurses into the body of `repeat` blocks, and collects assets from `file ... from`, `mkdir ... from`, and `copy`. Skips `ask`, `let`, assignments, `include`, and `run` (no asset references).
- Source path classifier accepts two shapes: fully literal (walk the exact target) and a static prefix that ends in `/` followed by dynamic segments (walk the prefix as a directory). A leading dynamic segment, or a dynamic segment that splices mid-filename, is rejected with a precise diagnostic.
- Directory walk uses `recursive_directory_iterator` with `follow_directory_symlink`. Symlink loops are broken on canonical-directory paths (the iterator follows but does not break loops on its own). Each candidate's `weakly_canonical` is checked against the canonical source root so a symlink that escapes the root is rejected. Asset keys are computed via `lexically_relative` rather than `fs::relative` so a file symlink keeps its bundled-tree position instead of being relocated to its target.
- Per-asset modes are read off disk and masked to `0o0777` — setuid, setgid, and sticky bits are dropped at bundle time, so a template author cannot ship a setuid payload by accident.
- Empty leaf directories (no descendants anywhere underneath) are recorded with a trailing `/` and zero data. Intermediate empties are not recorded — they are implied by `mkdir -p` at materialisation.
- Per-key dedup: identical bytes and mode collapse silently. Bytes differ → `conflicting bytes for asset <path>`. Mode differs → `conflicting mode for asset <path>`. Non-regular non-directory entries (fifo, socket) are rejected with `unsupported file type at <path>`.
- `tests/bundler_test.cpp` — 16 tests covering the happy path (file, mkdir from dir, copy, repeat-body), classifier (leading dynamic rejected, mid-filename dynamic rejected, dynamic suffix after `/` accepted), empty-leaf rules (recorded for the deepest empty only), dedup, source-root escape, fifo rejection, and symlink behaviour (file symlinks followed, directory loops broken).

## Test plan
- All 586 (16 new) tests pass locally
- Symlink behaviour covered: a file symlink inside the walked tree is bundled with its in-tree key, and a directory symlink loop terminates rather than infinite-looping
- Path classification covered: leading `{var}` rejected, `from tpl/file_{n}` (mid-filename dynamic) rejected, `from tpl/{choice}` accepted as a directory walk