### PR TITLE
fix: docs styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Drops the binary in `~/.local/bin`. Set `PREFIX=/usr/local` (and run with `sudo`
 
 Alternatives:
 - Download a binary from the [releases page](https://github.com/spuddydev/spudplate/releases) and put it on your `PATH`. `SHA256SUMS` is published alongside.
-- Build from source — see [Build](#build) below, then `sudo cmake --install build`.
+- Build from source - see [Build](#build) below, then `sudo cmake --install build`.
 
 ## How it works
 
 1. Write a `.spud` file describing your template
-2. Install it with `spudplate install my_template.spud` — spudplate bundles every asset the template references and stores everything as a single `<name>.spp` file under the install root
-3. Run it any time with `spudplate run my_template` — runs work from any working directory because the assets travel with the template
+2. Install it with `spudplate install my_template.spud` - spudplate bundles every asset the template references and stores everything as a single `<name>.spp` file under the install root
+3. Run it any time with `spudplate run my_template` - runs work from any working directory because the assets travel with the template
 
 ```
 spudplate install my_template.spud      # bundle assets, write <name>.spp under the install root
@@ -47,7 +47,7 @@ spudplate update                        # fetch and install the latest spudplate
 
 `install` prompts before overwriting an existing template. Pass `--yes` to skip the prompt (useful for scripts and CI). `update` fetches the latest release of spudplate itself by re-running the install script.
 
-To share a template, send the `<name>.spp` file. The recipient runs it with `spudplate run path/to/template.spp`. (Direct `install` from a `.spp` is intentionally not supported in this version — share the source instead, or run the spudpack directly.)
+To share a template, send the `<name>.spp` file. The recipient runs it with `spudplate run path/to/template.spp`. (Direct `install` from a `.spp` is intentionally not supported in this version - share the source instead, or run the spudpack directly.)
 
 The install root is `$SPUDPLATE_HOME` if set, otherwise `$XDG_DATA_HOME/spudplate` (default `~/.local/share/spudplate` on most systems).
 
@@ -93,8 +93,8 @@ Requires [Doxygen](https://www.doxygen.nl/) (`brew install doxygen`).
 cmake --build build --target docs
 ```
 
-Opens `docs/html/index.html` — includes the full spudlang syntax reference and API documentation.
+Opens `docs/html/index.html` - includes the full spudlang syntax reference and API documentation.
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT - see [LICENSE](LICENSE).

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -374,7 +374,7 @@ use_tests
 
 Spudlang interpolates `{expr}` in three places:
 
-- **String literals** in any expression - `let s = "hello {name}"`, `run "echo {label}"`, `ask q "{prompt_for}?" string`. The full expression grammar applies inside the braces (identifiers, arithmetic, function calls, string concatenation). Each interpolation result is stringified and concatenated with the surrounding literal text. Brace pairs are balanced, so `{f({x})}` parses as a single interpolation. A `"` inside an interpolation closes the surrounding string literal - keep the inner expression to identifiers and operations on them, or bind a value with `let` first.
+- **String literals** in any expression - `let s = "hello {name}"`, `run "echo {label}"`, `ask q "{prompt_for}?" string`. The full expression grammar applies inside the braces (identifiers, arithmetic, function calls, string concatenation). Each interpolation result is stringified and concatenated with the surrounding literal text. Brace pairs are balanced, so `{f({x})}` parses as a single interpolation. A literal double-quote inside an interpolation closes the surrounding string literal - keep the inner expression to identifiers and operations on them, or bind a value with `let` first.
 - **Path expressions** in `mkdir`, `file`, `copy` - `mkdir week_{n}`, `mkdir {prefix}/notes`. Same expression grammar, with no surrounding quotes.
 - **`from` source files** and files copied by `copy` - only bare `{ident}` substitution is applied to file contents read from disk; no function calls or arithmetic inside the braces. Use `verbatim` to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -8,13 +8,13 @@
 
 A `.spud` file executes top-to-bottom. Questions (`ask`) and actions (`mkdir`, `file`, `copy`, `include`) can be freely interleaved.
 
-The interpreter runs the file in a single pass. Internal state (variables, loops, conditions) evaluates as it is encountered, but filesystem writes are **deferred until the end of the run**. This guarantees the template either fully succeeds or makes no changes — you never see half-written output if the user aborts a prompt.
+The interpreter runs the file in a single pass. Internal state (variables, loops, conditions) evaluates as it is encountered, but filesystem writes are **deferred until the end of the run**. This guarantees the template either fully succeeds or makes no changes - you never see half-written output if the user aborts a prompt.
 
 ---
 
 ## Statements
 
-### `ask` — Prompt the user for input
+### `ask` - Prompt the user for input
 
 ```
 ask <name> "<prompt>" <type> [options <v1> <v2> ...] [default <value>] [when <condition>]
@@ -23,10 +23,10 @@ ask <name> "<prompt>" <type> [options <v1> <v2> ...] [default <value>] [when <co
 Declares a variable `<name>` and asks the user a question at runtime.
 
 - A question is **required** unless it has a `default` value. With a `default`, the user may skip the prompt (empty input) and the default value is used in its place.
-- The `default` accepts any expression — a literal, a previously declared variable, or a computed expression like `lower(trim(project_name))`. The expression is evaluated against the live environment when the user skips the prompt.
+- The `default` accepts any expression - a literal, a previously declared variable, or a computed expression like `lower(trim(project_name))`. The expression is evaluated against the live environment when the user skips the prompt.
 - `options` restricts valid answers to a fixed set, presented as a numbered menu. The user may type either the literal value or its 1-based number.
 - `when <condition>` only asks the question if the condition is true.
-- `ask` is allowed inside `repeat`. Each iteration prompts afresh; the binding lives only for that iteration. Prompts inside `repeat` are indented by 2 spaces per nesting level and are not counted in the `(N/M)` progress indicator (since the iteration count is dynamic). Shadowing rules still apply — an `ask` cannot reuse a name visible from the surrounding scope.
+- `ask` is allowed inside `repeat`. Each iteration prompts afresh; the binding lives only for that iteration. Prompts inside `repeat` are indented by 2 spaces per nesting level and are not counted in the `(N/M)` progress indicator (since the iteration count is dynamic). Shadowing rules still apply - an `ask` cannot reuse a name visible from the surrounding scope.
 
 **Types:**
 
@@ -52,7 +52,7 @@ ask slug "Slug?" string default lower(trim(project_name))
 
 ---
 
-### `let` — Declare a derived variable
+### `let` - Declare a derived variable
 
 ```
 let <name> = <expression>
@@ -75,7 +75,7 @@ let total_days = num_weeks * 7
 
 ---
 
-### Reassignment — Update an existing variable
+### Reassignment - Update an existing variable
 
 ```
 <name> = <expression>
@@ -94,16 +94,16 @@ end
 **Rules:**
 
 - The name must already be declared by `let` and visible in the current scope. Use `let` for the first binding; reassignment is rejected for undeclared names.
-- Only `let` bindings are mutable. `ask` answers, path aliases (`as <name>` on `mkdir` or `file`), and repeat iterators are read-only — assigning to them is a validation error.
-- The runtime captures values at statement time. After `let n = 1`, `mkdir dir_{n}`, `n = n + 1`, `mkdir dir_{n}` you get two directories `dir_1` and `dir_2` — each `mkdir` resolves its path before the next statement runs, so reassignment between them is safe.
+- Only `let` bindings are mutable. `ask` answers, path aliases (`as <name>` on `mkdir` or `file`), and repeat iterators are read-only - assigning to them is a validation error.
+- The runtime captures values at statement time. After `let n = 1`, `mkdir dir_{n}`, `n = n + 1`, `mkdir dir_{n}` you get two directories `dir_1` and `dir_2` - each `mkdir` resolves its path before the next statement runs, so reassignment between them is safe.
 
-Reassignment to an outer-scope `let` from inside a `repeat` body mutates the outer binding (used for accumulators). Bindings local to a `repeat` body cannot be reassigned from outside it once the loop ends — they are out of scope.
+Reassignment to an outer-scope `let` from inside a `repeat` body mutates the outer binding (used for accumulators). Bindings local to a `repeat` body cannot be reassigned from outside it once the loop ends - they are out of scope.
 
 ---
 
 ### Path expressions
 
-Paths in `mkdir`, `file`, and `copy` are written as **path expressions** — an unquoted sequence of identifiers, slashes, dots, hyphens, and `{expr}` interpolations.
+Paths in `mkdir`, `file`, and `copy` are written as **path expressions** - an unquoted sequence of identifiers, slashes, dots, hyphens, and `{expr}` interpolations.
 
 ```
 mkdir static/notes
@@ -113,15 +113,15 @@ mkdir my-project/pre-commit-hooks
 file src/main.cpp from base/main.cpp
 ```
 
-Hyphens are allowed inside a path but cannot start one — `mkdir -foo` would be ambiguous with the subtraction operator and is rejected. Paths containing spaces must be quoted: `mkdir "my notes"`.
+Hyphens are allowed inside a path but cannot start one - `mkdir -foo` would be ambiguous with the subtraction operator and is rejected. Paths containing spaces must be quoted: `mkdir "my notes"`.
 
 `{expr}` interpolation works directly in unquoted paths: `mkdir week_{n}`, `file {prefix}/README.md`.
 
 `mkdir` creates intermediate directories automatically (`mkdir -p` semantics).
 
-#### `as <varname>` — bind a path alias
+#### `as <varname>` - bind a path alias
 
-The `as <varname>` clause binds the path to a variable for reuse. Any identifier in a subsequent path expression is checked against bound aliases — if it matches, it is a variable reference; if not, it is a literal path component. This applies to every segment, not just the leading one:
+The `as <varname>` clause binds the path to a variable for reuse. Any identifier in a subsequent path expression is checked against bound aliases - if it matches, it is a variable reference; if not, it is a literal path component. This applies to every segment, not just the leading one:
 
 ```
 mkdir static as staticpath
@@ -129,19 +129,19 @@ mkdir notes as notespath
 mkdir staticpath/notespath/week_{n}    # both staticpath and notespath are alias references
 ```
 
-On `file`, `as` binds the file path — primarily useful for conditional appends (see `file` below).
+On `file`, `as` binds the file path - primarily useful for conditional appends (see `file` below).
 
 If a path segment matches a bound alias but you want the literal directory name instead, quote that segment: `mkdir "staticpath"/notes`.
 
 ##### Conditional alias scoping
 
-`as <varname>` on a conditional `mkdir` or `file` is a compile-time error if the alias is referenced outside a statement with a semantically equivalent `when` condition. Conditions are compared after normalization, so `use_git`, `use_git == true`, and `not not use_git` are all considered equivalent. Commutativity (`a and b` vs `b and a`) is **not** considered equivalent — a known limitation.
+`as <varname>` on a conditional `mkdir` or `file` is a compile-time error if the alias is referenced outside a statement with a semantically equivalent `when` condition. Conditions are compared after normalization, so `use_git`, `use_git == true`, and `not not use_git` are all considered equivalent. Commutativity (`a and b` vs `b and a`) is **not** considered equivalent - a known limitation.
 
 If the binding is unconditional, it can be referenced anywhere.
 
 ---
 
-### `mkdir` — Create a directory
+### `mkdir` - Create a directory
 
 ```
 mkdir <path> [from <source>] [verbatim] [mode <octal>] [when <condition>] [as <name>]
@@ -149,10 +149,10 @@ mkdir <path> [from <source>] [verbatim] [mode <octal>] [when <condition>] [as <n
 
 Creates a directory at the given path expression.
 
-- `from <source>` — populates the new directory from the contents of `<source>`. The source is embedded at compile time. `{var}` interpolation is applied at runtime to copied file contents unless `verbatim` is specified.
-- `mode <octal>` — sets directory permissions (e.g., `mode 0755`).
-- `when <condition>` — only creates the directory if the condition is true.
-- `as <name>` — binds the path to an alias for later reuse.
+- `from <source>` - populates the new directory from the contents of `<source>`. The source is embedded at compile time. `{var}` interpolation is applied at runtime to copied file contents unless `verbatim` is specified.
+- `mode <octal>` - sets directory permissions (e.g., `mode 0755`).
+- `when <condition>` - only creates the directory if the condition is true.
+- `as <name>` - binds the path to an alias for later reuse.
 
 **Examples:**
 
@@ -165,16 +165,16 @@ mkdir templates from base_templates verbatim when use_templates as templatepath
 
 ---
 
-### `copy` — Copy a directory into an existing destination
+### `copy` - Copy a directory into an existing destination
 
 ```
 copy <source> into <destination> [verbatim] [when <condition>]
 ```
 
-Copies the contents of `<source>` into an **already existing** `<destination>` directory. Errors if the destination does not exist — use `mkdir from` for that. Use `copy` to merge several sources into one directory.
+Copies the contents of `<source>` into an **already existing** `<destination>` directory. Errors if the destination does not exist - use `mkdir from` for that. Use `copy` to merge several sources into one directory.
 
-- `verbatim` — suppress `{var}` interpolation when copying source file contents.
-- `when <condition>` — only perform the copy if the condition is true.
+- `verbatim` - suppress `{var}` interpolation when copying source file contents.
+- `when <condition>` - only perform the copy if the condition is true.
 
 **Examples:**
 
@@ -186,7 +186,7 @@ copy assets into staticpath/assets verbatim
 
 ---
 
-### `file` — Create or append to a file
+### `file` - Create or append to a file
 
 ```
 file <path> [append] from <source> [verbatim] [mode <octal>] [when <condition>] [as <name>]
@@ -195,12 +195,12 @@ file <path> [append] content <expression>     [mode <octal>] [when <condition>] 
 
 Creates a file at `<path>`, either from a source file (`from`) or from an inline expression (`content`).
 
-- `append` — appends to the file instead of overwriting. Without `append`, the file is created fresh (or overwritten if previously created in the same run).
-- `from <source>` — embeds the contents of `<source>` at compile time. `{var}` interpolation is applied at runtime unless `verbatim` is specified.
-- `content <expression>` — inline content. String literals interpolate `{expr}` like everywhere else (`content "n={n}"` writes `n=1` when `n` is `1`). String concatenation also works (`content "n=" + name`). See **Variable Interpolation** below for the full rules.
-- `mode <octal>` — sets file permissions (e.g., `mode 0644`, `mode 0755`).
-- `when <condition>` — only creates the file if the condition is true.
-- `as <name>` — binds the file path; useful for conditional appends.
+- `append` - appends to the file instead of overwriting. Without `append`, the file is created fresh (or overwritten if previously created in the same run).
+- `from <source>` - embeds the contents of `<source>` at compile time. `{var}` interpolation is applied at runtime unless `verbatim` is specified.
+- `content <expression>` - inline content. String literals interpolate `{expr}` like everywhere else (`content "n={n}"` writes `n=1` when `n` is `1`). String concatenation also works (`content "n=" + name`). See **Variable Interpolation** below for the full rules.
+- `mode <octal>` - sets file permissions (e.g., `mode 0644`, `mode 0755`).
+- `when <condition>` - only creates the file if the condition is true.
+- `as <name>` - binds the file path; useful for conditional appends.
 
 **Examples:**
 
@@ -222,7 +222,7 @@ file readme append content "## Testing\n" when use_tests
 
 ---
 
-### `repeat` — Loop over a range
+### `repeat` - Loop over a range
 
 ```
 repeat <int_var> as <iter> [when <condition>]
@@ -236,7 +236,7 @@ The optional `when` clause skips the entire loop if the condition is false.
 
 #### Repeat scoping
 
-A `repeat` block introduces a new scope. The iterator variable and any `let` or `as` names declared inside the block are **local to that loop body** — references from outside are rejected.
+A `repeat` block introduces a new scope. The iterator variable and any `let` or `as` names declared inside the block are **local to that loop body** - references from outside are rejected.
 
 A `let` or `as` binding inside the block whose name collides with any currently visible outer binding (or with the iterator of any enclosing repeat) is rejected as a **shadowing error**. The language never silently shadows.
 
@@ -252,15 +252,15 @@ end
 
 ---
 
-### `include` — Run another installed template
+### `include` - Run another installed template
 
 ```
 include <name> [when <condition>]
 ```
 
-Runs another installed spudplate template by name as an **independent subprocess** — its own questions, its own file creation, no shared scope. The named template must be installed (or bundled into `_deps/` at export time).
+Runs another installed spudplate template by name as an **independent subprocess** - its own questions, its own file creation, no shared scope. The named template must be installed (or bundled into `_deps/` at export time).
 
-- `when <condition>` — only run the include if the condition is true.
+- `when <condition>` - only run the include if the condition is true.
 
 ```
 ask use_claude "Set up Claude config?" bool default false
@@ -271,16 +271,16 @@ There is no source-level inlining; all template reuse goes through `include` and
 
 ---
 
-### `run` — Execute a shell command
+### `run` - Execute a shell command
 
 ```
 run <expression> [in <path>] [when <condition>]
 ```
 
-Runs a shell command via `/bin/sh -c`. The expression evaluates to a string at runtime — supporting concatenation with `ask`/`let` values — and the resulting command is queued for execution at flush time, in source order alongside the file operations. Output streams live to the parent process's stdout/stderr.
+Runs a shell command via `/bin/sh -c`. The expression evaluates to a string at runtime - supporting concatenation with `ask`/`let` values - and the resulting command is queued for execution at flush time, in source order alongside the file operations. Output streams live to the parent process's stdout/stderr.
 
-- `in <path>` — pin the command's working directory to `<path>`. Without it, the command inherits the cwd of the `spudplate` process, which is rarely what you want once the template has created a project subdirectory. The path is a regular path expression — alias references and `{expr}` interpolation work, and the directory must exist by the time the command runs (errors otherwise). The cwd is restored after the command, even on failure.
-- `when <condition>` — only run the command if the condition is true.
+- `in <path>` - pin the command's working directory to `<path>`. Without it, the command inherits the cwd of the `spudplate` process, which is rarely what you want once the template has created a project subdirectory. The path is a regular path expression - alias references and `{expr}` interpolation work, and the directory must exist by the time the command runs (errors otherwise). The cwd is restored after the command, even on failure.
+- `when <condition>` - only run the command if the condition is true.
 
 ```
 ask project "Project name?" string
@@ -301,7 +301,7 @@ This template will execute the following shell commands via /bin/sh:
 Authorise these commands? [y/N]
 ```
 
-The summary lists each command's source-form expression. Declining aborts cleanly with no side effects — no prompts run, no files are written, no commands execute. Conditional clauses appear in the summary regardless of the eventual `when` outcome (the validator can't predict runtime values), and commands inside `repeat` bodies are flagged as such.
+The summary lists each command's source-form expression. Declining aborts cleanly with no side effects - no prompts run, no files are written, no commands execute. Conditional clauses appear in the summary regardless of the eventual `when` outcome (the validator can't predict runtime values), and commands inside `repeat` bodies are flagged as such.
 
 The `--yes` (or `-y`) flag bypasses the prompt for non-interactive callers; the caller takes responsibility for having vetted the source. Once `spudplate install` lands, install-time consent will be recorded so installed templates run without re-prompting.
 
@@ -312,9 +312,9 @@ A non-zero exit, a signal-killed process, or a failure to invoke the shell raise
 #### Security caveats
 
 - **Shell injection via interpolation.** Commands are dispatched through `/bin/sh -c`. The trust prompt shows the literal source expression; the *evaluated* string is what executes. A command like `run "git clone " + url` looks safe in the prompt, but a malicious `url` answer (`; rm -rf $HOME`) would still be passed through. Treat any `ask`/`let` value flowing into a `run` command as untrusted and quote it appropriately in the command string, or restrict input via `options`.
-- **Working directory.** Without `in <path>`, commands run in whatever directory `spudplate run` was invoked from — *not* a per-template sandbox. Templates that create a project subdirectory should pin every following command to it via `in <path>`.
+- **Working directory.** Without `in <path>`, commands run in whatever directory `spudplate run` was invoked from - *not* a per-template sandbox. Templates that create a project subdirectory should pin every following command to it via `in <path>`.
 - **No timeout.** A long-running command blocks the flush indefinitely. Templates running interactive commands (e.g. `vim`) will hand the terminal over.
-- **No allowlist.** Any command is permitted once authorised. Privilege escalation (e.g. `sudo`) prompts for the user's password — that natural friction is the safety net for anything destructive.
+- **No allowlist.** Any command is permitted once authorised. Privilege escalation (e.g. `sudo`) prompts for the user's password - that natural friction is the safety net for anything destructive.
 
 ---
 
@@ -374,9 +374,9 @@ use_tests
 
 Spudlang interpolates `{expr}` in three places:
 
-- **String literals** in any expression — `let s = "hello {name}"`, `run "echo {label}"`, `ask q "{prompt_for}?" string`. The full expression grammar applies inside the braces (identifiers, arithmetic, function calls, string concatenation). Each interpolation result is stringified and concatenated with the surrounding literal text. Brace pairs are balanced, so `{f({x})}` parses as a single interpolation. A `"` inside an interpolation closes the surrounding string literal — keep the inner expression to identifiers and operations on them, or bind a value with `let` first.
-- **Path expressions** in `mkdir`, `file`, `copy` — `mkdir week_{n}`, `mkdir {prefix}/notes`. Same expression grammar, with no surrounding quotes.
-- **`from` source files** and files copied by `copy` — only bare `{ident}` substitution is applied to file contents read from disk; no function calls or arithmetic inside the braces. Use `verbatim` to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
+- **String literals** in any expression - `let s = "hello {name}"`, `run "echo {label}"`, `ask q "{prompt_for}?" string`. The full expression grammar applies inside the braces (identifiers, arithmetic, function calls, string concatenation). Each interpolation result is stringified and concatenated with the surrounding literal text. Brace pairs are balanced, so `{f({x})}` parses as a single interpolation. A `"` inside an interpolation closes the surrounding string literal - keep the inner expression to identifiers and operations on them, or bind a value with `let` first.
+- **Path expressions** in `mkdir`, `file`, `copy` - `mkdir week_{n}`, `mkdir {prefix}/notes`. Same expression grammar, with no surrounding quotes.
+- **`from` source files** and files copied by `copy` - only bare `{ident}` substitution is applied to file contents read from disk; no function calls or arithmetic inside the braces. Use `verbatim` to copy file contents byte-for-byte without any substitution. A literal `{` or `}` in a non-verbatim source is a runtime error; switch the statement to `verbatim` if you need literal braces.
 
 Errors are surfaced at parse time where possible: an unclosed `{`, an empty `{}`, or an interpolation whose contents don't parse as an expression all stop the build before the run begins. An interpolation that references an undeclared name surfaces in the validator the same as any other expression.
 
@@ -408,7 +408,7 @@ ask name "Your name?" string
 
 ## Safety
 
-The interpreter refuses to write to any path that already existed before the run. It tracks paths created during execution and only allows overwriting those. This tracking is ephemeral — no metadata is left behind after the run finishes.
+The interpreter refuses to write to any path that already existed before the run. It tracks paths created during execution and only allows overwriting those. This tracking is ephemeral - no metadata is left behind after the run finishes.
 
 Combined with deferred file operations, this means a run either fully succeeds or makes no changes to your filesystem.
 
@@ -428,9 +428,9 @@ Would create:
         └── test_main.cpp
 ```
 
-Append-mode files appear once with a trailing `(append)` annotation. `mkdir from` and `copy` expand into the individual files they would create. `copy` destination-existence checks are skipped — dry-run cannot validate them without touching the filesystem. Conditional statements whose `when` clause evaluated to false are pruned from the queue, so the tree only shows what would actually happen.
+Append-mode files appear once with a trailing `(append)` annotation. `mkdir from` and `copy` expand into the individual files they would create. `copy` destination-existence checks are skipped - dry-run cannot validate them without touching the filesystem. Conditional statements whose `when` clause evaluated to false are pruned from the queue, so the tree only shows what would actually happen.
 
-Tree glyphs default to UTF-8 box-drawing characters (`├──`/`└──`/`│`). On terminals where the locale environment (`LC_ALL`, `LC_CTYPE`, or `LANG`) does not advertise UTF-8 support, spudplate falls back to plain ASCII (`|--`/`\\--`/`|`). The detection follows POSIX precedence — the first set variable wins.
+Tree glyphs default to UTF-8 box-drawing characters (`├──`/`└──`/`│`). On terminals where the locale environment (`LC_ALL`, `LC_CTYPE`, or `LANG`) does not advertise UTF-8 support, spudplate falls back to plain ASCII (`|--`/`\\--`/`|`). The detection follows POSIX precedence - the first set variable wins.
 
 ---
 

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -14,7 +14,7 @@ The interpreter runs the file in a single pass. Internal state (variables, loops
 
 ## Statements
 
-### `ask` - Prompt the user for input
+### ask - Prompt the user for input
 
 ```
 ask <name> "<prompt>" <type> [options <v1> <v2> ...] [default <value>] [when <condition>]
@@ -52,7 +52,7 @@ ask slug "Slug?" string default lower(trim(project_name))
 
 ---
 
-### `let` - Declare a derived variable
+### let - Declare a derived variable
 
 ```
 let <name> = <expression>
@@ -119,7 +119,7 @@ Hyphens are allowed inside a path but cannot start one - `mkdir -foo` would be a
 
 `mkdir` creates intermediate directories automatically (`mkdir -p` semantics).
 
-#### `as <varname>` - bind a path alias
+#### Path aliases with as
 
 The `as <varname>` clause binds the path to a variable for reuse. Any identifier in a subsequent path expression is checked against bound aliases - if it matches, it is a variable reference; if not, it is a literal path component. This applies to every segment, not just the leading one:
 
@@ -141,7 +141,7 @@ If the binding is unconditional, it can be referenced anywhere.
 
 ---
 
-### `mkdir` - Create a directory
+### mkdir - Create a directory
 
 ```
 mkdir <path> [from <source>] [verbatim] [mode <octal>] [when <condition>] [as <name>]
@@ -165,7 +165,7 @@ mkdir templates from base_templates verbatim when use_templates as templatepath
 
 ---
 
-### `copy` - Copy a directory into an existing destination
+### copy - Copy a directory into an existing destination
 
 ```
 copy <source> into <destination> [verbatim] [when <condition>]
@@ -186,7 +186,7 @@ copy assets into staticpath/assets verbatim
 
 ---
 
-### `file` - Create or append to a file
+### file - Create or append to a file
 
 ```
 file <path> [append] from <source> [verbatim] [mode <octal>] [when <condition>] [as <name>]
@@ -222,7 +222,7 @@ file readme append content "## Testing\n" when use_tests
 
 ---
 
-### `repeat` - Loop over a range
+### repeat - Loop over a range
 
 ```
 repeat <int_var> as <iter> [when <condition>]
@@ -252,7 +252,7 @@ end
 
 ---
 
-### `include` - Run another installed template
+### include - Run another installed template
 
 ```
 include <name> [when <condition>]
@@ -271,7 +271,7 @@ There is no source-level inlining; all template reuse goes through `include` and
 
 ---
 
-### `run` - Execute a shell command
+### run - Execute a shell command
 
 ```
 run <expression> [in <path>] [when <condition>]

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -136,7 +136,7 @@ struct PathInterp {
 using PathSegment = std::variant<PathLiteral, PathVar, PathInterp>;
 
 /**
- * @brief A path expression — an ordered sequence of segments.
+ * @brief A path expression - an ordered sequence of segments.
  *
  * Used by `mkdir`, `file`, and `file ... from` for destination and source paths.
  * Segments are concatenated at runtime, with literals inserted verbatim and
@@ -167,7 +167,7 @@ using FileSource = std::variant<FileFromSource, FileContentSource>;
 // ---------------------------------------------------------------------------
 
 /**
- * @brief An `ask` statement — declares a variable and prompts the user.
+ * @brief An `ask` statement - declares a variable and prompts the user.
  *
  * Example: `ask license "License?" string default "MIT"`
  *
@@ -186,7 +186,7 @@ struct AskStmt {
 };
 
 /**
- * @brief A `let` statement — declares a derived variable.
+ * @brief A `let` statement - declares a derived variable.
  *
  * Example: `let slug = lower(trim(name))`
  */
@@ -198,7 +198,7 @@ struct LetStmt {
 };
 
 /**
- * @brief A bare assignment statement — rebinds an existing variable.
+ * @brief A bare assignment statement - rebinds an existing variable.
  *
  * Example: `count = count + 1`
  *
@@ -215,7 +215,7 @@ struct AssignStmt {
 };
 
 /**
- * @brief A `mkdir` statement — creates a directory.
+ * @brief A `mkdir` statement - creates a directory.
  *
  * Example: `mkdir src/modules mode 0755`
  *
@@ -225,7 +225,7 @@ struct AssignStmt {
 struct MkdirStmt {
     PathExpr path;                         ///< Directory path expression.
     std::optional<std::string> alias;      ///< Optional `as <name>` binding; empty if no `as` clause.
-    bool mkdir_p;                          ///< Always true — create intermediate directories.
+    bool mkdir_p;                          ///< Always true - create intermediate directories.
     std::optional<PathExpr> from_source;   ///< Optional source directory to populate from.
     bool verbatim;                         ///< If true with from_source, suppress interpolation.
     std::optional<int> mode;               ///< Optional permission bits (e.g. 0755).
@@ -235,7 +235,7 @@ struct MkdirStmt {
 };
 
 /**
- * @brief A `file` statement — creates or appends to a file.
+ * @brief A `file` statement - creates or appends to a file.
  *
  * Example: `file "{slug}/README.md" content "# " + name`
  */
@@ -256,7 +256,7 @@ struct Stmt;
 using StmtPtr = std::unique_ptr<Stmt>;
 
 /**
- * @brief A `repeat` statement — loops a block N times.
+ * @brief A `repeat` statement - loops a block N times.
  *
  * Example:
  * @code
@@ -275,7 +275,7 @@ struct RepeatStmt {
 };
 
 /**
- * @brief A `copy` statement — copies contents from a source directory into
+ * @brief A `copy` statement - copies contents from a source directory into
  * an existing destination directory.
  *
  * Example: `copy standard_templates/ into templatepath`
@@ -293,13 +293,13 @@ struct CopyStmt {
 };
 
 /**
- * @brief A `run` statement — executes a shell command after user authorisation.
+ * @brief A `run` statement - executes a shell command after user authorisation.
  *
  * Example: `run "git init" in {dir} when use_git`
  *
  * The command expression is evaluated to a string at runtime and dispatched
  * via `/bin/sh -c`. The optional `in <path>` clause pins the working
- * directory for the command — without it, the command inherits the cwd of
+ * directory for the command - without it, the command inherits the cwd of
  * the `spudplate` process. Each `spudplate run` invocation prompts the
  * user once, up front, listing every literal command (and its `in <path>`,
  * if any) before any statement executes; declining aborts cleanly with no
@@ -314,7 +314,7 @@ struct RunStmt {
 };
 
 /**
- * @brief An `include` statement — runs another installed template as a subprocess.
+ * @brief An `include` statement - runs another installed template as a subprocess.
  *
  * Example: `include claude_setup when use_claude`
  *

--- a/include/spudplate/binary_serializer.h
+++ b/include/spudplate/binary_serializer.h
@@ -16,7 +16,7 @@ namespace spudplate {
  *
  * Each enum value equals the corresponding `std::variant::index()` for the
  * variant declared in `ast.h`. The variant declaration order is therefore
- * load-bearing for wire compatibility — adding a new arm is fine, but
+ * load-bearing for wire compatibility - adding a new arm is fine, but
  * reordering existing arms silently breaks every previously-produced
  * `.spp` file. Round-trip tests in `tests/binary_serializer_test.cpp`
  * exercise every arm by name to guard against accidental reordering.
@@ -98,7 +98,7 @@ class BinaryDeserializeError : public std::runtime_error {
  * payload, signed integer fields are zigzag-encoded inside the varint.
  *
  * Throws `BinarySerializeError` only for inputs that violate the AST's
- * own contract — e.g. a `UnaryExpr.op` outside the language's operator
+ * own contract - e.g. a `UnaryExpr.op` outside the language's operator
  * subset.
  */
 std::vector<std::uint8_t> serialize_program(const Program& program);

--- a/include/spudplate/bundler.h
+++ b/include/spudplate/bundler.h
@@ -15,7 +15,7 @@ namespace spudplate {
  * @brief The set of assets a parsed program references on disk.
  *
  * Asset paths are normalised (forward-slash separators, no leading `/`,
- * no `.` or `..` segments, no embedded NUL) and deduped by path — entries
+ * no `.` or `..` segments, no embedded NUL) and deduped by path - entries
  * with the same normalised path are collapsed iff their bytes and mode
  * match. A trailing `/` on a path means "empty leaf directory" and the
  * data field is empty.
@@ -47,7 +47,7 @@ class BundleError : public std::runtime_error {
 /**
  * @brief Walk a parsed program and collect every asset it references.
  *
- * `source_root` is the directory the source `.spud` lives in — relative
+ * `source_root` is the directory the source `.spud` lives in - relative
  * source paths in `file ... from`, `mkdir ... from`, and `copy` resolve
  * against it. The bundler dereferences symlinks, breaks loops on
  * canonical directory paths, and rejects:

--- a/include/spudplate/cli.h
+++ b/include/spudplate/cli.h
@@ -18,12 +18,12 @@ namespace spudplate {
  *                                         (caller has vetted the source)
  *
  * Exit codes:
- *   0 — success
- *   1 — unrecognised invocation (usage printed to `err`)
- *   2 — parse error
- *   3 — semantic error
- *   4 — runtime error
- *   5 — file not found or unreadable
+ *   0 - success
+ *   1 - unrecognised invocation (usage printed to `err`)
+ *   2 - parse error
+ *   3 - semantic error
+ *   4 - runtime error
+ *   5 - file not found or unreadable
  *
  * Errors are formatted as `<file>:<line>:<col>: <kind>: <message>` on `err`.
  */

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -71,7 +71,7 @@ class Environment {
     /**
      * @brief Bind `name` to `value` in the innermost frame.
      *
-     * Throws `std::logic_error` if `name` is already visible in any frame —
+     * Throws `std::logic_error` if `name` is already visible in any frame -
      * the language never silently shadows.
      */
     void declare(const std::string& name, Value value);
@@ -79,7 +79,7 @@ class Environment {
     /**
      * @brief Replace the value of an existing binding, innermost first.
      *
-     * Throws `std::logic_error` if `name` is not visible — the validator
+     * Throws `std::logic_error` if `name` is not visible - the validator
      * is expected to have rejected such inputs before the interpreter runs.
      */
     void assign(const std::string& name, Value value);
@@ -95,8 +95,8 @@ class Environment {
  * @brief Structured description of an `ask` prompt for the prompter to render.
  *
  * The interpreter populates this struct from an `AskStmt` and the live
- * environment, then hands it to the prompter. Rendering — colour, layout,
- * `[Y/n]` hints, numbered option menus, rejection feedback — is the
+ * environment, then hands it to the prompter. Rendering - colour, layout,
+ * `[Y/n]` hints, numbered option menus, rejection feedback - is the
  * prompter's responsibility.
  */
 struct PromptRequest {
@@ -210,7 +210,7 @@ class ScriptedPrompter : public Prompter {
  * or `..` segments, no embedded NUL). A trailing `/` on a returned `Entry`
  * path means "empty leaf directory".
  *
- * `mode == 0` is the documented "no mode information" sentinel — the
+ * `mode == 0` is the documented "no mode information" sentinel - the
  * disk-backed provider always reports zero so callers preserve the
  * pre-existing `nullopt`-mode behaviour of bare-`.spud` runs.
  */
@@ -279,7 +279,7 @@ class AssetMapSourceProvider final : public SourceProvider {
  * called once before any statement executes, with a summary of every
  * literal command. A `false` return aborts the run cleanly with no side
  * effects. The `skip_authorization` flag bypasses the prompt for non-
- * interactive callers — they take responsibility for having vetted the
+ * interactive callers - they take responsibility for having vetted the
  * source.
  *
  * `source` overrides where `from`/`copy` reads come from. A null `source`
@@ -302,8 +302,8 @@ Environment run_for_tests(const Program& program, Prompter& prompter,
 /**
  * @brief Run a program without touching the filesystem.
  *
- * Walks the program exactly like `run` — same prompts, same expression
- * evaluation, same alias bindings — but instead of flushing the deferred
+ * Walks the program exactly like `run` - same prompts, same expression
+ * evaluation, same alias bindings - but instead of flushing the deferred
  * write queue prints a `Would create:` tree of every path that would have
  * been created to `out`. `copy` destination-existence checks are skipped
  * (they would always fail in dry-run since nothing was written).

--- a/include/spudplate/spudpack.h
+++ b/include/spudplate/spudpack.h
@@ -15,7 +15,7 @@ namespace spudplate {
 /**
  * @brief One bundled asset entry inside a spudpack.
  *
- * `path` is normalised — forward-slash separators, no leading `/`, no `.` or
+ * `path` is normalised - forward-slash separators, no leading `/`, no `.` or
  * `..` segments, no embedded NUL. A trailing `/` means "empty leaf
  * directory" and the corresponding `data` is empty.
  */
@@ -26,7 +26,7 @@ struct SpudpackAsset {
 };
 
 /**
- * @brief A decoded spudpack — the source text, the opaque compiled program,
+ * @brief A decoded spudpack - the source text, the opaque compiled program,
  * and every bundled asset.
  *
  * `program_bytes` is held opaquely; this header does not include the
@@ -81,7 +81,7 @@ Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size);
 /**
  * @brief Write a `Spudpack` to disk.
  *
- * **Not atomic** — callers that need atomic install must write to a
+ * **Not atomic** - callers that need atomic install must write to a
  * temporary path and rename themselves.
  */
 void spudpack_write_file(const std::filesystem::path& path, const Spudpack& pack);

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -8,31 +8,31 @@ namespace spudplate {
 /** @brief All token types produced by the Lexer. */
 enum class TokenType {
     // Keywords
-    ASK,       ///< `ask` — declare a user prompt
-    LET,       ///< `let` — declare a derived variable
-    MKDIR,     ///< `mkdir` — create a directory
-    FILE,      ///< `file` — create or append to a file
-    FROM,      ///< `from` — source file path for file statements
-    CONTENT,   ///< `content` — inline content for file statements
-    WHEN,      ///< `when` — conditional modifier
-    REPEAT,    ///< `repeat` — begin a loop block
-    END,       ///< `end` — close a repeat block
-    VERBATIM,  ///< `verbatim` — suppress interpolation in from-file contents
-    APPEND,    ///< `append` — append to file instead of overwriting
-    MODE,      ///< `mode` — set file/directory permissions (octal)
-    AS,        ///< `as` — bind loop iterator variable in repeat
-    DEFAULT,   ///< `default` — fallback value for an ask when the user skips it
-    OPTIONS,   ///< `options` — restrict an ask to a bounded list of literals
-    COPY,      ///< `copy` — copy a source directory into an existing destination
-    INTO,      ///< `into` — destination marker used by `copy`
-    INCLUDE,   ///< `include` — run another installed template as a subprocess
-    RUN,       ///< `run` — execute a shell command (gated by trust prompt)
-    IN,        ///< `in` — working-directory marker on `run` statements
+    ASK,       ///< `ask` - declare a user prompt
+    LET,       ///< `let` - declare a derived variable
+    MKDIR,     ///< `mkdir` - create a directory
+    FILE,      ///< `file` - create or append to a file
+    FROM,      ///< `from` - source file path for file statements
+    CONTENT,   ///< `content` - inline content for file statements
+    WHEN,      ///< `when` - conditional modifier
+    REPEAT,    ///< `repeat` - begin a loop block
+    END,       ///< `end` - close a repeat block
+    VERBATIM,  ///< `verbatim` - suppress interpolation in from-file contents
+    APPEND,    ///< `append` - append to file instead of overwriting
+    MODE,      ///< `mode` - set file/directory permissions (octal)
+    AS,        ///< `as` - bind loop iterator variable in repeat
+    DEFAULT,   ///< `default` - fallback value for an ask when the user skips it
+    OPTIONS,   ///< `options` - restrict an ask to a bounded list of literals
+    COPY,      ///< `copy` - copy a source directory into an existing destination
+    INTO,      ///< `into` - destination marker used by `copy`
+    INCLUDE,   ///< `include` - run another installed template as a subprocess
+    RUN,       ///< `run` - execute a shell command (gated by trust prompt)
+    IN,        ///< `in` - working-directory marker on `run` statements
 
     // Logical operators (keywords)
-    AND,  ///< `and` — logical AND
-    OR,   ///< `or`  — logical OR
-    NOT,  ///< `not` — logical NOT
+    AND,  ///< `and` - logical AND
+    OR,   ///< `or`  - logical OR
+    NOT,  ///< `not` - logical NOT
 
     // Type keywords
     STRING_TYPE,  ///< `string` type annotation
@@ -55,10 +55,10 @@ enum class TokenType {
     LESS_EQUAL,     ///< `<=`
 
     // Arithmetic operators
-    PLUS,   ///< `+` — addition or string concatenation
-    MINUS,  ///< `-` — subtraction
-    STAR,   ///< `*` — multiplication
-    SLASH,  ///< `/` — division
+    PLUS,   ///< `+` - addition or string concatenation
+    MINUS,  ///< `-` - subtraction
+    STAR,   ///< `*` - multiplication
+    SLASH,  ///< `/` - division
 
     // Assignment
     ASSIGN,  ///< `=`
@@ -67,10 +67,10 @@ enum class TokenType {
     NEWLINE,  ///< Logical line break (newline or semicolon)
     LPAREN,   ///< `(`
     RPAREN,   ///< `)`
-    LBRACE,   ///< `{` — open inline interpolation in path expressions
-    RBRACE,   ///< `}` — close inline interpolation in path expressions
-    DOT,      ///< `.` — separator in path expressions (e.g. `README.md`)
-    COMMA,    ///< `,` — argument separator in function calls
+    LBRACE,   ///< `{` - open inline interpolation in path expressions
+    RBRACE,   ///< `}` - close inline interpolation in path expressions
+    DOT,      ///< `.` - separator in path expressions (e.g. `README.md`)
+    COMMA,    ///< `,` - argument separator in function calls
 
     // Special
     EOF_TOKEN,  ///< End of input

--- a/src/binary_serializer.cpp
+++ b/src/binary_serializer.cpp
@@ -16,7 +16,7 @@ namespace {
 // indicates either a malicious payload or a bug in the encoder.
 constexpr std::size_t kVarintMaxBytes = 10;
 
-// Static asserts pin the count of each variant — adding a new arm fails
+// Static asserts pin the count of each variant - adding a new arm fails
 // the build until the encode/decode tables grow with it. Reordering
 // existing arms is not caught by arity alone; the round-trip tests are
 // the second line of defence there.

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -18,7 +18,7 @@ BundleError::BundleError(std::string message, int line, int column)
 namespace {
 
 // Result of classifying a source PathExpr. The bundler distinguishes the
-// two legal shapes — a fully-literal path (walk the exact target) and a
+// two legal shapes - a fully-literal path (walk the exact target) and a
 // path with a static prefix that ends in `/` followed by dynamic segments
 // (walk the static-prefix directory). Anything else is a BundleError.
 struct ClassifiedSource {
@@ -62,8 +62,8 @@ ClassifiedSource classify_source_path(const PathExpr& path) {
     return {ClassifiedSource::Shape::StaticPrefix, std::move(literal)};
 }
 
-// Read a regular file's bytes off disk. Errors here are unusual — the
-// walker has already established the entry is a regular file — so they
+// Read a regular file's bytes off disk. Errors here are unusual - the
+// walker has already established the entry is a regular file - so they
 // surface as a BundleError pointing at the originating statement.
 std::vector<std::uint8_t> read_file_bytes(const fs::path& p, int line, int column) {
     std::ifstream in(p, std::ios::binary);
@@ -140,11 +140,11 @@ class Bundler {
             stmt.data);
     }
 
-    // `file ... from <path>` — the path may resolve to a regular file
+    // `file ... from <path>` - the path may resolve to a regular file
     // (whole-file embed) or to a directory whose contents are walked. The
     // static-prefix-with-dynamic-suffix form means "the static prefix is a
     // directory, and the runtime resolution picks one of the bundled files
-    // inside it" — same effect on bundling as the directory case.
+    // inside it" - same effect on bundling as the directory case.
     void process_file_source(const PathExpr& path, int line, int column) {
         auto cls = classify_source_path(path);
         fs::path target = resolve_under_root(cls.literal_prefix, line, column);
@@ -169,7 +169,7 @@ class Bundler {
         }
     }
 
-    // `mkdir ... from <path>` and `copy <path> into ...` — both must
+    // `mkdir ... from <path>` and `copy <path> into ...` - both must
     // resolve to a directory. CopyStmt explicitly disallows a regular-file
     // source per the language spec.
     void process_dir_source(const PathExpr& path, int line, int column,
@@ -361,7 +361,7 @@ class Bundler {
     }
 
     // Insert a normalised asset record. If the key is already present the
-    // bytes and mode must match — otherwise the bundler reports the more
+    // bytes and mode must match - otherwise the bundler reports the more
     // specific of the two diagnostics so a template author can see whether
     // the conflict is content or permissions.
     void insert_or_collide(const std::string& raw_key, std::uint16_t mode,
@@ -389,7 +389,7 @@ class Bundler {
         if (it->second.mode != mode) {
             throw BundleError("conflicting mode for asset " + key, line, column);
         }
-        // Identical record — fine; collapse silently.
+        // Identical record - fine; collapse silently.
     }
 
     fs::path root_;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -55,9 +55,9 @@ void print_usage(std::ostream& err) {
 }
 
 // Resolve the directory templates are installed into. Honours, in order:
-//   1. `SPUDPLATE_HOME` — explicit override (used by tests and dev setups).
-//   2. `XDG_DATA_HOME/spudplate` — the XDG Base Directory standard.
-//   3. `$HOME/.local/share/spudplate` — XDG default when the env var is unset.
+//   1. `SPUDPLATE_HOME` - explicit override (used by tests and dev setups).
+//   2. `XDG_DATA_HOME/spudplate` - the XDG Base Directory standard.
+//   3. `$HOME/.local/share/spudplate` - XDG default when the env var is unset.
 // Returns an empty path if none of those sources is available so the caller
 // can surface a usable error.
 std::filesystem::path install_dir() {
@@ -263,7 +263,7 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     std::filesystem::path final_path = home / (name + ".spp");
     std::filesystem::path tmp_path = home / (name + ".spp.tmp");
 
-    // Step 7a — refuse to clobber a stray non-regular file/dir that
+    // Step 7a - refuse to clobber a stray non-regular file/dir that
     // happens to sit at the destination. Surfacing this here gives a
     // friendlier diagnostic than letting the rename fail later.
     if (std::filesystem::exists(final_path) &&
@@ -273,7 +273,7 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         return 1;
     }
 
-    // Step 7b — overwrite prompt fires when either form (`<name>.spp` or
+    // Step 7b - overwrite prompt fires when either form (`<name>.spp` or
     // legacy `<name>/`) is present. Capture the legacy flag now so the
     // step-11 cleanup runs even when the prompt is suppressed by `--yes`.
     bool spp_existed = std::filesystem::exists(final_path);
@@ -419,7 +419,7 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         return 1;
     }
     if (!std::filesystem::is_directory(home)) {
-        return 0;  // No installs yet — empty output, success.
+        return 0;  // No installs yet - empty output, success.
     }
     std::vector<std::string> names;
     std::vector<std::string> shadowed_legacy;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -92,7 +92,7 @@ struct PendingCheckDir {
 };
 
 // A `run` statement queued for flush-time execution. The command stored
-// here is the *evaluated* expression result — what /bin/sh -c will run.
+// here is the *evaluated* expression result - what /bin/sh -c will run.
 // `cwd` is the optional resolved working directory from the `in <path>`
 // clause. The user authorised the literal source at the start of the run,
 // before any expression evaluated. Source-vs-resolved drift (the shell-
@@ -156,7 +156,7 @@ class DiskSourceProvider final : public SourceProvider {
             } else if (it->is_regular_file()) {
                 out.push_back({std::move(rel), /*is_directory=*/false, 0});
             }
-            // symlinks, fifos, etc. silently skipped — preserves v1
+            // symlinks, fifos, etc. silently skipped - preserves v1
             // bare-`.spud` behaviour byte-for-byte.
         }
         return out;
@@ -185,7 +185,7 @@ std::pair<std::string, std::uint16_t> read_source_file(
     }
 }
 
-// A source file is treated as binary — and therefore not interpolated —
+// A source file is treated as binary - and therefore not interpolated -
 // when it contains any NUL byte. This is the unambiguous binary signal:
 // every common binary format (PNG, JPEG, ELF, fonts, gzip) carries NUL
 // bytes in the first kilobyte. Latin-1 templates with stray high bytes
@@ -197,7 +197,7 @@ bool content_is_binary(std::string_view content) {
 
 // Substitute `{ident}` occurrences in `content` with the stringified value
 // of `ident` looked up in `env`. The grammar is deliberately narrow for v1
-// — only bare identifiers are accepted; arbitrary expressions are not. Use
+// - only bare identifiers are accepted; arbitrary expressions are not. Use
 // `verbatim` to copy file contents byte-for-byte without substitution.
 std::string interpolate_content(const std::string& content,
                                 const Environment& env, int line, int column) {
@@ -297,7 +297,7 @@ const char* type_name(const Value& v) {
     throw RuntimeError(msg, line, column);
 }
 
-// Wrap-around helpers — signed overflow is UB in C++, so route arithmetic
+// Wrap-around helpers - signed overflow is UB in C++, so route arithmetic
 // through unsigned and cast the bit pattern back.
 std::int64_t wrap_add(std::int64_t a, std::int64_t b) {
     return static_cast<std::int64_t>(static_cast<std::uint64_t>(a) +
@@ -335,7 +335,7 @@ bool int_compare(TokenType op, std::int64_t a, std::int64_t b) {
         case TokenType::LESS_EQUAL:
             return a <= b;
         default:
-            return false;  // unreachable — caller restricts the op set
+            return false;  // unreachable - caller restricts the op set
     }
 }
 
@@ -385,7 +385,7 @@ Value eval_binary(const BinaryExpr& bin, const Environment& env) {
                                  std::get<std::int64_t>(right))};
     }
 
-    // Arithmetic — `+` accepts both int+int and string+string; the others
+    // Arithmetic - `+` accepts both int+int and string+string; the others
     // are int-only.
     if (bin.op == TokenType::PLUS && std::holds_alternative<std::string>(left) &&
         std::holds_alternative<std::string>(right)) {
@@ -485,7 +485,7 @@ const char* expected_message(VarType type) {
 }
 
 // Render an expression as a readable approximation of its source text. Used
-// only by the trust prompt — users see the *structure* of each `run`
+// only by the trust prompt - users see the *structure* of each `run`
 // command before authorising, even though the actual value executed at
 // flush time may differ (interpolated identifiers, computed strings, etc).
 std::string preview_expr(const Expr& expr) {
@@ -552,7 +552,7 @@ std::string preview_expr(const Expr& expr) {
 // Walk every RunStmt in the program (top-level and inside repeat bodies)
 // and append a one-line preview of each command's source-form expression
 // to `out`. Repeat-internal commands are tagged so the user knows they
-// may run multiple times — or not at all.
+// may run multiple times - or not at all.
 // Render a path expression as a readable approximation of its source. Used
 // by the trust prompt to surface the `in <path>` clause on `run` statements.
 std::string preview_path(const PathExpr& path) {
@@ -586,7 +586,7 @@ void collect_run_previews(const std::vector<StmtPtr>& body,
                         line += " in " + preview_path(*s.cwd);
                     }
                     if (inside_repeat) {
-                        line += "  (inside repeat — may run 0 or many times)";
+                        line += "  (inside repeat - may run 0 or many times)";
                     }
                     if (s.when_clause.has_value()) {
                         line += "  (conditional)";
@@ -834,7 +834,7 @@ class Interpreter {
         }
         std::int64_t count = std::get<std::int64_t>(*count_v);
         if (count < 0) {
-            return;  // matches n == 0 — empty loop, no throw
+            return;  // matches n == 0 - empty loop, no throw
         }
 
         for (std::int64_t i = 0; i < count; ++i) {
@@ -932,7 +932,7 @@ class Interpreter {
     // its tree under `dst_root`. recursive_directory_iterator visits parents
     // before children, so the queued ops naturally satisfy create-parent-
     // first ordering at flush time. Symlinks and other non-regular entries
-    // are skipped — v1 has no defined behaviour for them.
+    // are skipped - v1 has no defined behaviour for them.
     void walk_source_into_pending(const std::string& src,
                                   const std::string& dst_root, bool verbatim,
                                   int line, int column) {
@@ -946,7 +946,7 @@ class Interpreter {
         // The disk-backed provider returns nothing for a missing source.
         // The historical behaviour is to surface a precise error in that
         // case, so the walker double-checks existence here when the
-        // provider produced no entries — but only against the disk so
+        // provider produced no entries - but only against the disk so
         // the asset-map case is not regressed.
         if (entries.empty()) {
             std::error_code ec;
@@ -1038,7 +1038,7 @@ class Interpreter {
                 content = interpolate_content(content, env_, s.line, s.column);
             }
             // Explicit `mode` on the statement wins over the source's mode;
-            // otherwise propagate the source mode (asset-map only — disk
+            // otherwise propagate the source mode (asset-map only - disk
             // provider always reports zero so bare-`.spud` runs preserve
             // the historical `nullopt`).
             if (!mode.has_value() && src_mode != 0) {
@@ -1126,7 +1126,7 @@ class Interpreter {
 
     void run_op(const PendingFile& op) {
         // For non-append, the path may have been written earlier in this run
-        // (a prior `PendingFile` to the same path) — that's an in-run
+        // (a prior `PendingFile` to the same path) - that's an in-run
         // overwrite, allowed. The pre-existing check only fires for paths
         // that existed before the run started.
         check_pre_existing(op.path, op.line, op.column);
@@ -1181,7 +1181,7 @@ class Interpreter {
             std::filesystem::permissions(
                 op.path, static_cast<std::filesystem::perms>(*op.mode),
                 std::filesystem::perm_options::replace);
-            // Skip the RAII guard's restore — the caller's explicit mode
+            // Skip the RAII guard's restore - the caller's explicit mode
             // wins over the original permissions.
             guard.active = false;
         }
@@ -1555,7 +1555,7 @@ void render_pending(std::ostream& out, const std::vector<PendingOp>& pending,
                 } else if constexpr (std::is_same_v<T, PendingFile>) {
                     insert_path(root, o.path, /*is_dir=*/false, o.append);
                 }
-                // PendingCheckDir is intentionally skipped — it doesn't
+                // PendingCheckDir is intentionally skipped - it doesn't
                 // create anything and dry-run can't validate it without
                 // hitting the real filesystem.
             },

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -155,7 +155,7 @@ void check_alias(const PathVar& pv, const std::optional<ExprPtr>& current_when,
     }
     const auto& stored = it->second;
     if (!stored.has_value()) {
-        return;  // Unconditional binding — references are unrestricted.
+        return;  // Unconditional binding - references are unrestricted.
     }
     if (!current_when.has_value()) {
         throw SemanticError("alias '" + pv.name +

--- a/tests/binary_serializer_test.cpp
+++ b/tests/binary_serializer_test.cpp
@@ -429,7 +429,7 @@ TEST(BinarySerializer, VarintLongerThanTenBytesThrows) {
 
 TEST(BinarySerializer, InvalidUnaryOpRejected) {
     // Hand-craft: program with one Let whose value is a Unary with op=PLUS.
-    // PLUS is a binary op — not legal in a unary slot. Encoder must throw.
+    // PLUS is a binary op - not legal in a unary slot. Encoder must throw.
     auto bad = make_expr(UnaryExpr{.op = TokenType::PLUS,
                                    .operand = ident("flag"),
                                    .line = 1,
@@ -466,7 +466,7 @@ TEST(BinarySerializer, RejectsHugeStatementCount) {
     // Statement count varint encodes a huge value with no statements
     // following. The decoder must reject without OOM-reserving.
     std::vector<std::uint8_t> bytes;
-    // Varint for ~2^60 — 9 continuation bytes plus a high terminator.
+    // Varint for ~2^60 - 9 continuation bytes plus a high terminator.
     for (int i = 0; i < 9; ++i) bytes.push_back(0xFF);
     bytes.push_back(0x0F);
     EXPECT_THROW(deserialize_program(bytes.data(), bytes.size()),
@@ -493,7 +493,7 @@ TEST(BinarySerializer, RejectsDeeplyNestedExpressions) {
 
 TEST(BinarySerializer, DeserializeErrorCarriesOffset) {
     // Single byte 0xFF: invalid as a varint (would need continuation), but
-    // legal as a single 7-bit value of 127 — actually 0xFF has the high bit
+    // legal as a single 7-bit value of 127 - actually 0xFF has the high bit
     // set so it expects a continuation, which is missing. That throws as a
     // truncated varint at offset 1.
     std::vector<std::uint8_t> bytes{0xFFU};

--- a/tests/bundler_test.cpp
+++ b/tests/bundler_test.cpp
@@ -141,7 +141,7 @@ TEST(Bundler, RejectsDynamicSegmentMidFilename) {
     Program p = parse(
         "ask n \"n?\" int default 1\n"
         "file out.txt from tpl/file_{n}\n");
-    // tpl/file_{n} — the literal prefix "tpl/file_" does not end with /,
+    // tpl/file_{n} - the literal prefix "tpl/file_" does not end with /,
     // so this is the mid-filename-dynamic case.
     EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
 }
@@ -239,10 +239,10 @@ TEST(Bundler, SymlinkLoopBroken) {
 
     Program p = parse("mkdir project from loop\n");
     // Should not infinite-recurse. The walker may produce zero assets (only
-    // the dir loop) or report an error — either way it must terminate.
+    // the dir loop) or report an error - either way it must terminate.
     try {
         bundle_assets(p, tmp.path());
     } catch (const BundleError&) {
-        // Acceptable — escaping or unsupported types may surface here.
+        // Acceptable - escaping or unsupported types may surface here.
     }
 }

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -318,7 +318,7 @@ TEST(CliTest, InstallDeclinedPromptLeavesExistingUnchanged) {
         ScriptedPrompter p({});
         ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
     }
-    // No `--yes` and no stdin available — confirm() returns false and the
+    // No `--yes` and no stdin available - confirm() returns false and the
     // command aborts cleanly with exit 0.
     write_file(src, "mkdir bar\n");
     Argv args({"spudplate", "install", src.string()});

--- a/tests/crc32_test.cpp
+++ b/tests/crc32_test.cpp
@@ -19,7 +19,7 @@ TEST(Crc32, EmptyInputIsZero) {
 
 TEST(Crc32, IsoHdlcCheckVector) {
     // The canonical CRC-32/ISO-HDLC check value for the ASCII string
-    // "123456789" — used by every reference implementation.
+    // "123456789" - used by every reference implementation.
     const char* s = "123456789";
     EXPECT_EQ(spudplate::crc32(as_bytes(s), 9), 0xCBF43926u);
 }

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -58,7 +58,7 @@ using spudplate::VarType;
 
 namespace {
 
-// Test stub — never asked, never answered. Used in Part 1 where every
+// Test stub - never asked, never answered. Used in Part 1 where every
 // statement throws "not yet supported" before the prompter is reached.
 class NullPrompter : public Prompter {
   public:
@@ -397,7 +397,7 @@ TEST(EvalExprTest, AndFalse) {
 
 TEST(EvalExprTest, AndShortCircuitsOnFalse) {
     Environment env;
-    // false and (1/0) — must not evaluate the right side
+    // false and (1/0) - must not evaluate the right side
     auto e = binop(TokenType::AND, bool_lit(false),
                    binop(TokenType::SLASH, int_lit(1), int_lit(0)));
     EXPECT_FALSE(std::get<bool>(evaluate_expr(*e, env)));
@@ -745,7 +745,7 @@ TEST(AskTest, NumberedIndexOnIntOptions) {
 
 TEST(AskTest, OutOfRangeIndexFallsThrough) {
     // "5" is outside the index range so it parses as the int 5, which is not
-    // in the options list — re-prompt rather than crash.
+    // in the options list - re-prompt rather than crash.
     auto p = parse(R"(ask v "PG?" int options 15 16 17
 )");
     ScriptedPrompter prompter({"5", "16"});
@@ -828,7 +828,7 @@ ask z "Z?" string
 )");
     ScriptedPrompter prompter({"av", "1", "loopv", "zv"});
     run_for_tests(p, prompter);
-    // Last presented prompt is `ask z` — top-level, should be (3/3).
+    // Last presented prompt is `ask z` - top-level, should be (3/3).
     EXPECT_EQ(prompter.last_request()->question_index, 3);
     EXPECT_EQ(prompter.last_request()->question_total, 3);
 }
@@ -1193,7 +1193,7 @@ let s = "{n}"
 }
 
 TEST(TemplateStringTest, RunCommandPreviewKeepsBraceForm) {
-    // The trust prompt shows the literal source — interpolations stay
+    // The trust prompt shows the literal source - interpolations stay
     // visible as `{...}` so the user sees what flows into the command.
     TmpDir td;
     auto p = parse(R"(let label = "ok"
@@ -1362,7 +1362,7 @@ TEST(MkdirTest, FromMissingSourceThrows) {
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
-    // The `from` rejection happens during execution, before flush — nothing
+    // The `from` rejection happens during execution, before flush - nothing
     // was written.
     EXPECT_FALSE(std::filesystem::exists(td.path() / "foo"));
 }
@@ -1445,7 +1445,7 @@ mkdir b from base
 TEST(MkdirTest, SkippedConditionalAliasNotBound) {
     TmpDir td;
     // Producer is skipped (`use_x=false`); consumer guarded by the same when
-    // is also skipped — neither directory is created and the alias is never
+    // is also skipped - neither directory is created and the alias is never
     // looked up. This proves the runtime does not bind aliases on skipped
     // statements.
     auto p = parse(R"(ask use_x "Use x?" bool
@@ -1939,7 +1939,7 @@ TEST(RepeatTest, InnerAliasDoesNotLeak) {
     TmpDir td;
     // `wk` is rebound each iteration to that iteration's `week_{i}` path;
     // the inner `mkdir wk/sub_{i}` resolves through the per-iteration alias.
-    // Each iteration must see only its own binding — no bleed across
+    // Each iteration must see only its own binding - no bleed across
     // iterations and no escape after the loop.
     auto p = parse(R"(let n = 2
 repeat n as i
@@ -1951,7 +1951,7 @@ end
     run(p, prompter);
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_0" / "sub_0"));
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "week_1" / "sub_1"));
-    // Crucially, week_0/sub_1 and week_1/sub_0 must NOT exist — they would
+    // Crucially, week_0/sub_1 and week_1/sub_0 must NOT exist - they would
     // if the alias from iteration 0 leaked into iteration 1 or vice versa.
     EXPECT_FALSE(std::filesystem::exists(td.path() / "week_0" / "sub_1"));
     EXPECT_FALSE(std::filesystem::exists(td.path() / "week_1" / "sub_0"));
@@ -2449,7 +2449,7 @@ TEST(SourceProvider, DiskBackedSkipsBrokenSymlinks) {
     TmpDir td;
     std::filesystem::create_directories(td.path() / "tree");
     std::ofstream(td.path() / "tree/regular.txt") << "hi\n";
-    // Broken symlink — target does not exist. Today's behaviour skips
+    // Broken symlink - target does not exist. Today's behaviour skips
     // these silently rather than aborting the run; the provider
     // preserves that.
     std::filesystem::create_symlink(td.path() / "no/such/target",

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -898,7 +898,7 @@ TEST(ParserTest, FileContentUnquotedPath) {
     ASSERT_EQ(file.path.segments.size(), 1u);
     EXPECT_EQ(std::get<PathLiteral>(file.path.segments[0]).value,
               "static/notes/README.md");
-    std::get<FileContentSource>(file.source);  // NOLINT — just verifying variant
+    std::get<FileContentSource>(file.source);  // NOLINT - just verifying variant
 }
 
 TEST(ParserTest, FileFromUnquotedPath) {
@@ -1117,7 +1117,7 @@ TEST(ParserTest, RepeatWithWhenClause) {
 
 TEST(ParserTest, RepeatHeaderWhenWithBodyStatementWhen) {
     // Proves the header when binds to repeat and the body statement's when
-    // binds to the body statement — no lexical collision.
+    // binds to the body statement - no lexical collision.
     auto program = parse_program(
         "repeat n as i when outer\n"
         "  mkdir \"x\" when inner\n"
@@ -1141,7 +1141,7 @@ TEST(ParserTest, RepeatWithoutWhenClauseHasEmptyOptional) {
 }
 
 TEST(ParserTest, RepeatBareWhenRaisesError) {
-    // `repeat n as i when\n ... end` — bare when with no expression.
+    // `repeat n as i when\n ... end` - bare when with no expression.
     // parseExpression sees NEWLINE and throws.
     EXPECT_THROW(parse_program("repeat n as i when\n"
                                "  mkdir \"x\"\n"

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -9,7 +9,7 @@ namespace spudplate::test {
 
 // Structural equality for AST nodes, used by round-trip assertions in the
 // binary-serializer tests. Compares every field including line/column. The
-// helpers are deliberately test-only — adding `operator==` to `ast.h` would
+// helpers are deliberately test-only - adding `operator==` to `ast.h` would
 // pin equality semantics into the public surface, which prior attempts
 // (PR #50, since reverted) showed to be more trouble than it is worth.
 
@@ -22,7 +22,7 @@ bool file_sources_equal(const FileSource& a, const FileSource& b);
 // Per-test scratch directory. Created on construction with a randomised name
 // under the system temp dir; the previous working directory is restored and
 // the directory is wiped on destruction. `chdir`-into-the-tempdir is opt-in
-// — pass `chdir = false` for tests that should keep the caller's cwd.
+// - pass `chdir = false` for tests that should keep the caller's cwd.
 class TmpDir {
   public:
     explicit TmpDir(bool chdir = true);

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -352,7 +352,7 @@ TEST(NormalizeTest, PositiveAndNegativeBoolNotEqual) {
 }
 
 TEST(NormalizeTest, CommutativityNotApplied) {
-    // `a and b` vs `b and a` — known limitation per TODO.
+    // `a and b` vs `b and a` - known limitation per TODO.
     TypeMap tm{{"a", VarType::Bool}, {"b", VarType::Bool}};
     auto left = bin(TokenType::AND, id("a"), id("b"));
     auto right = bin(TokenType::AND, id("b"), id("a"));
@@ -360,7 +360,7 @@ TEST(NormalizeTest, CommutativityNotApplied) {
 }
 
 TEST(NormalizeTest, UnknownIdentifierKeepsStructuralForm) {
-    // `x` is NOT in the type map — bool simplification skipped.
+    // `x` is NOT in the type map - bool simplification skipped.
     // `x == true` stays as the binary form; `x` stays as the identifier.
     TypeMap tm;  // empty
     auto a = id("x");
@@ -642,7 +642,7 @@ TEST(ValidatorTest, TemplateInWhenInRunIsWalked) {
 }
 
 TEST(ValidatorTest, ComposedRulesEndToEnd) {
-    // Exercises Part A (repeat when), Part B (no ask-in-repeat — valid case),
+    // Exercises Part A (repeat when), Part B (no ask-in-repeat - valid case),
     // Part C (nested let scoping), and Part E (bool-equivalent alias when).
     auto program = parse(
         "ask use_ci \"use ci?\" bool\n"


### PR DESCRIPTION
## Summary
Three fixes for how the syntax reference renders on the published Doxygen site, plus a sweep across the rest of the source.

## Changes
- Drop backticks from headings in `docs/syntax.md`. Doxygen rendered them as `<tt>...</tt>` in the navtree, which the sidebar JS surfaced as literal text.
- Avoid a backticked literal double-quote in the Variable Interpolation section. That single token was confusing Doxygen's markdown parser badly enough to spill raw escaped HTML into the rest of the page.
- Replace em dashes with hyphens everywhere - syntax doc, headers, sources, tests, README.

## Test plan
- `cmake --build build --target docs` produces `docs/html/index.html` with no warnings
- Variable Interpolation and the sections after it now render as normal prose
- Navtree TOC entries no longer show literal `<tt>...</tt>` text