### PR TITLE
feat: source provider for interpreter asset reads

### DIFF
--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -6,7 +6,9 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -196,6 +198,53 @@ class ScriptedPrompter : public Prompter {
 };
 
 /**
+ * @brief Source of bundled assets the interpreter draws from for `from`/`copy`.
+ *
+ * Two concrete implementations live in `src/interpreter.cpp`: a disk-backed
+ * provider (cwd-relative reads, used when no asset map is supplied) and an
+ * asset-map provider (used when running an installed `.spp`).
+ *
+ * Asset paths are bundle-root-relative and pre-normalised by
+ * `spudplate::normalize_asset_path` (forward-slash, no leading `/`, no `.`
+ * or `..` segments, no embedded NUL). A trailing `/` on a returned `Entry`
+ * path means "empty leaf directory".
+ *
+ * `mode == 0` is the documented "no mode information" sentinel — the
+ * disk-backed provider always reports zero so callers preserve the
+ * pre-existing `nullopt`-mode behaviour of bare-`.spud` runs.
+ */
+class SourceProvider {
+  public:
+    virtual ~SourceProvider() = default;
+
+    /** @brief One entry returned by `list_under`. */
+    struct Entry {
+        std::string path;       ///< Normalised bundle-root-relative path.
+        bool is_directory;      ///< True for directories (intermediate or empty leaf).
+        std::uint16_t mode;     ///< Permission bits, or 0 for "no mode information".
+    };
+
+    /**
+     * @brief Read the bytes of an asset by its normalised path.
+     *
+     * Returns the content and the asset mode (or 0 when the provider does
+     * not carry mode information).
+     */
+    virtual std::pair<std::vector<std::uint8_t>, std::uint16_t> read(
+        std::string_view path) const = 0;
+
+    /**
+     * @brief List every entry under the given prefix, including
+     * synthesised intermediate directories.
+     *
+     * The returned list is in pre-order (parent before children) so callers
+     * that map entries to filesystem operations naturally satisfy the
+     * create-parent-first ordering.
+     */
+    virtual std::vector<Entry> list_under(std::string_view prefix) const = 0;
+};
+
+/**
  * @brief Run a validated program.
  *
  * Walks `program.statements` top-to-bottom, prompting through `prompter` for
@@ -208,9 +257,14 @@ class ScriptedPrompter : public Prompter {
  * effects. The `skip_authorization` flag bypasses the prompt for non-
  * interactive callers — they take responsibility for having vetted the
  * source.
+ *
+ * `source` overrides where `from`/`copy` reads come from. A null `source`
+ * (the default) routes reads through a disk-backed provider so existing
+ * bare-`.spud` callers see the historical cwd-relative behaviour.
  */
 void run(const Program& program, Prompter& prompter,
-         bool skip_authorization = false);
+         bool skip_authorization = false,
+         const SourceProvider* source = nullptr);
 
 /**
  * @brief Test-only entry point: like `run`, but returns the final environment.
@@ -218,7 +272,8 @@ void run(const Program& program, Prompter& prompter,
  * Production callers should use `run`; this is exposed so tests can assert
  * on bindings without relying on filesystem side effects.
  */
-Environment run_for_tests(const Program& program, Prompter& prompter);
+Environment run_for_tests(const Program& program, Prompter& prompter,
+                          const SourceProvider* source = nullptr);
 
 /**
  * @brief Run a program without touching the filesystem.
@@ -237,7 +292,8 @@ Environment run_for_tests(const Program& program, Prompter& prompter);
  * the flush step.
  */
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
-             bool ascii_only = false);
+             bool ascii_only = false,
+             const SourceProvider* source = nullptr);
 
 /**
  * @brief Heuristic check: does the current environment look UTF-8 capable?

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "spudplate/ast.h"
+#include "spudplate/spudpack.h"
 
 namespace spudplate {
 
@@ -242,6 +243,28 @@ class SourceProvider {
      * create-parent-first ordering.
      */
     virtual std::vector<Entry> list_under(std::string_view prefix) const = 0;
