### PR TITLE
feat: add if block for grouped conditionals

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -252,6 +252,39 @@ end
 
 ---
 
+### if - Conditional block
+
+```
+if <condition>
+    # nested statements
+end
+```
+
+Executes the nested block when `<condition>` evaluates to `true`. The condition uses the same expression grammar as `when`. Nested `if` and `repeat` blocks, `ask`, and all action statements are allowed inside the body.
+
+There is no `else` or `else if`; gating gating composes via nested `if` blocks. An `if` block does **not** itself accept a `when` clause - the `if` already is the gate. Inner statements may still carry their own `when`.
+
+#### If scoping
+
+An `if` block introduces a new scope. Any `let` or `as` names declared inside the block are local to it and not visible after `end`. Shadowing rules match `repeat`: a binding inside the block whose name collides with a currently-visible outer binding is rejected.
+
+#### ask inside if
+
+An `ask` lexically inside an `if` body that has no inner `when` clause does not need a `default` - the `if` itself is the gate. An `ask` with its own `when` clause **still** requires a `default` even inside an `if`, because the inner gate can be false while the outer `if` is true.
+
+**Example:**
+
+```
+ask use_tests "Include a test suite?" bool default false
+if use_tests
+    mkdir tests
+    file tests/README.md content "# Tests"
+    ask test_runner "Test runner?" string options "ctest" "gtest" default "ctest"
+end
+```
+
+---
+
 ### include - Run another installed template
 
 ```

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -328,9 +328,34 @@ struct IncludeStmt {
     int column;  ///< 1-based source column where this node begins.
 };
 
+/**
+ * @brief An `if` statement - executes its body when the condition is true.
+ *
+ * Example:
+ * @code
+ * if use_tests
+ *     mkdir "tests"
+ *     file "tests/README.md" content "# Tests"
+ * end
+ * @endcode
+ *
+ * Mirrors `repeat` structurally: a condition expression, a body, and an `end`
+ * terminator. There is no `else` or `else if`; gating gating composes via
+ * nested `if` blocks. `let` and `as` declared inside the body are local; the
+ * usual no-shadowing rule applies. Inner statements may carry their own `when`
+ * clause; an `if` block does NOT itself accept a `when` clause.
+ */
+struct IfStmt {
+    ExprPtr condition;            ///< Expression that must evaluate to bool true to enter the body.
+    std::vector<StmtPtr> body;    ///< Statements inside the conditional block.
+    int line;    ///< 1-based source line where this node begins.
+    int column;  ///< 1-based source column where this node begins.
+};
+
 /** @brief Discriminated union of all statement node types. */
 using StmtData = std::variant<AskStmt, LetStmt, AssignStmt, MkdirStmt, FileStmt,
-                              RepeatStmt, CopyStmt, IncludeStmt, RunStmt>;
+                              RepeatStmt, CopyStmt, IncludeStmt, RunStmt,
+                              IfStmt>;
 
 /** @brief A statement node wrapping a StmtData variant. */
 struct Stmt {

--- a/include/spudplate/binary_serializer.h
+++ b/include/spudplate/binary_serializer.h
@@ -43,6 +43,7 @@ enum class StmtTag : std::uint8_t {
     Copy = 6,
     Include = 7,
     Run = 8,
+    If = 9,
 };
 
 /** @brief Tag values for `PathSegment` arms. See `ExprTag`. */

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -64,6 +64,8 @@ class Parser {
     StmtPtr parseFile();
     /** @brief Parses a `repeat` block. */
     StmtPtr parseRepeat();
+    /** @brief Parses an `if` block. */
+    StmtPtr parseIf();
     /** @brief Parses a `copy` statement. */
     StmtPtr parseCopy();
     /** @brief Parses an `include` statement. */

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -16,7 +16,8 @@ enum class TokenType {
     CONTENT,   ///< `content` - inline content for file statements
     WHEN,      ///< `when` - conditional modifier
     REPEAT,    ///< `repeat` - begin a loop block
-    END,       ///< `end` - close a repeat block
+    IF,        ///< `if` - begin a conditional block
+    END,       ///< `end` - close a repeat or if block
     VERBATIM,  ///< `verbatim` - suppress interpolation in from-file contents
     APPEND,    ///< `append` - append to file instead of overwriting
     MODE,      ///< `mode` - set file/directory permissions (octal)
@@ -111,6 +112,8 @@ inline std::string tokenTypeToString(TokenType type) {
             return "WHEN";
         case TokenType::REPEAT:
             return "REPEAT";
+        case TokenType::IF:
+            return "IF";
         case TokenType::END:
             return "END";
         case TokenType::VERBATIM:

--- a/src/binary_serializer.cpp
+++ b/src/binary_serializer.cpp
@@ -21,7 +21,7 @@ constexpr std::size_t kVarintMaxBytes = 10;
 // existing arms is not caught by arity alone; the round-trip tests are
 // the second line of defence there.
 static_assert(std::variant_size_v<ExprData> == 8);
-static_assert(std::variant_size_v<StmtData> == 9);
+static_assert(std::variant_size_v<StmtData> == 10);
 static_assert(std::variant_size_v<PathSegment> == 3);
 static_assert(std::variant_size_v<FileSource> == 2);
 
@@ -629,11 +629,17 @@ void encode_stmt(Writer& w, const Stmt& s) {
             } else if constexpr (std::is_same_v<T, IncludeStmt>) {
                 w.write_string(node.name);
                 encode_opt_expr(w, node.when_clause);
-            } else {
-                static_assert(std::is_same_v<T, RunStmt>);
+            } else if constexpr (std::is_same_v<T, RunStmt>) {
                 encode_expr(w, *node.command);
                 encode_opt_path_expr(w, node.cwd);
                 encode_opt_expr(w, node.when_clause);
+            } else {
+                static_assert(std::is_same_v<T, IfStmt>);
+                encode_expr(w, *node.condition);
+                w.write_varint(node.body.size());
+                for (const auto& sp : node.body) {
+                    encode_stmt(w, *sp);
+                }
             }
             w.write_zigzag(node.line);
             w.write_zigzag(node.column);
@@ -781,6 +787,21 @@ StmtPtr decode_stmt(Reader& r) {
                                 .when_clause = std::move(when_clause),
                                 .line = line,
                                 .column = column});
+        }
+        case StmtTag::If: {
+            ExprPtr condition = decode_expr(r);
+            const std::size_t body_size = r.read_varint();
+            std::vector<StmtPtr> body;
+            body.reserve(body_size);
+            for (std::size_t i = 0; i < body_size; ++i) {
+                body.push_back(decode_stmt(r));
+            }
+            const int line = static_cast<int>(r.read_zigzag());
+            const int column = static_cast<int>(r.read_zigzag());
+            return wrap(IfStmt{.condition = std::move(condition),
+                               .body = std::move(body),
+                               .line = line,
+                               .column = column});
         }
     }
     throw BinaryDeserializeError("invalid Stmt tag", at);

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -133,6 +133,10 @@ class Bundler {
                     for (const auto& body : s.body) {
                         if (body) visit_stmt(*body);
                     }
+                } else if constexpr (std::is_same_v<T, IfStmt>) {
+                    for (const auto& body : s.body) {
+                        if (body) visit_stmt(*body);
+                    }
                 }
                 // AskStmt, LetStmt, AssignStmt, IncludeStmt, RunStmt carry
                 // no asset references and are intentionally skipped.

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -594,6 +594,8 @@ void collect_run_previews(const std::vector<StmtPtr>& body,
                     out.push_back(std::move(line));
                 } else if constexpr (std::is_same_v<T, RepeatStmt>) {
                     collect_run_previews(s.body, out, /*inside_repeat=*/true);
+                } else if constexpr (std::is_same_v<T, IfStmt>) {
+                    collect_run_previews(s.body, out, inside_repeat);
                 }
             },
             stmt->data);
@@ -821,6 +823,8 @@ class Interpreter {
                         s.line, s.column);
                 } else if constexpr (std::is_same_v<T, RunStmt>) {
                     execute_run(s);
+                } else if constexpr (std::is_same_v<T, IfStmt>) {
+                    execute_if(s);
                 }
             },
             stmt.data);
@@ -899,6 +903,52 @@ class Interpreter {
             --repeat_depth_;
             env_.pop();
         }
+    }
+
+    void execute_if(const IfStmt& s) {
+        Value cond = evaluate_expr(*s.condition, env_);
+        if (!std::holds_alternative<bool>(cond)) {
+            throw RuntimeError("'if' condition must be bool", s.line, s.column);
+        }
+        if (!std::get<bool>(cond)) {
+            return;
+        }
+
+        // Snapshot aliases before the body so anything declared inside the
+        // block stays local. Mirrors `execute_repeat`'s alias handling without
+        // the iteration loop or `repeat_depth_` bump - prompt indent and the
+        // iteration counter stay unchanged for nested asks.
+        std::unordered_set<std::string> outer_aliases;
+        outer_aliases.reserve(alias_map_.size());
+        for (const auto& kv : alias_map_) {
+            outer_aliases.insert(kv.first);
+        }
+
+        env_.push();
+        try {
+            for (const auto& stmt : s.body) {
+                execute(*stmt);
+            }
+        } catch (...) {
+            for (auto it = alias_map_.begin(); it != alias_map_.end();) {
+                if (outer_aliases.find(it->first) == outer_aliases.end()) {
+                    it = alias_map_.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+            env_.pop();
+            throw;
+        }
+
+        for (auto it = alias_map_.begin(); it != alias_map_.end();) {
+            if (outer_aliases.find(it->first) == outer_aliases.end()) {
+                it = alias_map_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        env_.pop();
     }
 
     void execute_mkdir(const MkdirStmt& s) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -9,6 +9,7 @@ static const std::unordered_map<std::string, TokenType> keywords = {
     {"mkdir", TokenType::MKDIR},       {"file", TokenType::FILE},
     {"from", TokenType::FROM},         {"content", TokenType::CONTENT},
     {"when", TokenType::WHEN},         {"repeat", TokenType::REPEAT},
+    {"if", TokenType::IF},
     {"end", TokenType::END},           {"verbatim", TokenType::VERBATIM},
     {"append", TokenType::APPEND},
     {"mode", TokenType::MODE},         {"as", TokenType::AS},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -532,6 +532,34 @@ StmtPtr Parser::parseRepeat() {
     return stmt;
 }
 
+StmtPtr Parser::parseIf() {
+    Token start = expect(TokenType::IF, "expected 'if'");
+    ExprPtr condition = parseExpression();
+    if (check(TokenType::WHEN)) {
+        throw ParseError(
+            "'if' does not take a 'when' clause; nest inside another 'if' if needed",
+            current_.line, current_.column);
+    }
+    expect_newline("if header");
+
+    std::vector<StmtPtr> body;
+    skip_newlines();
+    while (!check(TokenType::END) && !check(TokenType::EOF_TOKEN)) {
+        body.push_back(parseStatement());
+        skip_newlines();
+    }
+
+    expect(TokenType::END, "expected 'end' to close if block");
+    expect_newline("if block");
+
+    auto stmt = std::make_unique<Stmt>();
+    stmt->data = IfStmt{.condition = std::move(condition),
+                        .body = std::move(body),
+                        .line = start.line,
+                        .column = start.column};
+    return stmt;
+}
+
 // Statement dispatch
 
 StmtPtr Parser::parseStatement() {
@@ -549,6 +577,9 @@ StmtPtr Parser::parseStatement() {
     }
     if (check(TokenType::REPEAT)) {
         return parseRepeat();
+    }
+    if (check(TokenType::IF)) {
+        return parseIf();
     }
     if (check(TokenType::COPY)) {
         return parseCopy();

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -132,10 +132,6 @@ struct Scope {
 struct AliasCtx {
     std::unordered_map<std::string, std::optional<ExprPtr>> registry;
     TypeMap type_map;
-    // Flag flipped by an `if` body walker so the when-requires-default rule
-    // can grant a context-sensitive exemption. Save/restore around the body
-    // walk; default false at program scope.
-    bool inside_if_body{false};
 };
 
 void walk_expr(const Expr& expr, const Scope& scope);
@@ -232,10 +228,10 @@ void check_shadowing(const std::string& name, int line, int column,
     }
 }
 
-void check_when_requires_default(const AskStmt& s, const AliasCtx& ctx) {
-    if (ctx.inside_if_body) {
-        return;
-    }
+void check_when_requires_default(const AskStmt& s, const AliasCtx& /*ctx*/) {
+    // Purely syntactic: any ask carrying a `when_clause` needs a `default`.
+    // An enclosing `if` block does not exempt this; the inner gate can still
+    // be false while the outer `if` is true, recreating bug #59.
     if (s.when_clause.has_value() && !s.default_value.has_value()) {
         throw SemanticError("when-gated ask '" + s.name +
                                 "' requires a default value (add: default <value>)",
@@ -341,6 +337,18 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
                 scope.declare(s.iterator_var);
                 for (const auto& inner : s.body) {
                     validate_stmt(*inner, scope, ctx);
+                }
+                scope.pop();
+            } else if constexpr (std::is_same_v<T, IfStmt>) {
+                walk_expr(*s.condition, scope);
+                scope.push();
+                try {
+                    for (const auto& inner : s.body) {
+                        validate_stmt(*inner, scope, ctx);
+                    }
+                } catch (...) {
+                    scope.pop();
+                    throw;
                 }
                 scope.pop();
             }

--- a/tests/binary_serializer_test.cpp
+++ b/tests/binary_serializer_test.cpp
@@ -491,6 +491,64 @@ TEST(BinarySerializer, RejectsDeeplyNestedExpressions) {
                  BinaryDeserializeError);
 }
 
+TEST(BinarySerializer, RoundTripIfBlock) {
+    std::vector<StmtPtr> body;
+    PathExpr path;
+    path.segments.emplace_back(
+        PathLiteral{.value = "x", .line = 2, .column = 9});
+    path.line = 2;
+    path.column = 9;
+    body.push_back(make_stmt(MkdirStmt{.path = std::move(path),
+                                       .alias = std::nullopt,
+                                       .mkdir_p = true,
+                                       .from_source = std::nullopt,
+                                       .verbatim = false,
+                                       .mode = std::nullopt,
+                                       .when_clause = std::nullopt,
+                                       .line = 2,
+                                       .column = 1}));
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(IfStmt{.condition = ident("use_x"),
+                                     .body = std::move(body),
+                                     .line = 1,
+                                     .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, RoundTripIfNestedInsideRepeat) {
+    std::vector<StmtPtr> if_body;
+    PathExpr path;
+    path.segments.emplace_back(
+        PathLiteral{.value = "leaf", .line = 3, .column = 11});
+    path.line = 3;
+    path.column = 11;
+    if_body.push_back(make_stmt(MkdirStmt{.path = std::move(path),
+                                          .alias = std::nullopt,
+                                          .mkdir_p = true,
+                                          .from_source = std::nullopt,
+                                          .verbatim = false,
+                                          .mode = std::nullopt,
+                                          .when_clause = std::nullopt,
+                                          .line = 3,
+                                          .column = 1}));
+
+    std::vector<StmtPtr> repeat_body;
+    repeat_body.push_back(make_stmt(IfStmt{.condition = ident("use_x"),
+                                           .body = std::move(if_body),
+                                           .line = 2,
+                                           .column = 3}));
+
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(RepeatStmt{.collection_var = "n",
+                                         .iterator_var = "i",
+                                         .body = std::move(repeat_body),
+                                         .when_clause = std::nullopt,
+                                         .line = 1,
+                                         .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
 TEST(BinarySerializer, DeserializeErrorCarriesOffset) {
     // Single byte 0xFF: invalid as a varint (would need continuation), but
     // legal as a single 7-bit value of 127 - actually 0xFF has the high bit

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -2600,3 +2600,83 @@ TEST(SourceProvider, UnclosedBraceStillSurfacedOnTextWithHighBytes) {
         spudplate::run(p, prompter, /*skip_authorization=*/true, &provider),
         RuntimeError);
 }
+
+// --- if blocks ---
+
+TEST(IfTest, BodyExecutesWhenConditionTrue) {
+    TmpDir td;
+    auto p = parse(R"(ask use_x "Use X?" bool
+if use_x
+  mkdir "x"
+end
+)");
+    ScriptedPrompter prompter({"true"});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "x"));
+}
+
+TEST(IfTest, BodySkippedWhenConditionFalse) {
+    TmpDir td;
+    auto p = parse(R"(ask use_x "Use X?" bool
+if use_x
+  mkdir "x"
+end
+)");
+    ScriptedPrompter prompter({"false"});
+    run(p, prompter);
+    EXPECT_FALSE(std::filesystem::exists(td.path() / "x"));
+}
+
+TEST(IfTest, NonBoolConditionThrowsAtRuntime) {
+    auto p = parse(R"(ask n "Count?" int
+if n
+  mkdir "x"
+end
+)");
+    ScriptedPrompter prompter({"5"});
+    try {
+        run_for_tests(p, prompter);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& e) {
+        EXPECT_NE(std::string(e.what()).find("'if' condition must be bool"),
+                  std::string::npos);
+    }
+}
+
+TEST(IfTest, NestedIfInsideRepeat) {
+    TmpDir td;
+    auto p = parse(R"(ask n "Count?" int
+ask use_extra "Extra?" bool
+repeat n as i
+  if use_extra
+    mkdir m_{i}
+  end
+end
+)");
+    ScriptedPrompter prompter({"2", "true"});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "m_0"));
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "m_1"));
+}
+
+TEST(IfTest, FalseIfDoesNotPromptInnerAsk) {
+    auto p = parse(R"(ask use_x "Use X?" bool
+if use_x
+  ask name "Name?" string
+end
+)");
+    ScriptedPrompter prompter({"false"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_FALSE(env.lookup("name").has_value());
+}
+
+TEST(IfTest, LetInsideIfNotVisibleAfterEnd) {
+    auto p = parse(R"(ask use_x "Use X?" bool
+if use_x
+  let x = 1
+end
+)");
+    ScriptedPrompter prompter({"true"});
+    Environment env = run_for_tests(p, prompter);
+    EXPECT_FALSE(env.lookup("x").has_value());
+}

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -28,6 +28,7 @@ using spudplate::PathInterp;
 using spudplate::PathLiteral;
 using spudplate::PathVar;
 using spudplate::Program;
+using spudplate::IfStmt;
 using spudplate::RepeatStmt;
 using spudplate::StmtPtr;
 using spudplate::StringLiteralExpr;
@@ -1131,6 +1132,90 @@ TEST(ParserTest, RepeatHeaderWhenWithBodyStatementWhen) {
     auto& mk = std::get<MkdirStmt>(rep.body[0]->data);
     ASSERT_TRUE(mk.when_clause.has_value());
     EXPECT_EQ(std::get<IdentifierExpr>((*mk.when_clause)->data).name, "inner");
+}
+
+TEST(ParserTest, IfBasic) {
+    auto program = parse_program(
+        "if use_tests\n"
+        "  mkdir \"tests\"\n"
+        "end\n");
+    ASSERT_EQ(program.statements.size(), 1);
+    auto& ifs = std::get<IfStmt>(program.statements[0]->data);
+    auto& cond = std::get<IdentifierExpr>(ifs.condition->data);
+    EXPECT_EQ(cond.name, "use_tests");
+    ASSERT_EQ(ifs.body.size(), 1);
+    std::get<MkdirStmt>(ifs.body[0]->data);
+}
+
+TEST(ParserTest, IfEmptyBody) {
+    auto program = parse_program(
+        "if use_tests\n"
+        "end\n");
+    auto& ifs = std::get<IfStmt>(program.statements[0]->data);
+    EXPECT_TRUE(ifs.body.empty());
+}
+
+TEST(ParserTest, IfMultipleBodyStatements) {
+    auto program = parse_program(
+        "if use_tests\n"
+        "  mkdir \"tests\"\n"
+        "  file \"tests/README.md\" content \"hi\"\n"
+        "end\n");
+    auto& ifs = std::get<IfStmt>(program.statements[0]->data);
+    EXPECT_EQ(ifs.body.size(), 2u);
+}
+
+TEST(ParserTest, IfNestedInsideIf) {
+    auto program = parse_program(
+        "if use_tests\n"
+        "  if use_smoke_tests\n"
+        "    mkdir \"tests/smoke\"\n"
+        "  end\n"
+        "end\n");
+    auto& outer = std::get<IfStmt>(program.statements[0]->data);
+    ASSERT_EQ(outer.body.size(), 1u);
+    auto& inner = std::get<IfStmt>(outer.body[0]->data);
+    EXPECT_EQ(inner.body.size(), 1u);
+}
+
+TEST(ParserTest, IfNestedInsideRepeat) {
+    auto program = parse_program(
+        "repeat n as i\n"
+        "  if use_tests\n"
+        "    mkdir \"tests/{i}\"\n"
+        "  end\n"
+        "end\n");
+    auto& rep = std::get<RepeatStmt>(program.statements[0]->data);
+    ASSERT_EQ(rep.body.size(), 1u);
+    std::get<IfStmt>(rep.body[0]->data);
+}
+
+TEST(ParserTest, IfWithComplexCondition) {
+    auto program = parse_program(
+        "if a and b\n"
+        "  mkdir \"x\"\n"
+        "end\n");
+    auto& ifs = std::get<IfStmt>(program.statements[0]->data);
+    auto& bin = std::get<BinaryExpr>(ifs.condition->data);
+    EXPECT_EQ(bin.op, TokenType::AND);
+}
+
+TEST(ParserTest, IfRejectsWhenClause) {
+    try {
+        parse_program(
+            "if a when b\n"
+            "  mkdir \"x\"\n"
+            "end\n");
+        FAIL() << "expected ParseError";
+    } catch (const ParseError& e) {
+        EXPECT_NE(std::string(e.what()).find(
+                      "'if' does not take a 'when' clause"),
+                  std::string::npos);
+    }
+}
+
+TEST(ParserTest, IfKeywordCannotBeIdentifier) {
+    EXPECT_THROW(parse_program("let if = 0\n"), ParseError);
 }
 
 TEST(ParserTest, RepeatWithoutWhenClauseHasEmptyOptional) {

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -223,12 +223,19 @@ bool stmts_equal(const Stmt& a, const Stmt& b) {
                     return false;
                 }
                 return av.line == bv.line && av.column == bv.column;
-            } else {
-                static_assert(std::is_same_v<T, RunStmt>);
+            } else if constexpr (std::is_same_v<T, RunStmt>) {
                 if (!ptr_expr_equal(av.command, bv.command)) return false;
                 if (!optional_path_expr_equal(av.cwd, bv.cwd)) return false;
                 if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
                     return false;
+                }
+                return av.line == bv.line && av.column == bv.column;
+            } else {
+                static_assert(std::is_same_v<T, IfStmt>);
+                if (!ptr_expr_equal(av.condition, bv.condition)) return false;
+                if (av.body.size() != bv.body.size()) return false;
+                for (std::size_t i = 0; i < av.body.size(); ++i) {
+                    if (!stmts_equal(*av.body[i], *bv.body[i])) return false;
                 }
                 return av.line == bv.line && av.column == bv.column;
             }

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -213,6 +213,60 @@ TEST(ValidatorTest, DefaultExprReferencingPriorBindingPasses) {
     EXPECT_NO_THROW(validate(program));
 }
 
+// --- if block ---
+
+TEST(ValidatorTest, IfBlockBodyValidates) {
+    auto program = parse(
+        "ask use_x \"Use X?\" bool\n"
+        "if use_x\n"
+        "  mkdir \"x\"\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, IfShadowingOuterIsError) {
+    auto program = parse(
+        "ask use_x \"Use X?\" bool\n"
+        "let x = 1\n"
+        "if use_x\n"
+        "  let x = 2\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, LetInsideIfNotVisibleOutside) {
+    auto program = parse(
+        "ask use_x \"Use X?\" bool\n"
+        "if use_x\n"
+        "  let x = 1\n"
+        "end\n"
+        "let y = x\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AskInsideIfWithoutDefaultPasses) {
+    // The if block gates the ask structurally; without an inner when_clause
+    // the rule from #59 does not fire.
+    auto program = parse(
+        "ask use_x \"Use X?\" bool\n"
+        "if use_x\n"
+        "  ask name \"Name?\" string\n"
+        "end\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, AskInsideIfWithInnerWhenStillRequiresDefault) {
+    // The inner when can be false while the outer if is true, so the bug
+    // shape from #59 still applies. Section A's rule must still fire.
+    auto program = parse(
+        "ask use_x \"Use X?\" bool\n"
+        "ask use_y \"Use Y?\" bool\n"
+        "if use_x\n"
+        "  ask name \"Name?\" string when use_y\n"
+        "end\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
 // --- Scope stack tests ---
 
 TEST(ValidatorTest, LetInsideRepeatReferencedOutsideIsError) {


### PR DESCRIPTION
## Summary

Adds an `if <condition> ... end` block so groups of related actions can share a single gate, instead of repeating the same `when` clause on every line. Closes #60.

## Changes

- New `if` keyword and AST node, mirroring `repeat` minus the iterator and the loop. `else`/`else if` deferred.
- Parser rejects a `when` clause on the `if` itself with a clear diagnostic - the `if` is the gate. Inner statements may still carry their own `when`.
- Validator walks the body in a fresh scope: `let` and `as` declared inside are local to the block, with the same shadowing rules as `repeat`.
- Interpreter evaluates the condition (must be bool at runtime) and only executes the body when it is true. `repeat_depth_` is not bumped, so prompts inside an `if` are not extra-indented and the iteration counter is unaffected.
- Bundler walks the body so assets referenced inside an `if` are still bundled.
- Binary serialiser gets a new `StmtTag::If = 9`; the `static_assert` on the variant arity is bumped accordingly. Round-trip tests cover plain and nested-in-repeat shapes.
- Doc note in `docs/syntax.md` describes the block, scoping, and the inner-`when`-still-needs-default rule.

## Test plan

- `ctest --test-dir build` passes (643 tests, 21 new).
- Parser tests cover empty body, single body, nested if, nested repeat-in-if, complex condition, rejection of `when` on the if itself, and rejection of `if` as an identifier.
- Validator tests cover shadowing, let-not-visible-outside, ask-without-default-in-if accepted, ask-with-inner-when-without-default-in-if still rejected.
- Interpreter tests cover true/false branches, runtime non-bool condition error, nested if-in-repeat directory creation, false-if-doesn't-prompt-inner-ask, and let-not-visible-after-end.
- Serialiser tests round-trip a plain `if` and an `if` inside a `repeat`.