### PR TITLE
feat: show iteration counter inside repeat prompts

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -26,7 +26,7 @@ Declares a variable `<name>` and asks the user a question at runtime.
 - The `default` accepts any expression - a literal, a previously declared variable, or a computed expression like `lower(trim(project_name))`. The expression is evaluated against the live environment when the user skips the prompt.
 - `options` restricts valid answers to a fixed set, presented as a numbered menu. The user may type either the literal value or its 1-based number.
 - `when <condition>` only asks the question if the condition is true. A `when`-gated question must have a `default` so the variable is always bound after the statement, whether the user answered or the question was skipped.
-- `ask` is allowed inside `repeat`. Each iteration prompts afresh; the binding lives only for that iteration. Prompts inside `repeat` are indented by 2 spaces per nesting level and are not counted in the `(N/M)` progress indicator (since the iteration count is dynamic). Shadowing rules still apply - an `ask` cannot reuse a name visible from the surrounding scope.
+- `ask` is allowed inside `repeat`. Each iteration prompts afresh; the binding lives only for that iteration. Prompts inside `repeat` are indented by 2 spaces per nesting level. The static `(N/M)` counter still shows the position of the enclosing static `ask` statement, and an additional `iteration K of L` is rendered next to it for each enclosing repeat - for example `(3/7, iteration 2 of 4)`. Nested repeats stack the iteration counters outermost first. Shadowing rules still apply - an `ask` cannot reuse a name visible from the surrounding scope.
 
 **Types:**
 

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -108,6 +108,7 @@ struct PromptRequest {
     int question_index{0};                    ///< 1-based position of this question among presented ones; 0 suppresses the counter.
     int question_total{0};                    ///< Total static `ask` statements in the program; 0 suppresses the counter.
     int indent_level{0};                      ///< Number of nested `repeat` blocks above this prompt; renders as 2 spaces per level.
+    std::vector<std::pair<std::int64_t, std::int64_t>> iterations; ///< One {current, total} pair per enclosing `repeat` block, outermost first. Empty outside any repeat.
 };
 
 /**

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -620,7 +620,9 @@ std::string build_authorize_summary(const Program& program) {
 }
 
 void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter,
-                 int question_index, int question_total, int indent_level) {
+                 int question_index, int question_total, int indent_level,
+                 const std::vector<std::pair<std::int64_t, std::int64_t>>&
+                     iterations) {
     if (!when_passes(stmt.when_clause, env)) {
         if (!stmt.default_value.has_value()) {
             throw RuntimeError(
@@ -655,6 +657,7 @@ void execute_ask(const AskStmt& stmt, Environment& env, Prompter& prompter,
         .question_index = question_index,
         .question_total = question_total,
         .indent_level = indent_level,
+        .iterations = iterations,
     };
 
     while (true) {
@@ -785,11 +788,19 @@ class Interpreter {
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, AskStmt>) {
-                    bool show_counter = ask_total_ > 0 && repeat_depth_ == 0;
-                    int index = show_counter ? ++ask_index_ : 0;
-                    int total = show_counter ? ask_total_ : 0;
+                    // ask_index_ counts top-level (static) prompts only - the
+                    // same static `ask` repeated in a `repeat` body should not
+                    // bump the counter past `ask_total_`. Inside a repeat the
+                    // already-incremented index is reused so the renderer can
+                    // still show "(N/M)" as a positional anchor alongside any
+                    // iteration counter the prompter assembles.
+                    if (ask_total_ > 0 && repeat_depth_ == 0) {
+                        ++ask_index_;
+                    }
+                    int index = ask_total_ > 0 ? ask_index_ : 0;
+                    int total = ask_total_;
                     execute_ask(s, env_, prompter_, index, total,
-                                repeat_depth_);
+                                repeat_depth_, repeat_iters_);
                 } else if constexpr (std::is_same_v<T, LetStmt>) {
                     Value v = evaluate_expr(*s.value, env_);
                     env_.declare(s.name, std::move(v));

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -857,6 +857,7 @@ class Interpreter {
             env_.push();
             env_.declare(s.iterator_var, Value{i});
             ++repeat_depth_;
+            repeat_iters_.emplace_back(i + 1, count);
             try {
                 for (const auto& stmt : s.body) {
                     execute(*stmt);
@@ -870,6 +871,7 @@ class Interpreter {
                         ++it;
                     }
                 }
+                repeat_iters_.pop_back();
                 --repeat_depth_;
                 env_.pop();
                 throw;
@@ -882,6 +884,7 @@ class Interpreter {
                     ++it;
                 }
             }
+            repeat_iters_.pop_back();
             --repeat_depth_;
             env_.pop();
         }
@@ -1204,6 +1207,11 @@ class Interpreter {
     int ask_total_{0};
     int ask_index_{0};
     int repeat_depth_{0};
+    // One {1-based current, total} pair pushed per active `repeat` iteration,
+    // outermost first. `execute_repeat` pushes at the top of each iteration
+    // body and pops on both normal-exit and exception paths so the stack is
+    // never left dirty.
+    std::vector<std::pair<std::int64_t, std::int64_t>> repeat_iters_;
 };
 
 int count_ask_statements(const Program& program) {

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1295,9 +1295,25 @@ void render_request(std::ostream& out, const PromptRequest& req,
 
     out << indent;
 
-    if (req.question_total > 0 && req.question_index > 0) {
-        std::string counter = "(" + std::to_string(req.question_index) + "/" +
-                              std::to_string(req.question_total) + ") ";
+    bool has_static_counter = req.question_total > 0 && req.question_index > 0;
+    bool has_iter_counter = !req.iterations.empty();
+    if (has_static_counter || has_iter_counter) {
+        std::string counter = "(";
+        bool first = true;
+        if (has_static_counter) {
+            counter += std::to_string(req.question_index) + "/" +
+                       std::to_string(req.question_total);
+            first = false;
+        }
+        for (const auto& [k, n] : req.iterations) {
+            if (!first) {
+                counter += ", ";
+            }
+            counter += "iteration " + std::to_string(k) + " of " +
+                       std::to_string(n);
+            first = false;
+        }
+        counter += ") ";
         out << wrap(counter, kAccent, use_colour);
     }
 

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -895,6 +895,69 @@ ask z "Z?" string
     EXPECT_EQ(prompter.last_request()->question_total, 3);
 }
 
+TEST(AskTest, AskInsideRepeatReportsIteration) {
+    auto p = parse(R"(ask n "Count?" int
+repeat n as i
+  ask name "Module?" string
+end
+)");
+    // Four iterations; we want the second iteration's prompt captured. The
+    // scripted prompter records `last_request` on every prompt, so we drive
+    // through all four and rely on the last being iteration 4 of 4.
+    ScriptedPrompter prompter({"4", "a", "b", "c", "d"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request().has_value());
+    ASSERT_EQ(prompter.last_request()->iterations.size(), 1u);
+    EXPECT_EQ(prompter.last_request()->iterations[0].first, 4);
+    EXPECT_EQ(prompter.last_request()->iterations[0].second, 4);
+}
+
+TEST(AskTest, AskInsideNestedRepeatReportsStackedIterations) {
+    auto p = parse(R"(ask n "Outer?" int
+ask m "Inner?" int
+repeat n as i
+  repeat m as j
+    ask name "Inner?" string
+  end
+end
+)");
+    // Outer count 2, inner count 3 - the final inner prompt is i=2, j=3.
+    ScriptedPrompter prompter({"2", "3",
+                               "a", "b", "c",
+                               "d", "e", "f"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request().has_value());
+    ASSERT_EQ(prompter.last_request()->iterations.size(), 2u);
+    EXPECT_EQ(prompter.last_request()->iterations[0].first, 2);
+    EXPECT_EQ(prompter.last_request()->iterations[0].second, 2);
+    EXPECT_EQ(prompter.last_request()->iterations[1].first, 3);
+    EXPECT_EQ(prompter.last_request()->iterations[1].second, 3);
+}
+
+TEST(AskTest, AskOutsideRepeatHasNoIterations) {
+    auto p = parse(R"(ask name "Name?" string
+)");
+    ScriptedPrompter prompter({"x"});
+    run_for_tests(p, prompter);
+    ASSERT_TRUE(prompter.last_request().has_value());
+    EXPECT_TRUE(prompter.last_request()->iterations.empty());
+}
+
+TEST(AskTest, ZeroIterationRepeatNeverPrompts) {
+    auto p = parse(R"(ask n "Count?" int
+repeat n as i
+  ask name "Module?" string
+end
+)");
+    ScriptedPrompter prompter({"0"});
+    run_for_tests(p, prompter);
+    // Only the outer `ask n` was prompted. The inner ask was never reached so
+    // last_request() reflects the outer prompt with empty iterations.
+    ASSERT_TRUE(prompter.last_request().has_value());
+    EXPECT_EQ(prompter.last_request()->text, "Count?");
+    EXPECT_TRUE(prompter.last_request()->iterations.empty());
+}
+
 TEST(AskTest, OffOptionPropagatesError) {
     auto p = parse(R"(ask format "Format?" string options "pdf" "html"
 )");

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -846,7 +846,11 @@ end
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "gamma"));
 }
 
-TEST(AskTest, AskInsideRepeatGetsNoCounter) {
+TEST(AskTest, AskInsideRepeatKeepsStaticCounter) {
+    // The static `(N/M)` counter is shown inside a repeat as a positional
+    // anchor; M is the static-statement count and does not grow with
+    // iterations. Iteration position is reported separately via
+    // `iterations` (see B5 tests).
     auto p = parse(R"(ask n "Count?" int
 repeat n as i
   ask name "Module?" string
@@ -855,8 +859,8 @@ end
     ScriptedPrompter prompter({"1", "x"});
     run_for_tests(p, prompter);
     ASSERT_TRUE(prompter.last_request().has_value());
-    EXPECT_EQ(prompter.last_request()->question_index, 0);
-    EXPECT_EQ(prompter.last_request()->question_total, 0);
+    EXPECT_EQ(prompter.last_request()->question_index, 1);
+    EXPECT_EQ(prompter.last_request()->question_total, 1);
     EXPECT_EQ(prompter.last_request()->indent_level, 1);
 }
 


### PR DESCRIPTION
## Summary

Prompts inside a `repeat` block previously suppressed the static `(N/M)` counter entirely, leaving the user with no positional information at exactly the point where the prompt stream gets longest. Closes #70.

## Changes

- `PromptRequest` carries an `iterations` vector: one `{current, total}` pair per enclosing `repeat`, outermost first.
- The interpreter pushes the pair at iteration start and pops on both normal-exit and exception paths.
- The static `(N/M)` counter is no longer suppressed inside repeats. The static index counts top-level `ask` statements only, so a repeat-bound `ask` does not push it past `M`.
- The renderer assembles `(N/M, iteration K of L[, iteration K of L])` from the static counter and the iteration vector, comma-joined.
- Doc note in `docs/syntax.md`. Existing repeat-counter test updated; four new tests cover single, nested, outside-repeat, and zero-iteration cases.

## Test plan

- `ctest --test-dir build` passes (613 tests, 4 new).
- New tests assert `last_request().iterations` for single repeat, nested repeats, outside-any-repeat, and a zero-count loop where the body never runs.
- The pre-existing `TopLevelCounterUnaffectedByRepeatAsks` test still passes - the counter is still bounded by the static count.