+};
+
+/**
+ * @brief `SourceProvider` backed by a borrowed asset map.
+ *
+ * Used by `cmd_run` when running an installed `.spp`. The provider holds
+ * a reference to the asset vector inside the decoded `Spudpack`; the
+ * caller must keep that pack alive for the duration of any call into the
+ * interpreter. `cmd_run` does so by scoping the `Spudpack` and the
+ * provider in the same lexical block.
+ */
+class AssetMapSourceProvider final : public SourceProvider {
+  public:
+    explicit AssetMapSourceProvider(const std::vector<SpudpackAsset>& assets);
+
+    std::pair<std::vector<std::uint8_t>, std::uint16_t> read(
+        std::string_view path) const override;
+    std::vector<Entry> list_under(std::string_view prefix) const override;
+
+  private:
+    const std::vector<SpudpackAsset>& assets_;
+    std::unordered_map<std::string, std::size_t> index_;
 };
 
 /**

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1295,18 +1295,22 @@ std::string value_to_string(const Value& value) {
         value);
 }
 
-void run(const Program& program, Prompter& prompter, bool skip_authorization) {
+void run(const Program& program, Prompter& prompter, bool skip_authorization,
+         const SourceProvider* source) {
     if (!skip_authorization) {
         std::string summary = build_authorize_summary(program);
         if (!summary.empty() && !prompter.authorize(summary)) {
             return;  // declined: clean exit, no side effects, no statements ran
         }
     }
+    (void)source;  // wired in by the next commit
     Interpreter interp(prompter);
     run_program(program, interp);
 }
 
-Environment run_for_tests(const Program& program, Prompter& prompter) {
+Environment run_for_tests(const Program& program, Prompter& prompter,
+                          const SourceProvider* source) {
+    (void)source;
     Interpreter interp(prompter);
     run_program(program, interp);
     return std::move(interp.env());
@@ -1482,7 +1486,8 @@ bool locale_is_utf8() {
 }
 
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
-             bool ascii_only) {
+             bool ascii_only, const SourceProvider* source) {
+    (void)source;
     Interpreter interp(prompter);
     interp.set_ask_total(count_ask_statements(program));
     for (const auto& stmt : program.statements) {

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include "spudplate/ast.h"
+#include "spudplate/spudpack.h"
 #include "spudplate/token.h"
 
 namespace spudplate {
@@ -107,32 +108,91 @@ struct PendingRun {
 using PendingOp =
     std::variant<PendingMkdir, PendingFile, PendingCheckDir, PendingRun>;
 
+// Disk-backed implementation of `SourceProvider`. Reads run against
+// `std::filesystem` rooted at the current working directory; mode is
+// always zero so callers preserve the bare-`.spud` behaviour where mode
+// information is absent and `PendingFile.mode` stays `nullopt`.
+//
+// `list_under` matches the historical walk: directories visited
+// pre-order, file symlinks visited as-is, non-regular non-directory
+// entries silently skipped (preserving the legacy comment "symlinks,
+// fifos, etc. are silently skipped for v1").
+class DiskSourceProvider final : public SourceProvider {
+  public:
+    std::pair<std::vector<std::uint8_t>, std::uint16_t> read(
+        std::string_view path) const override {
+        std::filesystem::path p(path);
+        std::error_code ec;
+        auto status = std::filesystem::status(p, ec);
+        if (ec || !std::filesystem::exists(status)) {
+            throw std::runtime_error(
+                "source file '" + std::string(path) + "' does not exist");
+        }
+        if (!std::filesystem::is_regular_file(status)) {
+            throw std::runtime_error(
+                "source '" + std::string(path) + "' is not a regular file");
+        }
+        std::ifstream in(p, std::ios::binary);
+        if (!in) {
+            throw std::runtime_error(
+                "cannot open source '" + std::string(path) + "' for reading");
+        }
+        std::vector<std::uint8_t> bytes(
+            (std::istreambuf_iterator<char>(in)),
+            std::istreambuf_iterator<char>());
+        return {std::move(bytes), 0};
+    }
+
+    std::vector<Entry> list_under(std::string_view prefix) const override {
+        std::vector<Entry> out;
+        std::filesystem::path root(prefix);
+        std::error_code ec;
+        for (auto it = std::filesystem::recursive_directory_iterator(root, ec);
+             it != std::filesystem::recursive_directory_iterator{}; ++it) {
+            const auto& p = it->path();
+            std::string rel = p.lexically_relative(root).generic_string();
+            if (it->is_directory()) {
+                out.push_back({std::move(rel), /*is_directory=*/true, 0});
+            } else if (it->is_regular_file()) {
+                out.push_back({std::move(rel), /*is_directory=*/false, 0});
+            }
+            // symlinks, fifos, etc. silently skipped — preserves v1
+            // bare-`.spud` behaviour byte-for-byte.
+        }
+        return out;
+    }
+};
+
+// Default disk-backed provider used when the caller passes `nullptr`.
+// Lives at process scope so a single instance is shared across runs and
+// the no-allocation back-compat path never touches the heap.
+const SourceProvider& default_source_provider() {
+    static DiskSourceProvider instance;
+    return instance;
+}
+
 // Read a regular file (cwd-relative) into a string. The position arguments
 // point at the *.spud* statement that triggered the read so error messages
 // surface there rather than at some unhelpful internal site.
