### PR TITLE
chore: community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Something is broken or behaving unexpectedly
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Summary
+
+<!-- One or two sentences describing what is wrong. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behaviour
+
+<!-- What did you expect to happen? -->
+
+## Actual behaviour
+
+<!-- What happened instead? Include error output if relevant. -->
+
+## Minimal `.spud` (if applicable)
+
+```
+# paste the smallest .spud file that triggers the issue
+```
+
+## Environment
+
+- spudplate version: <!-- output of `spudplate version` -->
+- OS:
+- Compiler / CMake version (only if building from source):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Syntax reference
+    url: https://spuddydev.github.io/spudplate/
+    about: Full spudlang language reference (Doxygen site).
+  - name: VS Code extension
+    url: https://github.com/spuddydev/spudlang-vscode
+    about: Syntax highlighting for .spud files.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What are you trying to do? What is awkward, slow, or impossible today? -->
+
+## Proposed solution
+
+<!-- What would you like to see? Sketch the syntax, CLI shape, or API if relevant. -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about and why you ruled them out. -->
+
+## Additional context
+
+<!-- Links, prior art, related issues. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Code of Conduct
+
+Spudplate is a small project with a friendly community, and we'd like to keep it that way.
+
+## The short version
+
+Be kind. Assume good faith. Disagree about the code, not the person.
+
+We want spudplate to be somewhere people of any background, experience level, or potato variety can show up, ask questions, and contribute without grief.
+
+## What that looks like
+
+- Welcoming newcomers and beginner questions, even the ones that have been asked before.
+- Crediting people's work and giving them room to learn.
+- Disagreeing on technical points by talking about the technical points.
+- Walking away from a thread for a bit when it gets heated, instead of escalating.
+
+## What it doesn't look like
+
+Anything that makes the project feel unsafe or unwelcoming for someone else. Maintainers will use their judgement, and if it's making people not want to participate, that's enough to act on it.
+
+## If something goes wrong
+
+Email hlisle@protonmail.com. Reports go to the maintainer and are kept in confidence. You don't need to be the target to report something - if you saw it and it bothered you, that's a fine reason to flag it.
+
+Maintainers can remove comments, close issues or PRs, and ban contributors when needed. We'd rather not, but we will if we have to.
+
+## Scope
+
+This applies in the issue tracker, pull requests, discussions, and any other space connected to the project.
+
+## Attribution
+
+Inspired by, and in the spirit of, the [Contributor Covenant](https://www.contributor-covenant.org/) v2.1. The full text lives at https://www.contributor-covenant.org/version/2/1/code_of_conduct/ if you'd like the long form.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to spudplate
+
+Thanks for your interest in spudplate. This guide covers how to build, test, and submit changes.
+
+## Code of conduct
+
+By participating, you agree to abide by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Getting started
+
+Requires CMake and a C++20 compiler. `clang-format` and `clang-tidy` are used for formatting and linting.
+
+```bash
+cmake -B build && cmake --build build        # build
+ctest --test-dir build                        # run tests
+clang-format -i src/**/*.cpp include/**/*.h   # format
+clang-tidy src/**/*.cpp -- -Iinclude          # lint
+```
+
+Doxygen docs build with `cmake --build build --target docs` and land in `docs/html/index.html`.
+
+## Branching
+
+- Branch off the latest merged work on `main`.
+- Keep branches small and focused on a single feature, fix, or refactor. Do not bundle unrelated changes.
+
+## Commits
+
+- Conventional commits style: `feat:`, `fix:`, `test:`, `refactor:`, `chore:`, `docs:`, `ci:`.
+- One small focused change per commit. Split implementation and tests into separate commits.
+- Plain words, British English spelling (organise, colour, behaviour).
+- Use snake_case for local and member variables.
+
+## Tests
+
+Write tests for every major feature. Tests live under `tests/` and run via `ctest`.
+
+## Pull requests
+
+The repo ships a PR template - fill it in. Keep summaries short, use bullets, and describe the change on its own terms.
+
+A PR is ready when:
+
+- It builds cleanly and `ctest` passes locally.
+- Code is formatted (`clang-format`) and lint-clean (`clang-tidy`).
+- New behaviour is covered by tests.
+- The summary explains what changed and how to verify it.
+
+## Reporting issues
+
+Use the issue templates for bug reports and feature requests. Include enough detail that a maintainer can reproduce or evaluate the request without follow-up.
+
+## Editor support
+
+A syntax highlighting extension for `.spud` files is available at [spuddydev/spudlang-vscode](https://github.com/spuddydev/spudlang-vscode).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,11 @@ file project/src/main.cpp from templates/main.cpp
 file project/tests/test_main.cpp from templates/test_main.cpp when use_tests
 ```
 
-Spudlang supports questions with defaults and option lists, derived variables, conditional actions, path aliases, loops, and including other installed templates. See [docs/syntax.md](docs/syntax.md) for the full language reference.
+Spudlang supports questions with defaults and option lists, derived variables, conditional actions, path aliases, loops, and including other installed templates. See the [language reference](https://spuddydev.github.io/spudplate/) for the full syntax.
+
+## Editor support
+
+Syntax highlighting for `.spud` files is available through the [spudlang-vscode](https://github.com/spuddydev/spudlang-vscode) extension.
 
 ## Build
 
@@ -93,7 +97,11 @@ Requires [Doxygen](https://www.doxygen.nl/) (`brew install doxygen`).
 cmake --build build --target docs
 ```
 
-Opens `docs/html/index.html` - includes the full spudlang syntax reference and API documentation.
+Opens `docs/html/index.html` - includes the full spudlang syntax reference and API documentation. Published online at https://spuddydev.github.io/spudplate/.
+
+## Contributing
+
+Bug reports, feature requests, and pull requests are welcome. See [CONTRIBUTING](CONTRIBUTING.md) for build and submission guidelines, and the [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 


### PR DESCRIPTION
## Summary
Add the missing community health files and tidy a couple of README pointers.

## Changes
- `CONTRIBUTING.md` covering build, test, format, lint, branching, commits, and PR expectations.
- `CODE_OF_CONDUCT.md` - short, plain-spoken, in the spirit of Contributor Covenant 2.1, with the maintainer email for reports.
- `.github/ISSUE_TEMPLATE/` with bug and feature templates and a `config.yml` that disables blank issues and surfaces the hosted reference and the VS Code extension.
- README now links the published reference at https://spuddydev.github.io/spudplate/ instead of `docs/syntax.md`, gains an Editor support section pointing at https://github.com/spuddydev/spudlang-vscode, and a Contributing section linking the two new docs.

## Test plan
- Build still green locally
- Files render as expected on GitHub once the branch is pushed