### PR TITLE
chore: docs and decode hardening for spudpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,28 +27,27 @@ Alternatives:
 ## How it works
 
 1. Write a `.spud` file describing your template
-2. Install it with `spudplate install my_template.spud`
-3. Run it any time with `spudplate run my_template`
-
-To share a template, export it as a `.spudpack` (a signed zip) and the recipient installs it the same way.
+2. Install it with `spudplate install my_template.spud` — spudplate bundles every asset the template references and stores everything as a single `<name>.spp` file under the install root
+3. Run it any time with `spudplate run my_template` — runs work from any working directory because the assets travel with the template
 
 ```
-spudplate install my_template.spud      # validate, store under the install root
+spudplate install my_template.spud      # bundle assets, write <name>.spp under the install root
 spudplate install --yes my_template.spud  # overwrite an existing install without prompting
 spudplate validate my_template.spud     # parse and validate without installing (also: `check`)
 spudplate run my_template               # run by installed name
-spudplate run path/to/file.spud         # or run a file directly
+spudplate run path/to/file.spud         # or run a file directly (cwd-relative assets)
+spudplate run path/to/file.spp          # or run a built spudpack directly
 spudplate list                          # list installed templates
-spudplate inspect my_template           # print the source
+spudplate inspect my_template           # print the source captured at install time
 spudplate uninstall my_template         # remove
 
 spudplate version                       # print the spudplate version
 spudplate update                        # fetch and install the latest spudplate release
-
-spudplate export my_template -o my_template.spudpack
 ```
 
 `install` prompts before overwriting an existing template. Pass `--yes` to skip the prompt (useful for scripts and CI). `update` fetches the latest release of spudplate itself by re-running the install script.
+
+To share a template, send the `<name>.spp` file. The recipient runs it with `spudplate run path/to/template.spp`. (Direct `install` from a `.spp` is intentionally not supported in this version — share the source instead, or run the spudpack directly.)
 
 The install root is `$SPUDPLATE_HOME` if set, otherwise `$XDG_DATA_HOME/spudplate` (default `~/.local/share/spudplate` on most systems).
 

--- a/src/binary_serializer.cpp
+++ b/src/binary_serializer.cpp
@@ -116,6 +116,43 @@ class Reader {
         return s;
     }
 