-std::string read_source_file(const std::string& path, int line, int column) {
-    std::error_code ec;
-    auto status = std::filesystem::status(path, ec);
-    if (ec) {
-        throw RuntimeError("cannot stat source '" + path + "': " + ec.message(),
-                           line, column);
+std::pair<std::string, std::uint16_t> read_source_file(
+    const SourceProvider& source, const std::string& path, int line, int column) {
+    try {
+        auto [bytes, mode] = source.read(path);
+        std::string s(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        return {std::move(s), mode};
+    } catch (const std::exception& e) {
+        throw RuntimeError(e.what(), line, column);
     }
-    if (!std::filesystem::exists(status)) {
-        throw RuntimeError("source file '" + path + "' does not exist", line,
-                           column);
-    }
-    if (!std::filesystem::is_regular_file(status)) {
-        throw RuntimeError("source '" + path + "' is not a regular file", line,
-                           column);
-    }
-    std::ifstream in(path, std::ios::binary);
-    if (!in) {
-        throw RuntimeError("cannot open source '" + path + "' for reading", line,
-                           column);
-    }
-    std::string content((std::istreambuf_iterator<char>(in)),
-                        std::istreambuf_iterator<char>());
-    return content;
+}
+
+// A source file is treated as binary — and therefore not interpolated —
+// when it contains any NUL byte. This is the unambiguous binary signal:
+// every common binary format (PNG, JPEG, ELF, fonts, gzip) carries NUL
+// bytes in the first kilobyte. Latin-1 templates with stray high bytes
+// but no NUL still go through `interpolate_content` and surface today's
+// `unclosed '{'` / bad-identifier errors when the author has a typo.
+bool content_is_binary(std::string_view content) {
+    return content.find('\0') != std::string_view::npos;
 }
 
 // Substitute `{ident}` occurrences in `content` with the stringified value
@@ -141,6 +201,9 @@ std::string read_source_file(const std::string& path, int line, int column) {
 // `verbatim` to copy file contents byte-for-byte without substitution.
 std::string interpolate_content(const std::string& content,
                                 const Environment& env, int line, int column) {
+    if (content_is_binary(content)) {
+        return content;
+    }
     std::string out;
     out.reserve(content.size());
     std::size_t i = 0;
@@ -705,7 +768,8 @@ Value eval_call(const FunctionCallExpr& fc, const Environment& env) {
 
 class Interpreter {
   public:
-    explicit Interpreter(Prompter& prompter) : prompter_(prompter) {}
+    Interpreter(Prompter& prompter, const SourceProvider& source)
+        : prompter_(prompter), source_(source) {}
 
     void set_ask_total(int total) { ask_total_ = total; }
 
@@ -873,46 +937,65 @@ class Interpreter {
                                   const std::string& dst_root, bool verbatim,
                                   int line, int column) {
         namespace fs = std::filesystem;
-        std::error_code ec;
-        auto src_status = fs::status(src, ec);
-        if (ec) {
-            throw RuntimeError(
-                "cannot stat source '" + src + "': " + ec.message(), line,
-                column);
+        std::vector<SourceProvider::Entry> entries;
+        try {
+            entries = source_.list_under(src);
+        } catch (const std::exception& e) {
+            throw RuntimeError(e.what(), line, column);
         }
-        if (!fs::exists(src_status)) {
-            throw RuntimeError("source directory '" + src + "' does not exist",
-                               line, column);
+        // The disk-backed provider returns nothing for a missing source.
+        // The historical behaviour is to surface a precise error in that
+        // case, so the walker double-checks existence here when the
+        // provider produced no entries — but only against the disk so
+        // the asset-map case is not regressed.
+        if (entries.empty()) {
+            std::error_code ec;
+            auto status = fs::status(src, ec);
+            if (!ec && fs::exists(status) && !fs::is_directory(status)) {
+                throw RuntimeError("source '" + src + "' is not a directory",
+                                   line, column);
+            }
+            if (ec || !fs::exists(status)) {
+                // Asset-map providers will simply have nothing to list
+                // under a non-existent prefix; if no asset-map keys
+                // matched and disk also has nothing, surface the legacy
+                // diagnostic.
+                throw RuntimeError(
+                    "source directory '" + src + "' does not exist", line,
+                    column);
+            }
         }
-        if (!fs::is_directory(src_status)) {
-            throw RuntimeError("source '" + src + "' is not a directory", line,
-                               column);
-        }
-        fs::path src_path{src};
+
         fs::path dst_path{dst_root};
-        for (auto it = fs::recursive_directory_iterator(src_path);
-             it != fs::recursive_directory_iterator{}; ++it) {
-            auto rel = fs::relative(it->path(), src_path);
-            auto target = (dst_path / rel).string();
-            if (it->is_directory()) {
+        for (auto& entry : entries) {
+            std::string target = (dst_path / entry.path).generic_string();
+            if (entry.is_directory) {
+                std::optional<int> mode_opt;
+                if (entry.mode != 0) mode_opt = static_cast<int>(entry.mode);
                 pending_.push_back(PendingMkdir{.path = std::move(target),
-                                                .mode = std::nullopt,
+                                                .mode = mode_opt,
                                                 .line = line,
                                                 .column = column});
-            } else if (it->is_regular_file()) {
-                std::string content =
-                    read_source_file(it->path().string(), line, column);
-                if (!verbatim) {
-                    content = interpolate_content(content, env_, line, column);
-                }
-                pending_.push_back(PendingFile{.path = std::move(target),
-                                               .content = std::move(content),
-                                               .append = false,
-                                               .mode = std::nullopt,
-                                               .line = line,
-                                               .column = column});
+                continue;
             }
-            // symlinks, fifos, etc. are silently skipped for v1
+            // Regular file: provider key joins to the source root for
+            // disk lookups; asset-map providers store the full key
+            // already, so passing the joined key to `provider.read` is
+            // correct in both cases.
+            std::string lookup = (fs::path(src) / entry.path).generic_string();
+            auto [content, mode] =
+                read_source_file(source_, lookup, line, column);
+            if (!verbatim) {
+                content = interpolate_content(content, env_, line, column);
+            }
+            std::optional<int> mode_opt;
+            if (mode != 0) mode_opt = static_cast<int>(mode);
+            pending_.push_back(PendingFile{.path = std::move(target),
+                                           .content = std::move(content),
+                                           .append = false,
+                                           .mode = mode_opt,
+                                           .line = line,
+                                           .column = column});
         }
     }
 
@@ -944,12 +1027,22 @@ class Interpreter {
             return;
         }
         std::string content;
+        std::optional<int> mode = s.mode;
         if (std::holds_alternative<FileFromSource>(s.source)) {
             const auto& fs = std::get<FileFromSource>(s.source);
             std::string src_path = evaluate_path(fs.path, env_, alias_map_);
-            content = read_source_file(src_path, s.line, s.column);
+            auto [bytes, src_mode] =
+                read_source_file(source_, src_path, s.line, s.column);
+            content = std::move(bytes);
             if (!fs.verbatim) {
                 content = interpolate_content(content, env_, s.line, s.column);
+            }
+            // Explicit `mode` on the statement wins over the source's mode;
+            // otherwise propagate the source mode (asset-map only — disk
+            // provider always reports zero so bare-`.spud` runs preserve
+            // the historical `nullopt`).
+            if (!mode.has_value() && src_mode != 0) {
+                mode = static_cast<int>(src_mode);
             }
         } else {
             const auto& content_src = std::get<FileContentSource>(s.source);
@@ -964,7 +1057,7 @@ class Interpreter {
         pending_.push_back(PendingFile{.path = std::move(path_str),
                                        .content = std::move(content),
                                        .append = s.append,
-                                       .mode = s.mode,
+                                       .mode = mode,
                                        .line = s.line,
                                        .column = s.column});
     }
@@ -1037,30 +1130,67 @@ class Interpreter {
         // overwrite, allowed. The pre-existing check only fires for paths
         // that existed before the run started.
         check_pre_existing(op.path, op.line, op.column);
-        std::ios::openmode mode = std::ios::out;
+        std::ios::openmode mode = std::ios::out | std::ios::binary;
         if (op.append) {
             mode |= std::ios::app;
         } else {
             mode |= std::ios::trunc;
         }
+
+        // Append over a file whose mode lacks owner_write would fail at
+        // open time. Documented case: `file foo from readonly` (mode 0444)
+        // followed by `file foo append content "..."`. Widen owner_write
+        // for the duration of the append, restore the prior mode on scope
+        // exit even if the write throws. Inert when already writable.
+        struct Restore {
+            std::filesystem::path path;
+            std::filesystem::perms prev;
+            bool active{false};
+            ~Restore() {
+                if (active) {
+                    std::error_code ec;
+                    std::filesystem::permissions(
+                        path, prev, std::filesystem::perm_options::replace, ec);
+                }
+            }
+        } guard;
+        if (op.append && std::filesystem::exists(op.path)) {
+            std::error_code ec;
+            auto prev = std::filesystem::status(op.path, ec).permissions();
+            if (!ec && (prev & std::filesystem::perms::owner_write) ==
+                           std::filesystem::perms::none) {
+                guard.path = op.path;
+                guard.prev = prev;
+                guard.active = true;
+                std::filesystem::permissions(
+                    op.path, std::filesystem::perms::owner_write,
+                    std::filesystem::perm_options::add);
+            }
+        }
+
         {
             std::ofstream out(op.path, mode);
             if (!out) {
                 throw RuntimeError("cannot open '" + op.path + "' for writing",
                                    op.line, op.column);
             }
-            out << op.content;
+            out.write(op.content.data(),
+                      static_cast<std::streamsize>(op.content.size()));
         }
         if (op.mode.has_value()) {
             std::filesystem::permissions(
                 op.path, static_cast<std::filesystem::perms>(*op.mode),
                 std::filesystem::perm_options::replace);
+            // Skip the RAII guard's restore — the caller's explicit mode
+            // wins over the original permissions.
+            guard.active = false;
         }
         created_during_run_.insert(op.path);
     }
 
     Environment env_;
     Prompter& prompter_;
+    const SourceProvider& source_;
     AliasMap alias_map_;
     std::vector<PendingOp> pending_;
     std::unordered_set<std::string> created_during_run_;
@@ -1303,15 +1433,15 @@ void run(const Program& program, Prompter& prompter, bool skip_authorization,
             return;  // declined: clean exit, no side effects, no statements ran
         }
     }
-    (void)source;  // wired in by the next commit
-    Interpreter interp(prompter);
+    Interpreter interp(prompter,
+                       source != nullptr ? *source : default_source_provider());
     run_program(program, interp);
 }
 
 Environment run_for_tests(const Program& program, Prompter& prompter,
                           const SourceProvider* source) {
-    (void)source;
-    Interpreter interp(prompter);
+    Interpreter interp(prompter,
+                       source != nullptr ? *source : default_source_provider());
     run_program(program, interp);
     return std::move(interp.env());
 }
@@ -1487,14 +1617,76 @@ bool locale_is_utf8() {
 
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
              bool ascii_only, const SourceProvider* source) {
-    (void)source;
-    Interpreter interp(prompter);
+    Interpreter interp(prompter,
+                       source != nullptr ? *source : default_source_provider());
     interp.set_ask_total(count_ask_statements(program));
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }
     render_pending(out, interp.pending(),
                    ascii_only ? kAsciiGlyphs : kUtf8Glyphs);
+}
+
+// Public out-of-line definitions for `AssetMapSourceProvider`. The class
+// lives in the public header so callers can construct one alongside a
+// decoded `Spudpack`; the definitions sit here so the file-local
+// `DiskSourceProvider` can stay file-local and the implementation
+// details (the asset index, the dir-prefix logic) do not bleed into
+// downstream translation units.
+AssetMapSourceProvider::AssetMapSourceProvider(
+    const std::vector<SpudpackAsset>& assets)
+    : assets_(assets) {
+    index_.reserve(assets.size());
+    for (std::size_t i = 0; i < assets.size(); ++i) {
+        index_.emplace(assets[i].path, i);
+    }
+}
+
+std::pair<std::vector<std::uint8_t>, std::uint16_t>
+AssetMapSourceProvider::read(std::string_view path) const {
+    auto it = index_.find(std::string(path));
+    if (it == index_.end()) {
+        throw std::runtime_error("source '" + std::string(path) +
+                                 "' was not bundled");
+    }
+    const auto& a = assets_[it->second];
+    return {a.data, a.mode};
+}
+
+std::vector<SourceProvider::Entry>
+AssetMapSourceProvider::list_under(std::string_view raw_prefix) const {
+    std::string prefix(raw_prefix);
+    if (!prefix.empty() && prefix.back() != '/') prefix.push_back('/');
+
+    std::vector<Entry> out;
+    std::unordered_set<std::string> emitted_dirs;
+
+    for (const auto& a : assets_) {
+        if (a.path.size() < prefix.size() ||
+            a.path.compare(0, prefix.size(), prefix) != 0) {
+            continue;
+        }
+        std::string rel = a.path.substr(prefix.size());
+        if (rel.empty()) continue;
+
+        std::size_t slash = rel.find('/');
+        while (slash != std::string::npos) {
+            std::string dir = rel.substr(0, slash + 1);
+            if (emitted_dirs.insert(dir).second) {
+                out.push_back({dir, /*is_directory=*/true, 0});
+            }
+            slash = rel.find('/', slash + 1);
+        }
+
+        if (!rel.empty() && rel.back() == '/') {
+            if (emitted_dirs.insert(rel).second) {
+                out.push_back({std::move(rel), /*is_directory=*/true, a.mode});
+            }
+        } else {
+            out.push_back({std::move(rel), /*is_directory=*/false, a.mode});
+        }
+    }
+    return out;
 }
 
 }  // namespace spudplate

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -4,6 +4,7 @@
 
 #include <climits>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -2342,4 +2343,135 @@ mkdir {name}
     std::stringstream out;
     dry_run(p, prompter, out);
     EXPECT_NE(out.str().find("hello/"), std::string::npos);
+}
+
+// ----- SourceProvider plumbing --------------------------------------------
+
+namespace {
+
+std::string read_text(const std::filesystem::path& p) {
+    std::ifstream in(p, std::ios::binary);
+    std::stringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+}  // namespace
+
+TEST(SourceProvider, AssetMapMaterialisesFileAndMode) {
+    TmpDir td;
+    std::vector<spudplate::SpudpackAsset> assets;
+    assets.push_back(
+        {"tpl/main.cpp", 0644, {'h', 'i', '\n'}});
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse(
+        "mkdir out\n"
+        "file out/main.cpp from tpl/main.cpp\n");
+    ScriptedPrompter prompter({});
+    spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
+    EXPECT_EQ(read_text(td.path() / "out/main.cpp"), "hi\n");
+}
+
+TEST(SourceProvider, MkdirFromAssetMapNestedTree) {
+    TmpDir td;
+    std::vector<spudplate::SpudpackAsset> assets;
+    assets.push_back({"src/a/b/c.txt", 0644, {'x'}});
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse(
+        "mkdir tree from src\n"
+        "file tree/a/extra.txt content \"more\"\n");
+    ScriptedPrompter prompter({});
+    spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "tree/a/b/c.txt"));
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "tree/a/extra.txt"));
+}
+
+TEST(SourceProvider, MkdirFromEmptyLeafDir) {
+    TmpDir td;
+    std::vector<spudplate::SpudpackAsset> assets;
+    assets.push_back({"scaffold/logs/", 0755, {}});
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse("mkdir project from scaffold\n");
+    ScriptedPrompter prompter({});
+    spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "project/logs"));
+}
+
+TEST(SourceProvider, AssetMissSurfacesRuntimeError) {
+    TmpDir td;
+    std::vector<spudplate::SpudpackAsset> assets;
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse("file out.txt from missing.txt\n");
+    ScriptedPrompter prompter({});
+    try {
+        spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
+        FAIL() << "expected throw";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("was not bundled"),
+                  std::string::npos);
+        EXPECT_GT(e.line(), 0);
+    }
+}
+
+TEST(SourceProvider, BinaryContentSkipsInterpolation) {
+    TmpDir td;
+    std::vector<std::uint8_t> png{0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n',
+                                  0x00, 0x01, '{', 'x', '}'};
+    std::vector<spudplate::SpudpackAsset> assets;
+    assets.push_back({"logo.png", 0644, png});
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse(
+        "mkdir out\n"
+        "file out/logo.png from logo.png\n");
+    ScriptedPrompter prompter({});
+    spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
+    auto materialised = read_text(td.path() / "out/logo.png");
+    EXPECT_EQ(materialised.size(), png.size());
+    EXPECT_EQ(std::memcmp(materialised.data(), png.data(), png.size()), 0);
+}
+
+TEST(SourceProvider, AppendOverReadonlyRestoresPriorMode) {
+    TmpDir td;
+    std::vector<spudplate::SpudpackAsset> assets;
+    assets.push_back({"readonly.txt", 0444, {'b', 'a', 's', 'e', '\n'}});
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse(
+        "file out.txt from readonly.txt\n"
+        "file out.txt append content \"more\"\n");
+    ScriptedPrompter prompter({});
+    spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
+    EXPECT_EQ(read_text(td.path() / "out.txt"), "base\nmore");
+    auto perms = std::filesystem::status(td.path() / "out.txt").permissions();
+    EXPECT_EQ(static_cast<unsigned>(perms) & 0777, 0444u);
+}
+
+TEST(SourceProvider, DiskBackedSkipsBrokenSymlinks) {
+    TmpDir td;
+    std::filesystem::create_directories(td.path() / "tree");
+    std::ofstream(td.path() / "tree/regular.txt") << "hi\n";
+    // Broken symlink — target does not exist. Today's behaviour skips
+    // these silently rather than aborting the run; the provider
+    // preserves that.
+    std::filesystem::create_symlink(td.path() / "no/such/target",
+                                    td.path() / "tree/dangling");
+    auto p = parse("mkdir out from tree\n");
+    ScriptedPrompter prompter({});
+    spudplate::run(p, prompter, /*skip_authorization=*/true);
+    EXPECT_TRUE(std::filesystem::exists(td.path() / "out/regular.txt"));
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "out/dangling"));
+}
+
+TEST(SourceProvider, UnclosedBraceStillSurfacedOnTextWithHighBytes) {
+    TmpDir td;
+    // Latin-1 bytes (no NUL) plus a stray '{' should still hit the
+    // interpolation path and report `unclosed '{'`.
+    std::vector<std::uint8_t> body{0xC3, 0xA9, '{', 'a'};  // "é{a"
+    std::vector<spudplate::SpudpackAsset> assets;
+    assets.push_back({"latin.txt", 0644, body});
+    spudplate::AssetMapSourceProvider provider(assets);
+    auto p = parse("file out.txt from latin.txt\n");
+    ScriptedPrompter prompter({});
+    EXPECT_THROW(
+        spudplate::run(p, prompter, /*skip_authorization=*/true, &provider),
+        RuntimeError);
 }


