### PR TITLE
ci: deploy doxygen docs to github pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,58 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Doxyfile'
+      - 'CMakeLists.txt'
+      - 'include/**'
+      - 'src/**'
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends doxygen
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
+
+      - name: Generate docs
+        run: |
+          cmake -B build
+          cmake --build build --target docs
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
+        with:
+          path: docs/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -451,7 +451,7 @@ mkdir project/src
 mkdir project/tests when use_tests
 
 file project/README.md content "# " + project_name as readme
-file {readme} append content "\nLicensed under " + license + "\n"
+file {readme} append content "\\nLicensed under " + license + "\\n"
 file project/src/main.cpp from templates/main.cpp
 file project/tests/test_main.cpp from templates/test_main.cpp when use_tests
 

--- a/include/spudplate/binary_serializer.h
+++ b/include/spudplate/binary_serializer.h
@@ -78,6 +78,7 @@ class BinarySerializeError : public std::runtime_error {
  */
 class BinaryDeserializeError : public std::runtime_error {
   public:
+    /** @brief Construct with a message and the byte offset where decoding failed. */
     BinaryDeserializeError(std::string message, std::size_t offset);
 
     /** @brief Byte offset within the decoded buffer where the failure occurred. */

--- a/include/spudplate/bundler.h
+++ b/include/spudplate/bundler.h
@@ -21,7 +21,7 @@ namespace spudplate {
  * data field is empty.
  */
 struct BundleResult {
-    std::vector<SpudpackAsset> assets;
+    std::vector<SpudpackAsset> assets;  ///< Deduped, normalised assets ready to embed in a spudpack.
 };
 
 /**
@@ -32,8 +32,11 @@ struct BundleResult {
  */
 class BundleError : public std::runtime_error {
   public:
+    /** @brief Construct with a message and the source line/column of the offending statement. */
     BundleError(std::string message, int line, int column);
+    /** @brief Source line of the offending statement (1-based). */
     int line() const noexcept { return line_; }
+    /** @brief Source column of the offending statement (1-based). */
     int column() const noexcept { return column_; }
 
   private:

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -256,6 +256,7 @@ class SourceProvider {
  */
 class AssetMapSourceProvider final : public SourceProvider {
   public:
+    /** @brief Construct over a borrowed asset vector; the caller owns the lifetime. */
     explicit AssetMapSourceProvider(const std::vector<SpudpackAsset>& assets);
 
     std::pair<std::vector<std::uint8_t>, std::uint16_t> read(

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -68,6 +68,7 @@ class Parser {
     StmtPtr parseCopy();
     /** @brief Parses an `include` statement. */
     StmtPtr parseInclude();
+    /** @brief Parses a `run` statement. */
     StmtPtr parseRun();
     /** @brief Dispatches to the appropriate statement parser based on the current token.
      */

--- a/include/spudplate/spudpack.h
+++ b/include/spudplate/spudpack.h
@@ -20,9 +20,9 @@ namespace spudplate {
  * directory" and the corresponding `data` is empty.
  */
 struct SpudpackAsset {
-    std::string path;
-    std::uint16_t mode;
-    std::vector<std::uint8_t> data;
+    std::string path;                ///< Normalised asset path inside the pack.
+    std::uint16_t mode;              ///< POSIX mode bits, masked to `0o0777`.
+    std::vector<std::uint8_t> data;  ///< Raw asset bytes; empty for an empty leaf directory.
 };
 
 /**
@@ -34,9 +34,9 @@ struct SpudpackAsset {
  * Decoding `program_bytes` into a `Program` is the caller's job.
  */
 struct Spudpack {
-    std::string source;
-    std::vector<std::uint8_t> program_bytes;
-    std::vector<SpudpackAsset> assets;
+    std::string source;                       ///< Original `.spud` source text.
+    std::vector<std::uint8_t> program_bytes;  ///< Opaque serialised AST; decoded by the binary serializer.
+    std::vector<SpudpackAsset> assets;        ///< Every bundled asset referenced by the program.
 };
 
 /**
@@ -47,7 +47,9 @@ struct Spudpack {
  */
 class SpudpackError : public std::runtime_error {
   public:
+    /** @brief Construct with a message and an optional decode offset. */
     SpudpackError(std::string message, std::optional<std::size_t> offset = std::nullopt);
+    /** @brief Byte offset where decoding failed, if known. */
     std::optional<std::size_t> offset() const noexcept { return offset_; }
 
   private:


### PR DESCRIPTION
## Summary
Build the Doxygen site on every push to main and publish it to GitHub Pages. Also adds Dependabot to keep the workflow's pinned action SHAs current, fills in brief comments on the remaining undocumented public members, and escapes backslashes in the syntax.md example so Doxygen renders it correctly.

## Changes
- `.github/workflows/docs.yml` — runs the existing `docs` CMake target so the doxygen-awesome-css theme matches local builds, then uploads and deploys via `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages`. Path filters limit triggers to header, source, Doxyfile, and workflow changes. Per-job permissions, pinned `ubuntu-24.04` runner, pinned action SHAs, timeouts, and a `pages` concurrency group.
- `.github/dependabot.yml` — weekly bumps for github-actions so the pinned SHAs do not go stale.
- Brief doc comments on the remaining undocumented public members across the headers.
- `\\n` in the syntax.md full example so Doxygen does not misinterpret `\n` as a command.

## Test plan
- Local `cmake --build build --target docs` produces `docs/html/index.html` and exits 0
- After merge: in repo Settings, Pages, set Source to "GitHub Actions". The workflow's first run will then publish.