+    // Read a varint that names a vector element count and bound it against
+    // the bytes left in the input. Each AST element encodes to at least one
+    // byte (a tag), so the count cannot legitimately exceed `remaining()`.
+    // This stops a hand-crafted `n = 2^60` from triggering a multi-gigabyte
+    // `vector::reserve` before the truncation error fires.
+    std::size_t read_count() {
+        const std::size_t start = pos_;
+        const std::uint64_t n = read_varint();
+        if (n > remaining()) {
+            throw BinaryDeserializeError(
+                "element count exceeds remaining input", start);
+        }
+        return static_cast<std::size_t>(n);
+    }
+
+    // Recursion-depth tracker for expression / statement decoding. Real
+    // programs nest a handful of levels at most (a few binary operators
+    // inside a `when` clause, a couple of nested `repeat` blocks). A
+    // pathological `.spp` could chain thousands of `repeat` or binary-op
+    // nodes and blow the call stack; the cap keeps the worst case bounded.
+    class DepthGuard {
+      public:
+        explicit DepthGuard(Reader& r) : r_(r) {
+            constexpr std::size_t kMaxDepth = 256;
+            if (++r_.depth_ > kMaxDepth) {
+                throw BinaryDeserializeError(
+                    "recursion depth exceeds 256", r_.pos_);
+            }
+        }
+        ~DepthGuard() { --r_.depth_; }
+        DepthGuard(const DepthGuard&) = delete;
+        DepthGuard& operator=(const DepthGuard&) = delete;
+
+      private:
+        Reader& r_;
+    };
+
   private:
     void require(std::size_t n, const char* msg) {
         if (pos_ + n > size_) {
@@ -136,6 +173,7 @@ class Reader {
     const std::uint8_t* data_;
     std::size_t size_;
     std::size_t pos_ = 0;
+    std::size_t depth_ = 0;
 };
 
 // ----- Token / VarType wire encoding --------------------------------------
@@ -262,10 +300,10 @@ void encode_expr_vector(Writer& w, const std::vector<ExprPtr>& v) {
 }
 
 std::vector<ExprPtr> decode_expr_vector(Reader& r) {
-    const std::uint64_t n = r.read_varint();
+    const std::size_t n = r.read_count();
     std::vector<ExprPtr> v;
-    v.reserve(static_cast<std::size_t>(n));
-    for (std::uint64_t i = 0; i < n; ++i) {
+    v.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
         v.push_back(decode_expr(r));
     }
     return v;
@@ -332,9 +370,9 @@ void encode_path_expr(Writer& w, const PathExpr& p) {
 
 PathExpr decode_path_expr(Reader& r) {
     PathExpr p;
-    const std::uint64_t n = r.read_varint();
-    p.segments.reserve(static_cast<std::size_t>(n));
-    for (std::uint64_t i = 0; i < n; ++i) {
+    const std::size_t n = r.read_count();
+    p.segments.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
         p.segments.push_back(decode_path_segment(r));
     }
     p.line = static_cast<int>(r.read_zigzag());
@@ -431,6 +469,7 @@ void encode_expr(Writer& w, const Expr& e) {
 }
 
 ExprPtr decode_expr(Reader& r) {
+    Reader::DepthGuard guard(r);
     const std::size_t at = r.pos();
     const std::uint8_t tag = r.read_u8();
     auto wrap = [](auto&& data) {
@@ -511,10 +550,10 @@ ExprPtr decode_expr(Reader& r) {
                                          .column = column});
         }
         case ExprTag::TemplateString: {
-            const std::uint64_t n = r.read_varint();
+            const std::size_t n = r.read_count();
             std::vector<std::variant<std::string, ExprPtr>> parts;
-            parts.reserve(static_cast<std::size_t>(n));
-            for (std::uint64_t i = 0; i < n; ++i) {
+            parts.reserve(n);
+            for (std::size_t i = 0; i < n; ++i) {
                 const std::size_t sub_at = r.pos();
                 const std::uint8_t sub = r.read_u8();
                 switch (static_cast<TemplatePartTag>(sub)) {
@@ -603,6 +642,7 @@ void encode_stmt(Writer& w, const Stmt& s) {
 }
 
 StmtPtr decode_stmt(Reader& r) {
+    Reader::DepthGuard guard(r);
     const std::size_t at = r.pos();
     const std::uint8_t tag = r.read_u8();
     auto wrap = [](auto&& data) {
@@ -690,10 +730,10 @@ StmtPtr decode_stmt(Reader& r) {
         case StmtTag::Repeat: {
             std::string collection_var = r.read_string();
             std::string iterator_var = r.read_string();
-            const std::uint64_t n = r.read_varint();
+            const std::size_t n = r.read_count();
             std::vector<StmtPtr> body;
-            body.reserve(static_cast<std::size_t>(n));
-            for (std::uint64_t i = 0; i < n; ++i) {
+            body.reserve(n);
+            for (std::size_t i = 0; i < n; ++i) {
                 body.push_back(decode_stmt(r));
             }
             auto when_clause = decode_opt_expr(r);
@@ -760,9 +800,9 @@ std::vector<std::uint8_t> serialize_program(const Program& program) {
 Program deserialize_program(const std::uint8_t* data, std::size_t size) {
     Reader r(data, size);
     Program p;
-    const std::uint64_t n = r.read_varint();
-    p.statements.reserve(static_cast<std::size_t>(n));
-    for (std::uint64_t i = 0; i < n; ++i) {
+    const std::size_t n = r.read_count();
+    p.statements.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
         p.statements.push_back(decode_stmt(r));
     }
     return p;

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -251,12 +251,6 @@ class Bundler {
         // recursive_directory_iterator with follow_directory_symlink does
         // the *following* but does not break loops.
         std::unordered_map<std::string, bool> dir_has_children;
-        auto canonical_key = [&ec](const fs::path& p) {
-            return fs::weakly_canonical(p, ec).string();
-        };
-
-        std::vector<std::pair<fs::path, std::string>> dir_keys;
-        dir_keys.emplace_back(dir, normalise_dir_key(key_prefix));
 
         fs::recursive_directory_iterator it(
             dir, fs::directory_options::follow_directory_symlink, ec);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -571,12 +571,23 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
     }
 
     std::string raw_arg{argv[positional_start]};
-    bool is_path = looks_like_path(raw_arg);
-    bool is_spud = is_path && ends_with_spud(std::filesystem::path(raw_arg));
-    bool is_spp = !is_path || ends_with_spp(std::filesystem::path(raw_arg));
+    // Three legal shapes: bare name (resolves to a `.spp` under the install
+    // root), path to a `.spud` source (cwd-relative assets), or path to a
+    // pre-built `.spp` (bundled assets). The bare-name path additionally
+    // detects a directory-shaped legacy install and surfaces a precise
+    // diagnostic before any open is attempted.
+    enum class RunShape { InstalledSpp, SpudFile, SpudpackFile };
+    RunShape shape;
+    if (!looks_like_path(raw_arg)) {
+        shape = RunShape::InstalledSpp;
+    } else if (ends_with_spud(std::filesystem::path(raw_arg))) {
+        shape = RunShape::SpudFile;
+    } else {
+        shape = RunShape::SpudpackFile;
+    }
 
     std::filesystem::path file_path;
-    if (is_path) {
+    if (shape != RunShape::InstalledSpp) {
         file_path = raw_arg;
     } else {
         std::filesystem::path home = install_dir();
@@ -606,7 +617,7 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
     std::string source;
     bool have_pack = false;
 
-    if (is_spud) {
+    if (shape == RunShape::SpudFile) {
         std::ifstream in(file_path);
         if (!in) {
             err << file_path.string() << ": cannot open: " << std::strerror(errno)
@@ -625,7 +636,7 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
                         e.column(), e.what());
             return 2;
         }
-    } else if (is_spp) {
+    } else {
         if (!std::filesystem::exists(file_path)) {
             err << file_path.string() << ": cannot open: "
                 << std::strerror(ENOENT) << "\n";

--- a/tests/binary_serializer_test.cpp
+++ b/tests/binary_serializer_test.cpp
@@ -462,6 +462,35 @@ TEST(BinarySerializer, EmptyProgramRoundTrips) {
     expect_round_trip(program_with({}));
 }
 
+TEST(BinarySerializer, RejectsHugeStatementCount) {
+    // Statement count varint encodes a huge value with no statements
+    // following. The decoder must reject without OOM-reserving.
+    std::vector<std::uint8_t> bytes;
+    // Varint for ~2^60 — 9 continuation bytes plus a high terminator.
+    for (int i = 0; i < 9; ++i) bytes.push_back(0xFF);
+    bytes.push_back(0x0F);
+    EXPECT_THROW(deserialize_program(bytes.data(), bytes.size()),
+                 BinaryDeserializeError);
+}
+
+TEST(BinarySerializer, RejectsDeeplyNestedExpressions) {
+    // A chain of unary `not` ops nested 1000 deep. Each level encodes as
+    // [tag, op_token, ...nested...]; the decoder caps recursion at 256.
+    std::vector<std::uint8_t> bytes;
+    bytes.push_back(0x01);  // statement count = 1
+    bytes.push_back(static_cast<std::uint8_t>(StmtTag::Let));
+    bytes.push_back(0x01);  // name length = 1
+    bytes.push_back('x');   // name
+    for (int i = 0; i < 300; ++i) {
+        bytes.push_back(static_cast<std::uint8_t>(ExprTag::Unary));
+        bytes.push_back(static_cast<std::uint8_t>(TokenType::NOT));
+    }
+    // Inner-most operand and the rest of the encoding will be truncated;
+    // we only need to verify the depth cap fires before stack overflow.
+    EXPECT_THROW(deserialize_program(bytes.data(), bytes.size()),
+                 BinaryDeserializeError);
+}
+
 TEST(BinarySerializer, DeserializeErrorCarriesOffset) {
     // Single byte 0xFF: invalid as a varint (would need continuation), but
     // legal as a single 7-bit value of 127 — actually 0xFF has the high bit


### PR DESCRIPTION
## Summary
Follow-up after the spudpack work landed. Updates the README to reflect the new format, drops dead code in the bundler walk and clarifies the run command's dispatch, and hardens the binary deserialiser against pathological input by capping element counts and recursion depth.

## Changes
- README — install/run examples now mention `<name>.spp`, the cwd-independent run path, and the new "share the spudpack file" flow. The legacy "compressed zip" wording is gone.
- Bundler — removes an unused `dir_keys` vector and `canonical_key` lambda inside the directory walker. Both were left over from an earlier draft and read by no caller.
- CLI run dispatch — replaces three overlapping booleans (`is_path`, `is_spud`, `is_spp`) with a three-valued `RunShape` enum. The old form had `is_spp = !is_path || ends_with_spp(...)`, which is true whenever it's a bare name and tangles two cases.
- Binary deserialiser — every `vector::reserve` driven by a varint count now flows through `Reader::read_count`, which bounds the count against the bytes left in the input (each AST element encodes to at least one byte, so the count cannot legitimately exceed the remaining length). A `Reader::DepthGuard` caps recursion in `decode_expr`/`decode_stmt` at 256, so a hand-crafted `.spp` chaining thousands of `repeat`/binary-op nodes can no longer blow the stack.
- Two new tests cover the count and depth caps with hand-crafted byte streams.

## Test plan
- All 609 (2 new) tests pass locally
- Defence covered: a varint count of `~2^60` is rejected before any allocation, and a 300-deep `not` chain is rejected before reaching the recursion cap of 256