### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(spudplate VERSION 0.1.0 LANGUAGES CXX)
+project(spudplate VERSION 0.2.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary
Bump the project version baked into the binary to `0.2.0` ahead of the release tag.

## Test plan
- Build is green
- `spudplate version` will print `spudplate v0.2.0` once the v0.2.0 tag is pushed (the release workflow passes the tag via `-DSPUDPLATE_VERSION`; this bump keeps non-tagged builds in sync)