### PR DESCRIPTION
## Summary
Route every `from`/`copy` source lookup in the interpreter through a pluggable `SourceProvider`. A null provider keeps the historical disk-backed cwd-relative behaviour; a future asset-map provider lets installed templates run cwd-independently against bundled assets.

## Changes
- `include/spudplate/interpreter.h` — new abstract `SourceProvider` with `read(path)` returning bytes and a mode, and `list_under(prefix)` returning entries (path, is-directory flag, mode). Public `AssetMapSourceProvider` borrows a `Spudpack`'s asset vector and synthesises intermediate directory entries on demand. `run`, `run_for_tests`, and `dry_run` gain an optional trailing `const SourceProvider*` parameter that defaults to null so every existing call site is unaffected.
- `src/interpreter.cpp` — file-local `DiskSourceProvider` keeps the historical `recursive_directory_iterator` walk and reports `mode == 0` everywhere so bare-`.spud` runs still emit `nullopt` modes on the deferred-write queue. `read_source_file` and `walk_source_into_pending` go through the provider.
- Mode propagation: when an asset entry carries a non-zero mode (asset-map only), it propagates into `PendingMkdir.mode`/`PendingFile.mode`. The disk path's `mode == 0` sentinel preserves the pre-existing behaviour.
- Append-over-readonly: the deferred-write flush now widens `owner_write` for the duration of an append against a file whose mode lacks it, restoring the prior mode on scope exit (including exceptions). An explicit `mode` on the statement skips the restore so the caller's choice wins.
- NUL-byte binary detection: a file whose content contains a NUL byte is treated as binary and skips `{var}` interpolation. The check sits at the top of `interpolate_content`, so every `from`/`copy` flow is covered. Files without NUL bytes still surface today's `unclosed '{'` / bad-identifier errors when an author has a typo.
- File flush now uses `out.write(data, size)` instead of `operator<<` so embedded NULs round-trip byte-for-byte.

## Test plan
- All 594 (8 new) tests pass locally
- Asset-map covered: file content materialises with bytes and mode, nested mkdir tree appears with intermediate directories, empty leaf dirs become real empty dirs, asset miss surfaces a `RuntimeError` with line/column
- Mode and binary covered: PNG header bytes (with NUL) round-trip byte-identical without `verbatim`, append over a 0444 file succeeds and restores 0444, Latin-1 high-byte text without NUL still triggers `unclosed '{'`
- Disk-backed parity covered: a broken symlink inside the source tree is silently skipped, matching the pre-change walker