### PR TITLE
feat: bare-identifier and quoted path segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ ask license "License?" string default "MIT"
 
 let slug = lower(trim(project_name))
 
-mkdir {slug} as project
-mkdir project/src
-mkdir project/tests when use_tests
+mkdir "{slug}" as project
+mkdir project/"src"
+mkdir project/"tests" when use_tests
 
-file project/README.md content "# " + project_name
-file project/src/main.cpp from templates/main.cpp
-file project/tests/test_main.cpp from templates/test_main.cpp when use_tests
+file project/"README.md" content "# " + project_name
+file project/"src/main.cpp" from "templates/main.cpp"
+file project/"tests/test_main.cpp" from "templates/test_main.cpp" when use_tests
 ```
 
 Spudlang supports questions with defaults and option lists, derived variables, conditional actions, path aliases, loops, and including other installed templates. See the [language reference](https://spuddydev.github.io/spudplate/) for the full syntax.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,8 +39,8 @@ Create `hello.spud`:
 ```
 ask name "Your name?" string
 
-mkdir hello as dir
-file dir/greeting.txt content "Hello, " + name + "!\n"
+mkdir "hello" as dir
+file dir/"greeting.txt" content "Hello, " + name + "!\n"
 ```
 
 Three things are happening here:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,13 +32,13 @@ ask license "License?" string default "MIT"
 
 let slug = lower(trim(project_name))
 
-mkdir {slug} as project
-mkdir project/src
-mkdir project/tests when use_tests
+mkdir "{slug}" as project
+mkdir project/"src"
+mkdir project/"tests" when use_tests
 
-file project/README.md content "# " + project_name
-file project/src/main.cpp from templates/main.cpp
-file project/tests/test_main.cpp from templates/test_main.cpp when use_tests
+file project/"README.md" content "# " + project_name
+file project/"src/main.cpp" from "templates/main.cpp"
+file project/"tests/test_main.cpp" from "templates/test_main.cpp" when use_tests
 ```
 
 Read the [syntax reference](syntax.md) for the rest.

--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -103,35 +103,45 @@ Reassignment to an outer-scope `let` from inside a `repeat` body mutates the out
 
 ### Path expressions
 
-Paths in `mkdir`, `file`, and `copy` are written as **path expressions** - an unquoted sequence of identifiers, slashes, dots, hyphens, and `{expr}` interpolations.
+Paths in `mkdir`, `file`, and `copy` are written as a slash-separated sequence of segments. Each segment is one of:
+
+- A **bare identifier**, which is always a variable reference. It must resolve to a path alias (declared with `as`) or a `let`-bound string. Unresolved identifiers are rejected at validate time - quote the segment if you wanted a literal directory name.
+- A **quoted string**, which is a literal segment. Quoted strings may contain `/` (a single quoted token contributes one or more components, split on the slashes) and may contain `{var}` interpolation.
 
 ```
-mkdir static/notes
-file static/notes/README.md content ""
-mkdir week_{n}
-mkdir my-project/pre-commit-hooks
-file src/main.cpp from base/main.cpp
+mkdir "static/notes"
+file "static/notes/README.md" content ""
+mkdir "week_{n}"
+mkdir "my-project/pre-commit-hooks"
+file "src/main.cpp" from "base/main.cpp"
 ```
 
-Hyphens are allowed inside a path but cannot start one - `mkdir -foo` would be ambiguous with the subtraction operator and is rejected. Paths containing spaces must be quoted: `mkdir "my notes"`.
-
-`{expr}` interpolation works directly in unquoted paths: `mkdir week_{n}`, `file {prefix}/README.md`.
+`{var}` interpolation only works inside quoted segments. Bare `{var}` in a path is a parse error.
 
 `mkdir` creates intermediate directories automatically (`mkdir -p` semantics).
 
 #### Path aliases with as
 
-The `as <varname>` clause binds the path to a variable for reuse. Any identifier in a subsequent path expression is checked against bound aliases - if it matches, it is a variable reference; if not, it is a literal path component. This applies to every segment, not just the leading one:
+The `as <varname>` clause on `mkdir` or `file` binds the path to a name for reuse later. The bare-identifier path segment then resolves to that name:
 
 ```
-mkdir static as staticpath
-mkdir notes as notespath
-mkdir staticpath/notespath/week_{n}    # both staticpath and notespath are alias references
+mkdir "static" as staticpath
+mkdir "notes" as notespath
+mkdir staticpath/notespath/"week_{n}"  # both staticpath and notespath resolve as aliases
 ```
 
 On `file`, `as` binds the file path - primarily useful for conditional appends (see `file` below).
 
-If a path segment matches a bound alias but you want the literal directory name instead, quote that segment: `mkdir "staticpath"/notes`.
+#### let-bound strings as path roots
+
+A `let`-bound string can be used as a bare-identifier path segment too. The whole value is appended verbatim, so a let value containing slashes contributes multiple directory levels in a single segment:
+
+```
+let dir = "team/projects"
+mkdir dir/"alpha"   # creates team/projects/alpha
+```
+
+This differs from a quoted literal, which is split on `/` at parse time. Bundling treats let-bound roots as fully dynamic - only quoted literals contribute to the static prefix the bundler walks at install time.
 
 ##### Conditional alias scoping
 

--- a/include/spudplate/parser.h
+++ b/include/spudplate/parser.h
@@ -3,7 +3,7 @@
 
 #include <stdexcept>
 #include <string>
-#include <unordered_set>
+#include <vector>
 
 #include "spudplate/ast.h"
 #include "spudplate/lexer.h"
@@ -79,7 +79,6 @@ class Parser {
   private:
     Lexer lexer_;
     Token current_;
-    std::unordered_set<std::string> aliases_;  ///< Names bound by `as <name>` in prior statements.
 
     // Token consumption
     Token advance();
@@ -93,6 +92,8 @@ class Parser {
     std::optional<ExprPtr> parse_when_clause();
     std::optional<int> parse_mode_clause();
     PathExpr parse_path_expr();
+    void push_quoted_path_segments(const std::string& raw, int line, int column,
+                                   std::vector<PathSegment>& out);
     ExprPtr parse_literal();
     /**
      * Build the AST node for a string literal token. If the raw value

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -19,16 +19,19 @@ namespace {
 
 // Result of classifying a source PathExpr. The bundler distinguishes the
 // two legal shapes - a fully-literal path (walk the exact target) and a
-// path with a static prefix that ends in `/` followed by dynamic segments
-// (walk the static-prefix directory). Anything else is a BundleError.
+// path whose leading run of literal segments is followed by one or more
+// dynamic segments (walk the static-prefix directory). The split-on-`/`
+// parser keeps separators out of segment values, so the prefix is built by
+// joining leading PathLiterals with `/` and appending a trailing `/` once
+// a dynamic segment is encountered.
 struct ClassifiedSource {
     enum class Shape {
         Static,        ///< Every segment is a PathLiteral.
         StaticPrefix,  ///< Some segments are dynamic; the literal prefix
-                       ///< ends with `/`.
+                       ///< covers entire path components and ends with `/`.
     };
     Shape shape;
-    std::string literal_prefix;  ///< Concatenated leading PathLiteral values.
+    std::string literal_prefix;  ///< Joined leading PathLiteral values.
 };
 
 ClassifiedSource classify_source_path(const PathExpr& path) {
@@ -44,21 +47,24 @@ ClassifiedSource classify_source_path(const PathExpr& path) {
     std::string literal;
     bool has_dynamic = false;
     for (const auto& seg : path.segments) {
-        if (has_dynamic) break;
         if (std::holds_alternative<PathLiteral>(seg)) {
+            if (!literal.empty()) {
+                literal.push_back('/');
+            }
             literal.append(std::get<PathLiteral>(seg).value);
         } else {
             has_dynamic = true;
+            break;
         }
     }
 
     if (!has_dynamic) {
         return {ClassifiedSource::Shape::Static, std::move(literal)};
     }
-    if (literal.empty() || literal.back() != '/') {
-        throw BundleError(
-            "dynamic segment must follow a '/'", path.line, path.column);
-    }
+    // Append the trailing `/` that separates the static prefix from the
+    // first dynamic segment. The split-on-`/` parser keeps separators out
+    // of segment values, so we synthesise the boundary here.
+    literal.push_back('/');
     return {ClassifiedSource::Shape::StaticPrefix, std::move(literal)};
 }
 

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -571,7 +571,12 @@ std::string preview_expr(const Expr& expr) {
 // by the trust prompt to surface the `in <path>` clause on `run` statements.
 std::string preview_path(const PathExpr& path) {
     std::string out;
+    bool first = true;
     for (const auto& seg : path.segments) {
+        if (!first) {
+            out += '/';
+        }
+        first = false;
         std::visit(
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
@@ -1610,20 +1615,38 @@ Value evaluate_expr(const Expr& expr, const Environment& env) {
 std::string evaluate_path(const PathExpr& path, const Environment& env,
                           const AliasMap& aliases) {
     std::string out;
+    bool first = true;
     for (const auto& seg : path.segments) {
+        if (!first) {
+            out += '/';
+        }
+        first = false;
         std::visit(
             [&](const auto& s) {
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, PathLiteral>) {
                     out += s.value;
                 } else if constexpr (std::is_same_v<T, PathVar>) {
-                    auto it = aliases.find(s.name);
-                    if (it == aliases.end()) {
-                        throw RuntimeError(
-                            "internal error: unbound path alias '" + s.name + "'",
-                            s.line, s.column);
+                    auto alias_it = aliases.find(s.name);
+                    if (alias_it != aliases.end()) {
+                        out += alias_it->second;
+                        return;
                     }
-                    out += it->second;
+                    auto bound = env.lookup(s.name);
+                    if (bound.has_value()) {
+                        if (!std::holds_alternative<std::string>(*bound)) {
+                            throw RuntimeError(
+                                "path identifier '" + s.name +
+                                    "' must be a string",
+                                s.line, s.column);
+                        }
+                        out += std::get<std::string>(*bound);
+                        return;
+                    }
+                    throw RuntimeError(
+                        "internal: unresolved path identifier '" + s.name +
+                            "'; validator should have caught this",
+                        s.line, s.column);
                 } else if constexpr (std::is_same_v<T, PathInterp>) {
                     out += value_to_string(evaluate_expr(*s.expression, env));
                 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -163,88 +163,87 @@ ExprPtr Parser::parse_literal() {
     throw ParseError("expected literal value", current_.line, current_.column);
 }
 
+// Splits the raw value of a quoted path string into one or more PathSegments.
+// Splits on `/` (top level only - `/` inside `{...}` is part of the
+// expression), drops empty pieces, and within each non-empty piece emits a
+// PathLiteral or, if `{var}` interpolations are present, a PathInterp wrapping
+// a TemplateStringExpr built from that piece.
+void Parser::push_quoted_path_segments(const std::string& raw, int line,
+                                       int column,
+                                       std::vector<PathSegment>& out) {
+    std::vector<std::string> pieces;
+    std::string current;
+    int depth = 0;
+    for (char c : raw) {
+        if (c == '{') {
+            ++depth;
+            current.push_back(c);
+        } else if (c == '}') {
+            if (depth > 0) {
+                --depth;
+            }
+            current.push_back(c);
+        } else if (c == '/' && depth == 0) {
+            pieces.push_back(std::move(current));
+            current.clear();
+        } else {
+            current.push_back(c);
+        }
+    }
+    pieces.push_back(std::move(current));
+
+    for (auto& piece : pieces) {
+        if (piece.empty()) {
+            continue;
+        }
+        if (piece.find('{') == std::string::npos) {
+            out.push_back(PathLiteral{
+                .value = std::move(piece), .line = line, .column = column});
+            continue;
+        }
+        ExprPtr expr = make_string_expression(piece, line, column);
+        out.push_back(PathInterp{
+            .expression = std::move(expr), .line = line, .column = column});
+    }
+}
+
 PathExpr Parser::parse_path_expr() {
     PathExpr path;
     path.line = current_.line;
     path.column = current_.column;
 
-    // Quoted-string fallback for paths with spaces: `mkdir "my notes"`
-    if (check(TokenType::STRING_LITERAL)) {
-        Token tok = advance();
-        path.segments.push_back(
-            PathLiteral{.value = tok.value, .line = tok.line, .column = tok.column});
-        return path;
-    }
-
-    // Unquoted path: greedily consume IDENTIFIER / SLASH / DOT / INTEGER_LITERAL
-    // and `{expr}` interpolation blocks. Adjacent non-alias, non-interpolation
-    // tokens coalesce into a single PathLiteral via a text buffer.
-    std::string buffer;
-    int buf_line = 0;
-    int buf_col = 0;
-
-    auto flush_buffer = [&]() {
-        if (!buffer.empty()) {
-            path.segments.push_back(PathLiteral{
-                .value = std::move(buffer), .line = buf_line, .column = buf_col});
-            buffer.clear();
+    auto consume_segment = [&]() -> bool {
+        if (check(TokenType::STRING_LITERAL)) {
+            Token tok = advance();
+            push_quoted_path_segments(tok.value, tok.line, tok.column, path.segments);
+            return true;
         }
-    };
-
-    auto start_buffer = [&](int line, int col) {
-        if (buffer.empty()) {
-            buf_line = line;
-            buf_col = col;
-        }
-    };
-
-    while (true) {
         if (check(TokenType::IDENTIFIER)) {
             Token tok = advance();
-            if (aliases_.contains(tok.value)) {
-                flush_buffer();
-                path.segments.push_back(
-                    PathVar{.name = tok.value, .line = tok.line, .column = tok.column});
-            } else {
-                start_buffer(tok.line, tok.column);
-                buffer += tok.value;
-            }
-        } else if (check(TokenType::SLASH)) {
-            start_buffer(current_.line, current_.column);
-            buffer += '/';
-            advance();
-        } else if (check(TokenType::DOT)) {
-            start_buffer(current_.line, current_.column);
-            buffer += '.';
-            advance();
-        } else if (check(TokenType::INTEGER_LITERAL)) {
-            Token tok = advance();
-            start_buffer(tok.line, tok.column);
-            buffer += tok.value;
-        } else if (check(TokenType::MINUS)) {
-            // Interior `-` is part of the path (e.g. `my-project`). Reject a
-            // leading `-` so `mkdir -foo` is not confused with subtraction.
-            if (buffer.empty() && path.segments.empty()) {
-                break;
-            }
-            start_buffer(current_.line, current_.column);
-            buffer += '-';
-            advance();
-        } else if (check(TokenType::LBRACE)) {
-            int line = current_.line;
-            int col = current_.column;
-            advance();
-            flush_buffer();
-            auto expr = parseExpression();
-            expect(TokenType::RBRACE, "expected '}' to close path interpolation");
-            path.segments.push_back(PathInterp{
-                .expression = std::move(expr), .line = line, .column = col});
-        } else {
-            break;
+            path.segments.push_back(
+                PathVar{.name = tok.value, .line = tok.line, .column = tok.column});
+            return true;
         }
+        return false;
+    };
+
+    if (check(TokenType::LBRACE)) {
+        throw ParseError(
+            "'{...}' interpolation is only allowed inside quoted path strings",
+            current_.line, current_.column);
     }
 
-    flush_buffer();
+    if (!consume_segment()) {
+        throw ParseError("expected path expression", current_.line, current_.column);
+    }
+
+    while (check(TokenType::SLASH)) {
+        advance();
+        if (!consume_segment()) {
+            throw ParseError("expected path segment after '/'", current_.line,
+                             current_.column);
+        }
+    }
 
     if (path.segments.empty()) {
         throw ParseError("expected path expression", current_.line, current_.column);
@@ -379,7 +378,6 @@ StmtPtr Parser::parseMkdir() {
     if (match(TokenType::AS)) {
         Token alias_tok = expect(TokenType::IDENTIFIER, "expected alias name after 'as'");
         alias = alias_tok.value;
-        aliases_.insert(*alias);
     }
 
     expect_newline("mkdir statement");
@@ -424,7 +422,6 @@ StmtPtr Parser::parseFile() {
     if (match(TokenType::AS)) {
         Token alias_tok = expect(TokenType::IDENTIFIER, "expected alias name after 'as'");
         alias = alias_tok.value;
-        aliases_.insert(*alias);
     }
 
     expect_newline("file statement");

--- a/src/validator.cpp
+++ b/src/validator.cpp
@@ -170,6 +170,91 @@ void check_alias(const PathVar& pv, const std::optional<ExprPtr>& current_when,
     }
 }
 
+// Best-effort static type inference for the right-hand side of `let`. Returns
+// nullopt when the expression type is not deducible from the static
+// information available (e.g. a chain through a let whose own type was
+// inscrutable). The validator's path-identifier check treats nullopt as
+// "string-compatible" so we never raise false negatives on opaque expressions.
+std::optional<VarType> infer_expr_type(const Expr& expr, const TypeMap& tm) {
+    return std::visit(
+        [&](const auto& e) -> std::optional<VarType> {
+            using T = std::decay_t<decltype(e)>;
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                return VarType::String;
+            } else if constexpr (std::is_same_v<T, TemplateStringExpr>) {
+                return VarType::String;
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                return VarType::Int;
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                return VarType::Bool;
+            } else if constexpr (std::is_same_v<T, IdentifierExpr>) {
+                auto it = tm.find(e.name);
+                if (it == tm.end()) {
+                    return std::nullopt;
+                }
+                return it->second;
+            } else if constexpr (std::is_same_v<T, UnaryExpr>) {
+                if (e.op == TokenType::NOT) {
+                    return VarType::Bool;
+                }
+                if (e.op == TokenType::MINUS) {
+                    return VarType::Int;
+                }
+                return std::nullopt;
+            } else if constexpr (std::is_same_v<T, BinaryExpr>) {
+                switch (e.op) {
+                    case TokenType::PLUS: {
+                        auto l = infer_expr_type(*e.left, tm);
+                        auto r = infer_expr_type(*e.right, tm);
+                        if (l == VarType::String || r == VarType::String) {
+                            return VarType::String;
+                        }
+                        if (l == VarType::Int && r == VarType::Int) {
+                            return VarType::Int;
+                        }
+                        return std::nullopt;
+                    }
+                    case TokenType::MINUS:
+                    case TokenType::STAR:
+                    case TokenType::SLASH:
+                        return VarType::Int;
+                    case TokenType::EQUALS:
+                    case TokenType::NOT_EQUALS:
+                    case TokenType::LESS:
+                    case TokenType::GREATER:
+                    case TokenType::LESS_EQUAL:
+                    case TokenType::GREATER_EQUAL:
+                    case TokenType::AND:
+                    case TokenType::OR:
+                        return VarType::Bool;
+                    default:
+                        return std::nullopt;
+                }
+            } else if constexpr (std::is_same_v<T, FunctionCallExpr>) {
+                if (e.name == "lower" || e.name == "upper" || e.name == "trim" ||
+                    e.name == "replace") {
+                    return VarType::String;
+                }
+                return std::nullopt;
+            }
+            return std::nullopt;
+        },
+        expr.data);
+}
+
+// Render a VarType for diagnostics.
+const char* var_type_name(VarType t) {
+    switch (t) {
+        case VarType::String:
+            return "string";
+        case VarType::Bool:
+            return "bool";
+        case VarType::Int:
+            return "int";
+    }
+    return "unknown";
+}
+
 void walk_expr(const Expr& expr, const Scope& scope) {
     std::visit(
         [&](const auto& e) {
@@ -205,6 +290,27 @@ void walk_path(const PathExpr& path, const Scope& scope, const AliasCtx& ctx,
                 using T = std::decay_t<decltype(s)>;
                 if constexpr (std::is_same_v<T, PathVar>) {
                     check_reference(s.name, s.line, s.column, scope);
+                    // A path identifier must resolve to either a registered
+                    // path alias (declared via `as`) or a name whose static
+                    // type is `string`. Bare literal directory names must
+                    // be quoted to disambiguate.
+                    bool is_alias = ctx.registry.find(s.name) != ctx.registry.end();
+                    if (!is_alias) {
+                        auto it = ctx.type_map.find(s.name);
+                        if (it == ctx.type_map.end()) {
+                            throw SemanticError(
+                                "unresolved path identifier '" + s.name +
+                                    "' (use quotes for a literal directory name)",
+                                s.line, s.column);
+                        }
+                        if (it->second != VarType::String) {
+                            throw SemanticError(
+                                std::string("path identifier '") + s.name +
+                                    "' must be a string, got " +
+                                    var_type_name(it->second),
+                                s.line, s.column);
+                        }
+                    }
                     check_alias(s, current_when, ctx);
                 } else if constexpr (std::is_same_v<T, PathInterp>) {
                     walk_expr(*s.expression, scope);
@@ -274,6 +380,9 @@ void validate_stmt(const Stmt& stmt, Scope& scope, AliasCtx& ctx) {
                 walk_expr(*s.value, scope);
                 check_shadowing(s.name, s.line, s.column, scope);
                 scope.declare_mutable(s.name);
+                if (auto t = infer_expr_type(*s.value, ctx.type_map)) {
+                    ctx.type_map[s.name] = *t;
+                }
             } else if constexpr (std::is_same_v<T, AssignStmt>) {
                 walk_expr(*s.value, scope);
                 if (!scope.visible(s.name)) {

--- a/tests/bundler_test.cpp
+++ b/tests/bundler_test.cpp
@@ -52,7 +52,7 @@ const SpudpackAsset* find_asset(const BundleResult& r, const std::string& path) 
 TEST(Bundler, FileFromRegularFile) {
     TmpDir tmp;
     write_file(tmp.path() / "tpl/main.cpp", "int main() {}\n");
-    Program p = parse("file out/main.cpp from tpl/main.cpp\n");
+    Program p = parse("file \"out/main.cpp\" from \"tpl/main.cpp\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     ASSERT_EQ(r.assets.size(), 1u);
@@ -65,7 +65,7 @@ TEST(Bundler, MkdirFromDirectoryWalksTree) {
     TmpDir tmp;
     write_file(tmp.path() / "src/main.cpp", "x\n");
     write_file(tmp.path() / "src/util/util.cpp", "y\n");
-    Program p = parse("mkdir project from src\n");
+    Program p = parse("mkdir \"project\" from \"src\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_NE(find_asset(r, "src/main.cpp"), nullptr);
@@ -76,7 +76,7 @@ TEST(Bundler, CopySourceMustBeDirectory) {
     TmpDir tmp;
     write_file(tmp.path() / "regular.txt", "x\n");
     fs::create_directories(tmp.path() / "dst");
-    Program p = parse("copy regular.txt into dst\n");
+    Program p = parse("copy \"regular.txt\" into \"dst\"\n");
 
     EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
 }
@@ -86,7 +86,7 @@ TEST(Bundler, CopyDirectoryWalks) {
     write_file(tmp.path() / "snippets/a.txt", "a\n");
     write_file(tmp.path() / "snippets/b.txt", "b\n");
     fs::create_directories(tmp.path() / "dst");
-    Program p = parse("copy snippets into dst\n");
+    Program p = parse("copy \"snippets\" into \"dst\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_NE(find_asset(r, "snippets/a.txt"), nullptr);
@@ -99,7 +99,7 @@ TEST(Bundler, RepeatBodyIsWalked) {
     Program p = parse(
         "ask weeks \"How many?\" int default 1\n"
         "repeat weeks as i\n"
-        "  file out_{i}/body.txt from wk/body.txt\n"
+        "  file \"out_{i}/body.txt\" from \"wk/body.txt\"\n"
         "end\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
@@ -113,7 +113,7 @@ TEST(Bundler, NonAssetStatementsAreSkipped) {
         "let upper_name = upper(name)\n"
         "include foo when name == \"x\"\n"
         "run \"echo hi\"\n"
-        "file inline.txt content \"hi\"\n");
+        "file \"inline.txt\" content \"hi\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_TRUE(r.assets.empty());
@@ -125,7 +125,7 @@ TEST(Bundler, RejectsLeadingDynamicSegment) {
     TmpDir tmp;
     Program p = parse(
         "ask name \"Name?\" string\n"
-        "file out.txt from {name}/foo\n");
+        "file \"out.txt\" from \"{name}/foo\"\n");
     try {
         bundle_assets(p, tmp.path());
         FAIL() << "expected throw";
@@ -135,24 +135,13 @@ TEST(Bundler, RejectsLeadingDynamicSegment) {
     }
 }
 
-TEST(Bundler, RejectsDynamicSegmentMidFilename) {
-    TmpDir tmp;
-    fs::create_directories(tmp.path() / "tpl");
-    Program p = parse(
-        "ask n \"n?\" int default 1\n"
-        "file out.txt from tpl/file_{n}\n");
-    // tpl/file_{n} - the literal prefix "tpl/file_" does not end with /,
-    // so this is the mid-filename-dynamic case.
-    EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
-}
-
 TEST(Bundler, AcceptsDynamicSuffixAfterTrailingSlash) {
     TmpDir tmp;
     write_file(tmp.path() / "tpl/a.txt", "a\n");
     write_file(tmp.path() / "tpl/b.txt", "b\n");
     Program p = parse(
         "ask choice \"choice?\" string default \"a.txt\"\n"
-        "file out.txt from tpl/{choice}\n");
+        "file \"out.txt\" from \"tpl/{choice}\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_NE(find_asset(r, "tpl/a.txt"), nullptr);
@@ -164,7 +153,7 @@ TEST(Bundler, AcceptsDynamicSuffixAfterTrailingSlash) {
 TEST(Bundler, EmptyLeafDirRecorded) {
     TmpDir tmp;
     fs::create_directories(tmp.path() / "scaffold/logs");  // no files
-    Program p = parse("mkdir project from scaffold\n");
+    Program p = parse("mkdir \"project\" from \"scaffold\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     const SpudpackAsset* a = find_asset(r, "scaffold/logs/");
@@ -175,7 +164,7 @@ TEST(Bundler, EmptyLeafDirRecorded) {
 TEST(Bundler, NestedEmptyOnlyDeepestRecorded) {
     TmpDir tmp;
     fs::create_directories(tmp.path() / "scaffold/a/b/c");  // chain of empties
-    Program p = parse("mkdir project from scaffold\n");
+    Program p = parse("mkdir \"project\" from \"scaffold\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_NE(find_asset(r, "scaffold/a/b/c/"), nullptr);
@@ -187,8 +176,8 @@ TEST(Bundler, DuplicateAssetsCollapseWhenIdentical) {
     TmpDir tmp;
     write_file(tmp.path() / "shared/body.txt", "same\n");
     Program p = parse(
-        "file out_a/body.txt from shared/body.txt\n"
-        "file out_b/body.txt from shared/body.txt\n");
+        "file \"out_a/body.txt\" from \"shared/body.txt\"\n"
+        "file \"out_b/body.txt\" from \"shared/body.txt\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_EQ(r.assets.size(), 1u);
@@ -200,7 +189,7 @@ TEST(Bundler, RejectsSourceOutsideRoot) {
     TmpDir tmp;
     fs::create_directories(tmp.path() / "child");
     write_file(tmp.path() / "sibling.txt", "x\n");
-    Program p = parse("file out.txt from ../sibling.txt\n");
+    Program p = parse("file \"out.txt\" from \"../sibling.txt\"\n");
 
     EXPECT_THROW(bundle_assets(p, tmp.path() / "child"), BundleError);
 }
@@ -212,7 +201,7 @@ TEST(Bundler, RejectsFifo) {
     if (mkfifo(fifo.c_str(), 0644) != 0) {
         GTEST_SKIP() << "mkfifo failed; skipping fifo rejection test";
     }
-    Program p = parse("mkdir project from src\n");
+    Program p = parse("mkdir \"project\" from \"src\"\n");
     EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
 }
 
@@ -225,7 +214,7 @@ TEST(Bundler, SymlinkToFileFollowed) {
     fs::create_symlink(tmp.path() / "real" / "file.txt",
                        tmp.path() / "tree" / "link.txt");
 
-    Program p = parse("mkdir project from tree\n");
+    Program p = parse("mkdir \"project\" from \"tree\"\n");
     BundleResult r = bundle_assets(p, tmp.path());
     const SpudpackAsset* a = find_asset(r, "tree/link.txt");
     ASSERT_NE(a, nullptr);
@@ -237,7 +226,7 @@ TEST(Bundler, SymlinkLoopBroken) {
     fs::create_directories(tmp.path() / "loop/a");
     fs::create_directory_symlink(tmp.path() / "loop", tmp.path() / "loop/a/back");
 
-    Program p = parse("mkdir project from loop\n");
+    Program p = parse("mkdir \"project\" from \"loop\"\n");
     // Should not infinite-recurse. The walker may produce zero assets (only
     // the dir loop) or report an error - either way it must terminate.
     try {

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -118,7 +118,7 @@ class Argv {
 TEST(CliTest, RunSuccessExitsZero) {
     TmpDir td;
     auto file = td.path() / "ok.spud";
-    write_file(file, "ask name \"Project name?\" string\nmkdir {name}\n");
+    write_file(file, "ask name \"Project name?\" string\nmkdir \"{name}\"\n");
     Argv args({"spudplate", "run", file.string()});
     std::stringstream out;
     std::stringstream err;
@@ -161,7 +161,7 @@ TEST(CliTest, RuntimeErrorExitsFour) {
     auto file = td.path() / "runtime.spud";
     // `mkdir from` looks up `base` in the cwd; with no such directory the
     // walker raises a runtime error.
-    write_file(file, "mkdir foo from base\n");
+    write_file(file, "mkdir \"foo\" from \"base\"\n");
     Argv args({"spudplate", "run", file.string()});
     std::stringstream out;
     std::stringstream err;
@@ -195,7 +195,7 @@ TEST(CliTest, NoArgumentsExitsOne) {
 TEST(CliTest, DryRunPrintsTreeAndDoesNotWrite) {
     TmpDir td;
     auto file = td.path() / "ok.spud";
-    write_file(file, "mkdir my_project\nfile my_project/README.md content \"hi\"\n");
+    write_file(file, "mkdir \"my_project\"\nfile \"my_project/README.md\" content \"hi\"\n");
     Argv args({"spudplate", "run", "--dry-run", file.string()});
     std::stringstream out;
     std::stringstream err;
@@ -295,7 +295,7 @@ TEST(CliTest, InstallSuccessStoresTemplate) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "ask name \"Project name?\" string\nmkdir {name}\n");
+    write_file(src, "ask name \"Project name?\" string\nmkdir \"{name}\"\n");
     Argv args({"spudplate", "install", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -311,7 +311,7 @@ TEST(CliTest, InstallWithYesOverwritesExisting) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir foo\n");
+    write_file(src, "mkdir \"foo\"\n");
     {
         Argv args({"spudplate", "install", src.string()});
         std::stringstream o;
@@ -320,7 +320,7 @@ TEST(CliTest, InstallWithYesOverwritesExisting) {
         ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
     }
     // Rewrite the source so we can detect that the new content landed.
-    write_file(src, "mkdir bar\n");
+    write_file(src, "mkdir \"bar\"\n");
     Argv args({"spudplate", "install", "--yes", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -329,7 +329,7 @@ TEST(CliTest, InstallWithYesOverwritesExisting) {
     EXPECT_EQ(code, 0) << err.str();
     EXPECT_NE(out.str().find("reinstalled demo"), std::string::npos);
     spudplate::Spudpack pack = spudplate::spudpack_read_file(home / "demo.spp");
-    EXPECT_EQ(pack.source, "mkdir bar\n");
+    EXPECT_EQ(pack.source, "mkdir \"bar\"\n");
 }
 
 TEST(CliTest, InstallDeclinedPromptLeavesExistingUnchanged) {
@@ -337,7 +337,7 @@ TEST(CliTest, InstallDeclinedPromptLeavesExistingUnchanged) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir foo\n");
+    write_file(src, "mkdir \"foo\"\n");
     {
         Argv args({"spudplate", "install", src.string()});
         std::stringstream o;
@@ -347,7 +347,7 @@ TEST(CliTest, InstallDeclinedPromptLeavesExistingUnchanged) {
     }
     // No `--yes` and no stdin available - confirm() returns false and the
     // command aborts cleanly with exit 0.
-    write_file(src, "mkdir bar\n");
+    write_file(src, "mkdir \"bar\"\n");
     Argv args({"spudplate", "install", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -356,7 +356,7 @@ TEST(CliTest, InstallDeclinedPromptLeavesExistingUnchanged) {
     EXPECT_EQ(code, 0);
     EXPECT_NE(out.str().find("aborted"), std::string::npos);
     spudplate::Spudpack pack = spudplate::spudpack_read_file(home / "demo.spp");
-    EXPECT_EQ(pack.source, "mkdir foo\n");
+    EXPECT_EQ(pack.source, "mkdir \"foo\"\n");
 }
 
 TEST(CliTest, InstallRejectsBrokenTemplateAndLeavesNoTrace) {
@@ -382,7 +382,7 @@ TEST(CliTest, InstallUsesXdgDataHomeWhenNoSpudplateHome) {
     auto xdg_root = td.path() / "xdg";
     xdg.set(xdg_root.string());
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir foo\n");
+    write_file(src, "mkdir \"foo\"\n");
     Argv args({"spudplate", "install", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -413,7 +413,7 @@ TEST(CliTest, RunByNameLooksUpInstalledTemplate) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "ask name \"Project name?\" string\nmkdir {name}\n");
+    write_file(src, "ask name \"Project name?\" string\nmkdir \"{name}\"\n");
     {
         Argv install_args({"spudplate", "install", src.string()});
         std::stringstream o;
@@ -473,8 +473,8 @@ TEST(CliTest, ListShowsInstalledNamesSorted) {
     TmpDir td;
     auto home = td.path() / "home";
     ScopedHome scoped(home);
-    install_template(td.path() / "zebra.spud", "mkdir z\n");
-    install_template(td.path() / "alpha.spud", "mkdir a\n");
+    install_template(td.path() / "zebra.spud", "mkdir \"z\"\n");
+    install_template(td.path() / "alpha.spud", "mkdir \"a\"\n");
     Argv args({"spudplate", "list"});
     std::stringstream out;
     std::stringstream err;
@@ -488,7 +488,7 @@ TEST(CliTest, InspectPrintsSource) {
     TmpDir td;
     auto home = td.path() / "home";
     ScopedHome scoped(home);
-    const std::string body = "mkdir hello\n";
+    const std::string body = "mkdir \"hello\"\n";
     install_template(td.path() / "demo.spud", body);
     Argv args({"spudplate", "inspect", "demo"});
     std::stringstream out;
@@ -515,7 +515,7 @@ TEST(CliTest, UninstallRemovesTemplate) {
     TmpDir td;
     auto home = td.path() / "home";
     ScopedHome scoped(home);
-    install_template(td.path() / "demo.spud", "mkdir x\n");
+    install_template(td.path() / "demo.spud", "mkdir \"x\"\n");
     ASSERT_TRUE(std::filesystem::is_regular_file(home / "demo.spp"));
     Argv args({"spudplate", "uninstall", "demo"});
     std::stringstream out;
@@ -531,7 +531,7 @@ TEST(CliTest, UninstallRemovesTemplate) {
 TEST(CliTest, ValidateOkExitsZero) {
     TmpDir td;
     auto src = td.path() / "ok.spud";
-    write_file(src, "ask name \"Project name?\" string\nmkdir {name}\n");
+    write_file(src, "ask name \"Project name?\" string\nmkdir \"{name}\"\n");
     Argv args({"spudplate", "validate", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -544,7 +544,7 @@ TEST(CliTest, ValidateOkExitsZero) {
 TEST(CliTest, CheckIsAliasForValidate) {
     TmpDir td;
     auto src = td.path() / "ok.spud";
-    write_file(src, "mkdir foo\n");
+    write_file(src, "mkdir \"foo\"\n");
     Argv args({"spudplate", "check", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -574,7 +574,7 @@ TEST(CliTest, ValidateSemanticErrorExitsThree) {
                "repeat n as i\n"
                "  let local = 0\n"
                "end\n"
-               "mkdir {local}\n");
+               "mkdir \"{local}\"\n");
     Argv args({"spudplate", "validate", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -673,7 +673,7 @@ TEST(CliTest, InstallProducesValidSpudpack) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir foo\n");
+    write_file(src, "mkdir \"foo\"\n");
     Argv args({"spudplate", "install", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -682,7 +682,7 @@ TEST(CliTest, InstallProducesValidSpudpack) {
         << err.str();
     spudplate::Spudpack pack =
         spudplate::spudpack_read_file(home / "demo.spp");
-    EXPECT_EQ(pack.source, "mkdir foo\n");
+    EXPECT_EQ(pack.source, "mkdir \"foo\"\n");
     EXPECT_FALSE(pack.program_bytes.empty());
 }
 
@@ -720,7 +720,7 @@ TEST(CliTest, RunByNameOnLegacyOnlyAsksForReinstall) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     std::filesystem::create_directories(home / "legacy");
-    write_file(home / "legacy" / "template.spud", "mkdir x\n");
+    write_file(home / "legacy" / "template.spud", "mkdir \"x\"\n");
 
     Argv args({"spudplate", "run", "legacy"});
     std::stringstream out;
@@ -737,7 +737,7 @@ TEST(CliTest, UninstallRemovesLegacyDirectory) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     std::filesystem::create_directories(home / "legacy");
-    write_file(home / "legacy" / "template.spud", "mkdir x\n");
+    write_file(home / "legacy" / "template.spud", "mkdir \"x\"\n");
 
     Argv args({"spudplate", "uninstall", "legacy"});
     std::stringstream out;
@@ -780,10 +780,10 @@ TEST(CliTest, InstallYesRemovesLegacyDirectory) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     std::filesystem::create_directories(home / "demo");
-    write_file(home / "demo" / "template.spud", "mkdir old\n");
+    write_file(home / "demo" / "template.spud", "mkdir \"old\"\n");
 
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir new\n");
+    write_file(src, "mkdir \"new\"\n");
     Argv args({"spudplate", "install", "--yes", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -801,7 +801,7 @@ TEST(CliTest, InstallRejectsStrayDirectoryAtTarget) {
     std::filesystem::create_directories(home / "demo.spp");  // stray dir
 
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir x\n");
+    write_file(src, "mkdir \"x\"\n");
     Argv args({"spudplate", "install", "--yes", src.string()});
     std::stringstream out;
     std::stringstream err;
@@ -819,7 +819,7 @@ TEST(CliTest, InstallRenameFailureCleansUpTempFile) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir x\n");
+    write_file(src, "mkdir \"x\"\n");
 
     struct RenameGuard {
         spudplate::cli_internal::RenameFn prev;
@@ -853,7 +853,7 @@ TEST(CliTest, InspectPrintsSourceFromSpudpack) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    std::string body = "ask name \"Name?\" string\nmkdir {name}\n";
+    std::string body = "ask name \"Name?\" string\nmkdir \"{name}\"\n";
     write_file(src, body);
     {
         Argv args({"spudplate", "install", src.string()});
@@ -885,10 +885,10 @@ TEST(CliTest, InstallRunDeleteSourceMaterialisesAssets) {
                static_cast<std::streamsize>(bytes.size()));
     write_file(source_root / "tpl" / "main.txt", "hello\n");
     write_file(source_root / "demo.spud",
-               "mkdir out\n"
-               "mkdir out/assets\n"
-               "file out/main.txt from tpl/main.txt\n"
-               "file out/assets/logo.bin from assets/logo.bin\n");
+               "mkdir \"out\"\n"
+               "mkdir \"out/assets\"\n"
+               "file \"out/main.txt\" from \"tpl/main.txt\"\n"
+               "file \"out/assets/logo.bin\" from \"assets/logo.bin\"\n");
 
     auto home = source_td.path() / "home";
     ScopedHome scoped(home);
@@ -923,7 +923,7 @@ TEST(CliTest, ListWarnsAboutShadowedLegacy) {
     auto home = td.path() / "home";
     ScopedHome scoped(home);
     auto src = td.path() / "demo.spud";
-    write_file(src, "mkdir x\n");
+    write_file(src, "mkdir \"x\"\n");
     {
         Argv args({"spudplate", "install", src.string()});
         std::stringstream o, e;
@@ -932,7 +932,7 @@ TEST(CliTest, ListWarnsAboutShadowedLegacy) {
     }
     // Hand-craft a parallel legacy directory.
     std::filesystem::create_directories(home / "demo");
-    write_file(home / "demo" / "template.spud", "mkdir y\n");
+    write_file(home / "demo" / "template.spud", "mkdir \"y\"\n");
 
     Argv args({"spudplate", "list"});
     std::stringstream out;

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -535,7 +535,7 @@ TEST(EvalPathTest, PathVarFromAliasMap) {
     AliasMap aliases{{"project", "my-project"}};
     std::vector<PathSegment> segs;
     segs.push_back(pvar("project"));
-    segs.push_back(plit("/src"));
+    segs.push_back(plit("src"));
     auto pe = path(std::move(segs));
     EXPECT_EQ(evaluate_path(pe, env, aliases), "my-project/src");
 }
@@ -546,7 +546,7 @@ TEST(EvalPathTest, PathInterpAgainstEnvString) {
     AliasMap aliases;
     std::vector<PathSegment> segs;
     segs.push_back(pinterp(ident("prefix")));
-    segs.push_back(plit("/sub"));
+    segs.push_back(plit("sub"));
     auto pe = path(std::move(segs));
     EXPECT_EQ(evaluate_path(pe, env, aliases), "x/sub");
 }
@@ -556,10 +556,10 @@ TEST(EvalPathTest, PathInterpWithArithmetic) {
     env.declare("n", Value{std::int64_t{3}});
     AliasMap aliases;
     std::vector<PathSegment> segs;
-    segs.push_back(plit("week_"));
+    segs.push_back(plit("base"));
     segs.push_back(pinterp(binop(TokenType::PLUS, ident("n"), int_lit(1))));
     auto pe = path(std::move(segs));
-    EXPECT_EQ(evaluate_path(pe, env, aliases), "week_4");
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "base/4");
 }
 
 TEST(EvalPathTest, PathInterpStringifiesBool) {
@@ -567,10 +567,10 @@ TEST(EvalPathTest, PathInterpStringifiesBool) {
     env.declare("use_x", Value{true});
     AliasMap aliases;
     std::vector<PathSegment> segs;
-    segs.push_back(plit("flag_"));
+    segs.push_back(plit("base"));
     segs.push_back(pinterp(ident("use_x")));
     auto pe = path(std::move(segs));
-    EXPECT_EQ(evaluate_path(pe, env, aliases), "flag_true");
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "base/true");
 }
 
 TEST(EvalPathTest, UnboundAliasThrows) {
@@ -586,6 +586,45 @@ TEST(EvalPathTest, UnboundAliasThrows) {
         EXPECT_NE(std::string(ex.what()).find("ghost"), std::string::npos);
         EXPECT_EQ(ex.line(), 5);
         EXPECT_EQ(ex.column(), 9);
+    }
+}
+
+TEST(EvalPathTest, PathVarFallsBackToEnvString) {
+    Environment env;
+    env.declare("dir", Value{std::string{"notes"}});
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(pvar("dir"));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "notes");
+}
+
+TEST(EvalPathTest, LetStringWithSlashesAppendsVerbatim) {
+    Environment env;
+    env.declare("root", Value{std::string{"foo/bar"}});
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(pvar("root"));
+    segs.push_back(plit("baz"));
+    auto pe = path(std::move(segs));
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "foo/bar/baz");
+}
+
+TEST(EvalPathTest, NonStringLetInPathThrows) {
+    Environment env;
+    env.declare("count", Value{std::int64_t{3}});
+    AliasMap aliases;
+    std::vector<PathSegment> segs;
+    segs.push_back(PathVar{.name = "count", .line = 4, .column = 7});
+    auto pe = path(std::move(segs));
+    try {
+        evaluate_path(pe, env, aliases);
+        FAIL() << "expected RuntimeError";
+    } catch (const RuntimeError& ex) {
+        EXPECT_NE(std::string(ex.what()).find("must be a string"),
+                  std::string::npos);
+        EXPECT_EQ(ex.line(), 4);
+        EXPECT_EQ(ex.column(), 7);
     }
 }
 
@@ -836,7 +875,7 @@ TEST(AskTest, AskInsideRepeatRunsPerIteration) {
     auto p = parse(R"(ask n "Count?" int
 repeat n as i
   ask name "Module name?" string
-  mkdir {name}
+  mkdir "{name}"
 end
 )");
     ScriptedPrompter prompter({"3", "alpha", "beta", "gamma"});
@@ -1377,9 +1416,9 @@ TEST(AssignTest, MkdirCapturesValueAtStatementTime) {
     // between two mkdirs creates two distinct directories.
     TmpDir td;
     auto p = parse(R"(let n = 1
-mkdir dir_{n}
+mkdir "dir_{n}"
 n = n + 1
-mkdir dir_{n}
+mkdir "dir_{n}"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1390,9 +1429,9 @@ mkdir dir_{n}
 TEST(AssignTest, FileContentCapturesValueAtStatementTime) {
     TmpDir td;
     auto p = parse(R"(let label = "first"
-file a.txt content "label=" + label
+file "a.txt" content "label=" + label
 label = "second"
-file b.txt content "label=" + label
+file "b.txt" content "label=" + label
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1404,7 +1443,7 @@ file b.txt content "label=" + label
 
 TEST(MkdirTest, CreatesDirectory) {
     TmpDir td;
-    auto p = parse(R"(mkdir my_project
+    auto p = parse(R"(mkdir "my_project"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1413,8 +1452,8 @@ TEST(MkdirTest, CreatesDirectory) {
 
 TEST(MkdirTest, HyphenatedDirectoryName) {
     TmpDir td;
-    auto p = parse(R"(mkdir my-project
-mkdir my-project/pre-commit-hooks
+    auto p = parse(R"(mkdir "my-project"
+mkdir "my-project/pre-commit-hooks"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1425,7 +1464,7 @@ mkdir my-project/pre-commit-hooks
 
 TEST(MkdirTest, MkdirP) {
     TmpDir td;
-    auto p = parse(R"(mkdir a/b/c
+    auto p = parse(R"(mkdir "a/b/c"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1435,7 +1474,7 @@ TEST(MkdirTest, MkdirP) {
 TEST(MkdirTest, WhenFalseSkips) {
     TmpDir td;
     auto p = parse(R"(ask use_foo "Use foo?" bool
-mkdir foo when use_foo
+mkdir "foo" when use_foo
 )");
     ScriptedPrompter prompter({"false"});
     run(p, prompter);
@@ -1445,7 +1484,7 @@ mkdir foo when use_foo
 TEST(MkdirTest, WhenTrueCreates) {
     TmpDir td;
     auto p = parse(R"(ask use_foo "Use foo?" bool
-mkdir foo when use_foo
+mkdir "foo" when use_foo
 )");
     ScriptedPrompter prompter({"true"});
     run(p, prompter);
@@ -1454,7 +1493,7 @@ mkdir foo when use_foo
 
 TEST(MkdirTest, ModeApplied) {
     TmpDir td;
-    auto p = parse(R"(mkdir bar mode 0700
+    auto p = parse(R"(mkdir "bar" mode 0700
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1464,18 +1503,38 @@ TEST(MkdirTest, ModeApplied) {
 
 TEST(MkdirTest, AliasResolvesInLaterPath) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo as project
-mkdir project/sub
+    auto p = parse(R"(mkdir "foo" as project
+mkdir project/"sub"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "foo" / "sub"));
 }
 
+TEST(MkdirTest, LetStringResolvesAsPathRoot) {
+    TmpDir td;
+    auto p = parse(R"(let dir = "notes"
+mkdir dir
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "notes"));
+}
+
+TEST(MkdirTest, LetStringWithSlashAppendedVerbatim) {
+    TmpDir td;
+    auto p = parse(R"(let root = "outer/inner"
+mkdir root/"leaf"
+)");
+    ScriptedPrompter prompter({});
+    run(p, prompter);
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "outer" / "inner" / "leaf"));
+}
+
 TEST(MkdirTest, RejectsPreExistingPath) {
     TmpDir td;
     std::filesystem::create_directory(td.path() / "exists");
-    auto p = parse(R"(mkdir exists
+    auto p = parse(R"(mkdir "exists"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1483,7 +1542,7 @@ TEST(MkdirTest, RejectsPreExistingPath) {
 
 TEST(MkdirTest, FromMissingSourceThrows) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo from base
+    auto p = parse(R"(mkdir "foo" from "base"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1501,7 +1560,7 @@ TEST(MkdirTest, FromCopiesSourceTree) {
     {
         std::ofstream(td.path() / "src" / "sub" / "nested.txt") << "nested";
     }
-    auto p = parse(R"(mkdir dst from src
+    auto p = parse(R"(mkdir "dst" from "src"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1518,7 +1577,7 @@ TEST(MkdirTest, FromInterpolatesFileContents) {
         std::ofstream(td.path() / "src" / "readme.md") << "# {name}";
     }
     auto p = parse(R"(let name = "spudplate"
-mkdir dst from src
+mkdir "dst" from "src"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1532,7 +1591,7 @@ TEST(MkdirTest, FromVerbatimSuppressesInterpolation) {
         std::ofstream(td.path() / "src" / "raw.txt") << "{name} stays";
     }
     auto p = parse(R"(let name = "ignored"
-mkdir dst from src verbatim
+mkdir "dst" from "src" verbatim
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1545,8 +1604,8 @@ TEST(MkdirTest, FromBindsAlias) {
     {
         std::ofstream(td.path() / "src" / "a.txt") << "x";
     }
-    auto p = parse(R"(mkdir dst from src as out
-file out/extra.txt content "extra"
+    auto p = parse(R"(mkdir "dst" from "src" as out
+file out/"extra.txt" content "extra"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1558,8 +1617,8 @@ TEST(MkdirTest, DeferredWriteAtomicityOnPreFlushFailure) {
     TmpDir td;
     // First mkdir queues; second's `from` walk throws on missing source
     // before any flush runs, so neither directory ends up on disk.
-    auto p = parse(R"(mkdir a
-mkdir b from base
+    auto p = parse(R"(mkdir "a"
+mkdir "b" from "base"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1574,8 +1633,8 @@ TEST(MkdirTest, SkippedConditionalAliasNotBound) {
     // looked up. This proves the runtime does not bind aliases on skipped
     // statements.
     auto p = parse(R"(ask use_x "Use x?" bool
-mkdir foo when use_x as project
-mkdir project/sub when use_x
+mkdir "foo" when use_x as project
+mkdir project/"sub" when use_x
 )");
     ScriptedPrompter prompter({"false"});
     run(p, prompter);
@@ -1589,18 +1648,18 @@ TEST(EvalPathTest, MixedSegments) {
     AliasMap aliases{{"project", "my-app"}};
     std::vector<PathSegment> segs;
     segs.push_back(pvar("project"));
-    segs.push_back(plit("/week_"));
+    segs.push_back(plit("week"));
     segs.push_back(pinterp(ident("i")));
-    segs.push_back(plit("/notes.md"));
+    segs.push_back(plit("notes.md"));
     auto pe = path(std::move(segs));
-    EXPECT_EQ(evaluate_path(pe, env, aliases), "my-app/week_2/notes.md");
+    EXPECT_EQ(evaluate_path(pe, env, aliases), "my-app/week/2/notes.md");
 }
 
 // --- File content + flush (Part 6) ---
 
 TEST(FileTest, ContentLiteral) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt content "hello"
+    auto p = parse(R"(file "foo.txt" content "hello"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1610,7 +1669,7 @@ TEST(FileTest, ContentLiteral) {
 TEST(FileTest, ContentInterpolatedFromLet) {
     TmpDir td;
     auto p = parse(R"(let name = "world"
-file foo.txt content "hello, " + name
+file "foo.txt" content "hello, " + name
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1620,7 +1679,7 @@ file foo.txt content "hello, " + name
 TEST(FileTest, ContentBraceInterpolatesString) {
     TmpDir td;
     auto p = parse(R"(let name = "world"
-file foo.txt content "hello, {name}!"
+file "foo.txt" content "hello, {name}!"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1630,7 +1689,7 @@ file foo.txt content "hello, {name}!"
 TEST(FileTest, ContentBraceInterpolatesInt) {
     TmpDir td;
     auto p = parse(R"(let n = 7
-file foo.txt content "n={n}"
+file "foo.txt" content "n={n}"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1641,7 +1700,7 @@ TEST(FileTest, ContentBraceInterpolatesMultipleVars) {
     TmpDir td;
     auto p = parse(R"(let a = "x"
 let b = "y"
-file foo.txt content "{a} and {b}"
+file "foo.txt" content "{a} and {b}"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1650,22 +1709,22 @@ file foo.txt content "{a} and {b}"
 
 TEST(FileTest, ContentBraceMissingVarErrors) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt content "{nope}"
+    auto p = parse(R"(file "foo.txt" content "{nope}"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), spudplate::RuntimeError);
 }
 
 TEST(FileTest, ContentBraceUnclosedErrorsAtParse) {
-    EXPECT_THROW(parse(R"(file foo.txt content "{name"
+    EXPECT_THROW(parse(R"(file "foo.txt" content "{name"
 )"),
                  spudplate::ParseError);
 }
 
 TEST(FileTest, FileInsideQueuedDirectory) {
     TmpDir td;
-    auto p = parse(R"(mkdir x
-file x/foo.txt content "hi"
+    auto p = parse(R"(mkdir "x"
+file "x/foo.txt" content "hi"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1674,8 +1733,8 @@ file x/foo.txt content "hi"
 
 TEST(FileTest, AppendAfterContent) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt content "first"
-file foo.txt append content "second"
+    auto p = parse(R"(file "foo.txt" content "first"
+file "foo.txt" append content "second"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1684,8 +1743,8 @@ file foo.txt append content "second"
 
 TEST(FileTest, SamePathTwiceWithoutAppendOverwrites) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt content "A"
-file foo.txt content "B"
+    auto p = parse(R"(file "foo.txt" content "A"
+file "foo.txt" content "B"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1694,7 +1753,7 @@ file foo.txt content "B"
 
 TEST(FileTest, EmptyContent) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt content ""
+    auto p = parse(R"(file "foo.txt" content ""
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1705,7 +1764,7 @@ TEST(FileTest, EmptyContent) {
 TEST(FileTest, IntContentCoercedToString) {
     TmpDir td;
     auto p = parse(R"(let n = 42
-file count.txt content n
+file "count.txt" content n
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1714,7 +1773,7 @@ file count.txt content n
 
 TEST(FileTest, BoolContentCoercedToString) {
     TmpDir td;
-    auto p = parse(R"(file flag.txt content true
+    auto p = parse(R"(file "flag.txt" content true
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1723,7 +1782,7 @@ TEST(FileTest, BoolContentCoercedToString) {
 
 TEST(FileTest, AppendViaAlias) {
     TmpDir td;
-    auto p = parse(R"(file foo content "A" as f
+    auto p = parse(R"(file "foo" content "A" as f
 file f append content "B"
 )");
     ScriptedPrompter prompter({});
@@ -1748,7 +1807,7 @@ TEST(FileTest, RejectsPreExistingFile) {
         std::ofstream out(td.path() / "exists.txt");
         out << "old";
     }
-    auto p = parse(R"(file exists.txt content "new"
+    auto p = parse(R"(file "exists.txt" content "new"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1760,7 +1819,7 @@ TEST(FileTest, FromCopiesSourceContents) {
         std::ofstream out(td.path() / "src.txt");
         out << "from-source content";
     }
-    auto p = parse(R"(file foo.txt from src.txt
+    auto p = parse(R"(file "foo.txt" from "src.txt"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1774,7 +1833,7 @@ TEST(FileTest, FromInterpolatesIdentifiers) {
         out << "hello, {who}!";
     }
     auto p = parse(R"(let who = "world"
-file foo.txt from src.txt
+file "foo.txt" from "src.txt"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1787,7 +1846,7 @@ TEST(FileTest, FromVerbatimSkipsInterpolation) {
         std::ofstream out(td.path() / "src.txt");
         out << "literal {braces}";
     }
-    auto p = parse(R"(file foo.txt from src.txt verbatim
+    auto p = parse(R"(file "foo.txt" from "src.txt" verbatim
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1800,7 +1859,7 @@ TEST(FileTest, FromUnknownIdentInterpolationThrows) {
         std::ofstream out(td.path() / "src.txt");
         out << "{missing}";
     }
-    auto p = parse(R"(file foo.txt from src.txt
+    auto p = parse(R"(file "foo.txt" from "src.txt"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1809,7 +1868,7 @@ TEST(FileTest, FromUnknownIdentInterpolationThrows) {
 
 TEST(FileTest, FromMissingSourceThrows) {
     TmpDir td;
-    auto p = parse(R"(file foo.txt from nope.txt
+    auto p = parse(R"(file "foo.txt" from "nope.txt"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1822,8 +1881,8 @@ TEST(FileTest, FromAppendsToFile) {
         std::ofstream out(td.path() / "src.txt");
         out << "B";
     }
-    auto p = parse(R"(file foo.txt content "A"
-file foo.txt append from src.txt
+    auto p = parse(R"(file "foo.txt" content "A"
+file "foo.txt" append from "src.txt"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1836,7 +1895,7 @@ TEST(FileTest, FromUnclosedBraceThrows) {
         std::ofstream out(td.path() / "src.txt");
         out << "oops {name";
     }
-    auto p = parse(R"(file foo.txt from src.txt
+    auto p = parse(R"(file "foo.txt" from "src.txt"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1845,7 +1904,7 @@ TEST(FileTest, FromUnclosedBraceThrows) {
 TEST(FileTest, WhenFalseSkips) {
     TmpDir td;
     auto p = parse(R"(ask use_f "Use file?" bool
-file foo.txt content "hi" when use_f
+file "foo.txt" content "hi" when use_f
 )");
     ScriptedPrompter prompter({"false"});
     run(p, prompter);
@@ -1860,8 +1919,8 @@ TEST(CopyTest, MergesIntoExistingDir) {
     {
         std::ofstream(td.path() / "src" / "a.txt") << "a";
     }
-    auto p = parse(R"(mkdir dst
-copy src into dst
+    auto p = parse(R"(mkdir "dst"
+copy "src" into "dst"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1874,7 +1933,7 @@ TEST(CopyTest, MissingDestinationFailsAtFlush) {
     {
         std::ofstream(td.path() / "src" / "a.txt") << "a";
     }
-    auto p = parse(R"(copy src into dst
+    auto p = parse(R"(copy "src" into "dst"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1883,8 +1942,8 @@ TEST(CopyTest, MissingDestinationFailsAtFlush) {
 
 TEST(CopyTest, MissingSourceThrows) {
     TmpDir td;
-    auto p = parse(R"(mkdir dst
-copy nope into dst
+    auto p = parse(R"(mkdir "dst"
+copy "nope" into "dst"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -1901,9 +1960,9 @@ TEST(CopyTest, MergesMultipleSources) {
     {
         std::ofstream(td.path() / "src2" / "b.txt") << "b";
     }
-    auto p = parse(R"(mkdir dst
-copy src1 into dst
-copy src2 into dst
+    auto p = parse(R"(mkdir "dst"
+copy "src1" into "dst"
+copy "src2" into "dst"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1917,8 +1976,8 @@ TEST(CopyTest, RecursesIntoSubdirectories) {
     {
         std::ofstream(td.path() / "src" / "deep" / "x.txt") << "x";
     }
-    auto p = parse(R"(mkdir dst
-copy src into dst
+    auto p = parse(R"(mkdir "dst"
+copy "src" into "dst"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1933,8 +1992,8 @@ TEST(CopyTest, InterpolatesByDefault) {
         std::ofstream(td.path() / "src" / "f.txt") << "hello {who}";
     }
     auto p = parse(R"(let who = "you"
-mkdir dst
-copy src into dst
+mkdir "dst"
+copy "src" into "dst"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1948,8 +2007,8 @@ TEST(CopyTest, VerbatimSuppressesInterpolation) {
         std::ofstream(td.path() / "src" / "f.txt") << "{who}";
     }
     auto p = parse(R"(let who = "ignored"
-mkdir dst
-copy src into dst verbatim
+mkdir "dst"
+copy "src" into "dst" verbatim
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -1963,8 +2022,8 @@ TEST(CopyTest, WhenFalseSkips) {
         std::ofstream(td.path() / "src" / "f.txt") << "x";
     }
     auto p = parse(R"(ask flag "Copy?" bool
-mkdir dst
-copy src into dst when flag
+mkdir "dst"
+copy "src" into "dst" when flag
 )");
     ScriptedPrompter prompter({"false"});
     run(p, prompter);
@@ -1978,7 +2037,7 @@ TEST(RepeatTest, ZeroCountBodyNeverRuns) {
     TmpDir td;
     auto p = parse(R"(let n = 0
 repeat n as i
-    mkdir x_{i}
+    mkdir "x_{i}"
 end
 )");
     ScriptedPrompter prompter({});
@@ -1990,7 +2049,7 @@ TEST(RepeatTest, ThreeIterationsCreateThreeDirs) {
     TmpDir td;
     auto p = parse(R"(let n = 3
 repeat n as i
-    mkdir week_{i}
+    mkdir "week_{i}"
 end
 )");
     ScriptedPrompter prompter({});
@@ -2005,7 +2064,7 @@ TEST(RepeatTest, WhenFalseSkipsLoop) {
     auto p = parse(R"(ask use_loop "Use loop?" bool
 let n = 3
 repeat n as i when use_loop
-    mkdir week_{i}
+    mkdir "week_{i}"
 end
 )");
     ScriptedPrompter prompter({"false"});
@@ -2017,7 +2076,7 @@ TEST(RepeatTest, NegativeCountIsZeroIterations) {
     TmpDir td;
     auto p = parse(R"(let n = 0 - 5
 repeat n as i
-    mkdir x_{i}
+    mkdir "x_{i}"
 end
 )");
     ScriptedPrompter prompter({});
@@ -2032,7 +2091,7 @@ TEST(RepeatTest, InnerLetReferencesIterator) {
     auto p = parse(R"(let n = 3
 repeat n as i
     let doubled = i + i
-    mkdir d_{doubled}
+    mkdir "d_{doubled}"
 end
 )");
     ScriptedPrompter prompter({});
@@ -2048,7 +2107,7 @@ TEST(RepeatTest, NestedRepeatsCreateGrid) {
 let m = 2
 repeat n as i
     repeat m as j
-        mkdir x_{i}_{j}
+        mkdir "x_{i}_{j}"
     end
 end
 )");
@@ -2068,8 +2127,8 @@ TEST(RepeatTest, InnerAliasDoesNotLeak) {
     // iterations and no escape after the loop.
     auto p = parse(R"(let n = 2
 repeat n as i
-    mkdir week_{i} as wk
-    mkdir wk/sub_{i}
+    mkdir "week_{i}" as wk
+    mkdir wk/"sub_{i}"
 end
 )");
     ScriptedPrompter prompter({});
@@ -2095,7 +2154,7 @@ TEST(RunTest, AuthorizedCommandExecutes) {
 
 TEST(RunTest, DeclinedAbortsCleanly) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo
+    auto p = parse(R"(mkdir "foo"
 run "touch foo/marker"
 )");
     ScriptedPrompter prompter({});
@@ -2106,9 +2165,9 @@ run "touch foo/marker"
 
 TEST(RunTest, NonZeroExitAbortsRun) {
     TmpDir td;
-    auto p = parse(R"(mkdir before
+    auto p = parse(R"(mkdir "before"
 run "false"
-mkdir after
+mkdir "after"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -2148,7 +2207,7 @@ TEST(RunTest, NonStringCommandIsRuntimeError) {
 
 TEST(RunTest, ProgramWithoutRunDoesNotInvokeAuthorize) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo
+    auto p = parse(R"(mkdir "foo"
 )");
     ScriptedPrompter prompter({});
     prompter.set_authorize_response(false);  // would abort if called
@@ -2197,8 +2256,8 @@ TEST(RunTest, SkipAuthorizationBypassesPrompt) {
 
 TEST(RunTest, InClausePinsCwd) {
     TmpDir td;
-    auto p = parse(R"(mkdir myapp
-run "touch marker" in myapp
+    auto p = parse(R"(mkdir "myapp"
+run "touch marker" in "myapp"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -2209,8 +2268,8 @@ run "touch marker" in myapp
 TEST(RunTest, InClauseRestoresCwdAfterRun) {
     TmpDir td;
     auto saved = std::filesystem::current_path();
-    auto p = parse(R"(mkdir myapp
-run "touch marker" in myapp
+    auto p = parse(R"(mkdir "myapp"
+run "touch marker" in "myapp"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -2219,7 +2278,7 @@ run "touch marker" in myapp
 
 TEST(RunTest, InClauseAcceptsAlias) {
     TmpDir td;
-    auto p = parse(R"(mkdir myapp as proj
+    auto p = parse(R"(mkdir "myapp" as proj
 run "touch marker" in proj
 )");
     ScriptedPrompter prompter({});
@@ -2230,8 +2289,8 @@ run "touch marker" in proj
 TEST(RunTest, InClauseAcceptsInterpolation) {
     TmpDir td;
     auto p = parse(R"(let dir = "myapp"
-mkdir {dir}
-run "touch marker" in {dir}
+mkdir "{dir}"
+run "touch marker" in "{dir}"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -2240,7 +2299,7 @@ run "touch marker" in {dir}
 
 TEST(RunTest, InClauseMissingDirIsRuntimeError) {
     TmpDir td;
-    auto p = parse(R"(run "echo hi" in nope
+    auto p = parse(R"(run "echo hi" in "nope"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -2249,8 +2308,8 @@ TEST(RunTest, InClauseMissingDirIsRuntimeError) {
 TEST(RunTest, InClauseRestoresCwdOnCommandFailure) {
     TmpDir td;
     auto saved = std::filesystem::current_path();
-    auto p = parse(R"(mkdir myapp
-run "false" in myapp
+    auto p = parse(R"(mkdir "myapp"
+run "false" in "myapp"
 )");
     ScriptedPrompter prompter({});
     EXPECT_THROW(run(p, prompter), RuntimeError);
@@ -2259,8 +2318,8 @@ run "false" in myapp
 
 TEST(RunTest, AuthorizeSummaryIncludesInClause) {
     TmpDir td;
-    auto p = parse(R"(mkdir myapp
-run "git init" in myapp
+    auto p = parse(R"(mkdir "myapp"
+run "git init" in "myapp"
 )");
     ScriptedPrompter prompter({});
     run(p, prompter);
@@ -2340,8 +2399,8 @@ TEST(DryRunTest, EmptyProgramRendersNothing) {
 
 TEST(DryRunTest, MkdirAndFileRender) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo
-file foo/bar.txt content "hi"
+    auto p = parse(R"(mkdir "foo"
+file "foo/bar.txt" content "hi"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2354,8 +2413,8 @@ file foo/bar.txt content "hi"
 
 TEST(DryRunTest, AppendGetsAnnotation) {
     TmpDir td;
-    auto p = parse(R"(file log.txt content "first"
-file log.txt append content "second"
+    auto p = parse(R"(file "log.txt" content "first"
+file "log.txt" append content "second"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2368,9 +2427,9 @@ file log.txt append content "second"
 
 TEST(DryRunTest, SiblingsAreSortedAlphabetically) {
     TmpDir td;
-    auto p = parse(R"(mkdir zeta
-mkdir alpha
-mkdir mu
+    auto p = parse(R"(mkdir "zeta"
+mkdir "alpha"
+mkdir "mu"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2394,7 +2453,7 @@ TEST(DryRunTest, MkdirFromExpandsTree) {
     {
         std::ofstream(td.path() / "src" / "sub" / "deep.txt") << "y";
     }
-    auto p = parse(R"(mkdir dst from src
+    auto p = parse(R"(mkdir "dst" from "src"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2407,8 +2466,8 @@ TEST(DryRunTest, MkdirFromExpandsTree) {
 
 TEST(DryRunTest, NoFilesystemSideEffects) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo
-file foo/bar.txt content "hi"
+    auto p = parse(R"(mkdir "foo"
+file "foo/bar.txt" content "hi"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2426,7 +2485,7 @@ TEST(DryRunTest, CopyToMissingDestStillRendersTree) {
     // `copy` into a non-existent `dst` would be a runtime error during a
     // real run; dry-run skips the existence check so the user still gets
     // a useful preview.
-    auto p = parse(R"(copy src into dst
+    auto p = parse(R"(copy "src" into "dst"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2438,7 +2497,7 @@ TEST(DryRunTest, CopyToMissingDestStillRendersTree) {
 
 TEST(DryRunTest, MissingFromSourceStillThrows) {
     TmpDir td;
-    auto p = parse(R"(mkdir dst from nope
+    auto p = parse(R"(mkdir "dst" from "nope"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2449,10 +2508,10 @@ TEST(DryRunTest, AsciiGlyphsWhenRequested) {
     TmpDir td;
     // Two top-level siblings ensure the `|   ` continuation glyph shows
     // up under the non-last sibling.
-    auto p = parse(R"(mkdir foo
-file foo/bar.txt content "hi"
-file foo/baz.txt content "hi"
-mkdir last
+    auto p = parse(R"(mkdir "foo"
+file "foo/bar.txt" content "hi"
+file "foo/baz.txt" content "hi"
+mkdir "last"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2467,7 +2526,7 @@ mkdir last
 
 TEST(DryRunTest, Utf8GlyphsByDefault) {
     TmpDir td;
-    auto p = parse(R"(mkdir foo
+    auto p = parse(R"(mkdir "foo"
 )");
     ScriptedPrompter prompter({});
     std::stringstream out;
@@ -2508,7 +2567,7 @@ TEST(LocaleIsUtf8Test, FirstSetWinsOverLaterUtf8) {
 TEST(DryRunTest, PromptsRunBeforeRendering) {
     TmpDir td;
     auto p = parse(R"(ask name "Project?" string default "demo"
-mkdir {name}
+mkdir "{name}"
 )");
     ScriptedPrompter prompter({"hello"});
     std::stringstream out;
@@ -2536,8 +2595,8 @@ TEST(SourceProvider, AssetMapMaterialisesFileAndMode) {
         {"tpl/main.cpp", 0644, {'h', 'i', '\n'}});
     spudplate::AssetMapSourceProvider provider(assets);
     auto p = parse(
-        "mkdir out\n"
-        "file out/main.cpp from tpl/main.cpp\n");
+        "mkdir \"out\"\n"
+        "file \"out/main.cpp\" from \"tpl/main.cpp\"\n");
     ScriptedPrompter prompter({});
     spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
     EXPECT_EQ(read_text(td.path() / "out/main.cpp"), "hi\n");
@@ -2549,8 +2608,8 @@ TEST(SourceProvider, MkdirFromAssetMapNestedTree) {
     assets.push_back({"src/a/b/c.txt", 0644, {'x'}});
     spudplate::AssetMapSourceProvider provider(assets);
     auto p = parse(
-        "mkdir tree from src\n"
-        "file tree/a/extra.txt content \"more\"\n");
+        "mkdir \"tree\" from \"src\"\n"
+        "file \"tree/a/extra.txt\" content \"more\"\n");
     ScriptedPrompter prompter({});
     spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
     EXPECT_TRUE(std::filesystem::exists(td.path() / "tree/a/b/c.txt"));
@@ -2562,7 +2621,7 @@ TEST(SourceProvider, MkdirFromEmptyLeafDir) {
     std::vector<spudplate::SpudpackAsset> assets;
     assets.push_back({"scaffold/logs/", 0755, {}});
     spudplate::AssetMapSourceProvider provider(assets);
-    auto p = parse("mkdir project from scaffold\n");
+    auto p = parse("mkdir \"project\" from \"scaffold\"\n");
     ScriptedPrompter prompter({});
     spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "project/logs"));
@@ -2572,7 +2631,7 @@ TEST(SourceProvider, AssetMissSurfacesRuntimeError) {
     TmpDir td;
     std::vector<spudplate::SpudpackAsset> assets;
     spudplate::AssetMapSourceProvider provider(assets);
-    auto p = parse("file out.txt from missing.txt\n");
+    auto p = parse("file \"out.txt\" from \"missing.txt\"\n");
     ScriptedPrompter prompter({});
     try {
         spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
@@ -2592,8 +2651,8 @@ TEST(SourceProvider, BinaryContentSkipsInterpolation) {
     assets.push_back({"logo.png", 0644, png});
     spudplate::AssetMapSourceProvider provider(assets);
     auto p = parse(
-        "mkdir out\n"
-        "file out/logo.png from logo.png\n");
+        "mkdir \"out\"\n"
+        "file \"out/logo.png\" from \"logo.png\"\n");
     ScriptedPrompter prompter({});
     spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
     auto materialised = read_text(td.path() / "out/logo.png");
@@ -2607,8 +2666,8 @@ TEST(SourceProvider, AppendOverReadonlyRestoresPriorMode) {
     assets.push_back({"readonly.txt", 0444, {'b', 'a', 's', 'e', '\n'}});
     spudplate::AssetMapSourceProvider provider(assets);
     auto p = parse(
-        "file out.txt from readonly.txt\n"
-        "file out.txt append content \"more\"\n");
+        "file \"out.txt\" from \"readonly.txt\"\n"
+        "file \"out.txt\" append content \"more\"\n");
     ScriptedPrompter prompter({});
     spudplate::run(p, prompter, /*skip_authorization=*/true, &provider);
     EXPECT_EQ(read_text(td.path() / "out.txt"), "base\nmore");
@@ -2625,7 +2684,7 @@ TEST(SourceProvider, DiskBackedSkipsBrokenSymlinks) {
     // preserves that.
     std::filesystem::create_symlink(td.path() / "no/such/target",
                                     td.path() / "tree/dangling");
-    auto p = parse("mkdir out from tree\n");
+    auto p = parse("mkdir \"out\" from \"tree\"\n");
     ScriptedPrompter prompter({});
     spudplate::run(p, prompter, /*skip_authorization=*/true);
     EXPECT_TRUE(std::filesystem::exists(td.path() / "out/regular.txt"));
@@ -2640,7 +2699,7 @@ TEST(SourceProvider, UnclosedBraceStillSurfacedOnTextWithHighBytes) {
     std::vector<spudplate::SpudpackAsset> assets;
     assets.push_back({"latin.txt", 0644, body});
     spudplate::AssetMapSourceProvider provider(assets);
-    auto p = parse("file out.txt from latin.txt\n");
+    auto p = parse("file \"out.txt\" from \"latin.txt\"\n");
     ScriptedPrompter prompter({});
     EXPECT_THROW(
         spudplate::run(p, prompter, /*skip_authorization=*/true, &provider),
@@ -2695,7 +2754,7 @@ TEST(IfTest, NestedIfInsideRepeat) {
 ask use_extra "Extra?" bool
 repeat n as i
   if use_extra
-    mkdir m_{i}
+    mkdir "m_{i}"
   end
 end
 )");

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -777,24 +777,25 @@ TEST(ParserTest, FileWithoutAppendDefaultsFalse) {
 
 // --- Path expression tests ---
 
-TEST(ParserTest, MkdirUnquotedSimplePath) {
-    auto stmt = parse_mkdir("mkdir static\n");
+TEST(ParserTest, MkdirBareIdentifierIsPathVar) {
+    auto stmt = parse_mkdir("mkdir staticpath\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static");
+    EXPECT_EQ(std::get<PathVar>(mk.path.segments[0]).name, "staticpath");
     EXPECT_FALSE(mk.alias.has_value());
     EXPECT_TRUE(mk.mkdir_p);
 }
 
-TEST(ParserTest, MkdirUnquotedSlashSeparated) {
-    auto stmt = parse_mkdir("mkdir static/notes\n");
+TEST(ParserTest, MkdirQuotedSplitsOnSlash) {
+    auto stmt = parse_mkdir("mkdir \"static/notes\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
-    ASSERT_EQ(mk.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static/notes");
+    ASSERT_EQ(mk.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "notes");
 }
 
 TEST(ParserTest, MkdirWithAlias) {
-    auto stmt = parse_mkdir("mkdir static as staticpath\n");
+    auto stmt = parse_mkdir("mkdir \"static\" as staticpath\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 1u);
     EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static");
@@ -803,77 +804,70 @@ TEST(ParserTest, MkdirWithAlias) {
 }
 
 TEST(ParserTest, MkdirPathWithAlias) {
-    auto stmt = parse_mkdir("mkdir static/notes as notespath\n");
+    auto stmt = parse_mkdir("mkdir \"static/notes\" as notespath\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
-    ASSERT_EQ(mk.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static/notes");
+    ASSERT_EQ(mk.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "static");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "notes");
     ASSERT_TRUE(mk.alias.has_value());
     EXPECT_EQ(*mk.alias, "notespath");
 }
 
-TEST(ParserTest, MkdirAliasReferenceInLaterPath) {
-    auto program = parse_program(
-        "mkdir static as staticpath\n"
-        "mkdir staticpath/notes\n");
-    ASSERT_EQ(program.statements.size(), 2u);
-    auto& mk2 = std::get<MkdirStmt>(program.statements[1]->data);
-    ASSERT_EQ(mk2.path.segments.size(), 2u);
-    EXPECT_EQ(std::get<PathVar>(mk2.path.segments[0]).name, "staticpath");
-    EXPECT_EQ(std::get<PathLiteral>(mk2.path.segments[1]).value, "/notes");
-}
-
-TEST(ParserTest, MkdirInterpolation) {
-    auto stmt = parse_mkdir("mkdir week_{n}\n");
+TEST(ParserTest, MkdirIdentifierFollowedBySlashIsTwoSegments) {
+    auto stmt = parse_mkdir("mkdir staticpath/\"notes\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 2u);
-    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "week_");
-    auto& interp = std::get<PathInterp>(mk.path.segments[1]);
-    EXPECT_EQ(std::get<IdentifierExpr>(interp.expression->data).name, "n");
+    EXPECT_EQ(std::get<PathVar>(mk.path.segments[0]).name, "staticpath");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "notes");
+}
+
+TEST(ParserTest, MkdirInterpolationInQuotedSegment) {
+    auto stmt = parse_mkdir("mkdir \"week_{n}\"\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 1u);
+    auto& interp = std::get<PathInterp>(mk.path.segments[0]);
+    auto& tmpl = std::get<TemplateStringExpr>(interp.expression->data);
+    EXPECT_EQ(tmpl.parts.size(), 2u);
+    EXPECT_EQ(std::get<std::string>(tmpl.parts[0]), "week_");
 }
 
 TEST(ParserTest, MkdirAliasAndInterpolationInSamePath) {
     auto program = parse_program(
-        "mkdir static as staticpath\n"
-        "mkdir notes as notespath\n"
-        "mkdir staticpath/notespath/week_{n}\n");
+        "mkdir \"static\" as staticpath\n"
+        "mkdir \"notes\" as notespath\n"
+        "mkdir staticpath/notespath/\"week_{n}\"\n");
     ASSERT_EQ(program.statements.size(), 3u);
     auto& mk3 = std::get<MkdirStmt>(program.statements[2]->data);
-    ASSERT_EQ(mk3.path.segments.size(), 5u);
+    ASSERT_EQ(mk3.path.segments.size(), 3u);
     EXPECT_EQ(std::get<PathVar>(mk3.path.segments[0]).name, "staticpath");
-    EXPECT_EQ(std::get<PathLiteral>(mk3.path.segments[1]).value, "/");
-    EXPECT_EQ(std::get<PathVar>(mk3.path.segments[2]).name, "notespath");
-    EXPECT_EQ(std::get<PathLiteral>(mk3.path.segments[3]).value, "/week_");
-    auto& interp = std::get<PathInterp>(mk3.path.segments[4]);
-    EXPECT_EQ(std::get<IdentifierExpr>(interp.expression->data).name, "n");
+    EXPECT_EQ(std::get<PathVar>(mk3.path.segments[1]).name, "notespath");
+    EXPECT_TRUE(std::holds_alternative<PathInterp>(mk3.path.segments[2]));
 }
 
-TEST(ParserTest, MkdirHyphenInPath) {
-    auto stmt = parse_mkdir("mkdir my-project\n");
+TEST(ParserTest, MkdirHyphenInQuotedPath) {
+    auto stmt = parse_mkdir("mkdir \"my-project\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 1u);
     EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "my-project");
 }
 
-TEST(ParserTest, MkdirMultipleHyphens) {
-    auto stmt = parse_mkdir("mkdir pre-commit-hooks\n");
+TEST(ParserTest, MkdirMultipleHyphensInQuoted) {
+    auto stmt = parse_mkdir("mkdir \"pre-commit-hooks\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 1u);
     EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "pre-commit-hooks");
 }
 
-TEST(ParserTest, MkdirHyphenAfterSlash) {
-    auto stmt = parse_mkdir("mkdir src/my-lib\n");
-    auto& mk = std::get<MkdirStmt>(stmt->data);
-    ASSERT_EQ(mk.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "src/my-lib");
-}
-
-TEST(ParserTest, MkdirHyphenAfterInterpolation) {
-    auto stmt = parse_mkdir("mkdir {slug}-app\n");
+TEST(ParserTest, MkdirHyphenAfterSlashInQuoted) {
+    auto stmt = parse_mkdir("mkdir \"src/my-lib\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 2u);
-    EXPECT_TRUE(std::holds_alternative<PathInterp>(mk.path.segments[0]));
-    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "-app");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "src");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "my-lib");
+}
+
+TEST(ParserTest, MkdirInterpolationOutsideQuotesRejected) {
+    EXPECT_THROW(parse_mkdir("mkdir {slug}\n"), ParseError);
 }
 
 TEST(ParserTest, MkdirLeadingHyphenRejected) {
@@ -888,35 +882,66 @@ TEST(ParserTest, MkdirQuotedPathWithSpaces) {
 }
 
 TEST(ParserTest, MkdirAliasAfterWhenClause) {
-    auto stmt = parse_mkdir("mkdir static when use_static as staticpath\n");
+    auto stmt = parse_mkdir("mkdir \"static\" when use_static as staticpath\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_TRUE(mk.when_clause.has_value());
     ASSERT_TRUE(mk.alias.has_value());
     EXPECT_EQ(*mk.alias, "staticpath");
 }
 
-TEST(ParserTest, FileContentUnquotedPath) {
-    auto stmt = parse_file("file static/notes/README.md content \"\"\n");
+TEST(ParserTest, MkdirQuotedEmptyPiecesDropped) {
+    // Leading and trailing slashes inside the quoted value are dropped.
+    auto stmt = parse_mkdir("mkdir \"/foo//bar/\"\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "foo");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "bar");
+}
+
+TEST(ParserTest, MkdirQuotedSpaceSegmentPreserved) {
+    auto stmt = parse_mkdir("mkdir \"my notes/today\"\n");
+    auto& mk = std::get<MkdirStmt>(stmt->data);
+    ASSERT_EQ(mk.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "my notes");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[1]).value, "today");
+}
+
+TEST(ParserTest, MkdirMixedAliasLetLiteralSegments) {
+    auto program = parse_program(
+        "let prefix = \"team\"\n"
+        "mkdir \"static\" as staticpath\n"
+        "mkdir staticpath/prefix/\"out\"\n");
+    ASSERT_EQ(program.statements.size(), 3u);
+    auto& mk = std::get<MkdirStmt>(program.statements[2]->data);
+    ASSERT_EQ(mk.path.segments.size(), 3u);
+    EXPECT_EQ(std::get<PathVar>(mk.path.segments[0]).name, "staticpath");
+    EXPECT_EQ(std::get<PathVar>(mk.path.segments[1]).name, "prefix");
+    EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[2]).value, "out");
+}
+
+TEST(ParserTest, FileContentQuotedPathSplitsSegments) {
+    auto stmt = parse_file("file \"static/notes/README.md\" content \"\"\n");
     auto& file = std::get<FileStmt>(stmt->data);
-    ASSERT_EQ(file.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[0]).value,
-              "static/notes/README.md");
+    ASSERT_EQ(file.path.segments.size(), 3u);
+    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[0]).value, "static");
+    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[1]).value, "notes");
+    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[2]).value, "README.md");
     std::get<FileContentSource>(file.source);  // NOLINT - just verifying variant
 }
 
-TEST(ParserTest, FileFromUnquotedPath) {
-    auto stmt = parse_file("file static/notes/README.md from base/README.md\n");
+TEST(ParserTest, FileFromQuotedPathSplitsSegments) {
+    auto stmt = parse_file(
+        "file \"static/notes/README.md\" from \"base/README.md\"\n");
     auto& file = std::get<FileStmt>(stmt->data);
-    ASSERT_EQ(file.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(file.path.segments[0]).value,
-              "static/notes/README.md");
+    ASSERT_EQ(file.path.segments.size(), 3u);
     auto& src = std::get<FileFromSource>(file.source);
-    ASSERT_EQ(src.path.segments.size(), 1u);
-    EXPECT_EQ(std::get<PathLiteral>(src.path.segments[0]).value, "base/README.md");
+    ASSERT_EQ(src.path.segments.size(), 2u);
+    EXPECT_EQ(std::get<PathLiteral>(src.path.segments[0]).value, "base");
+    EXPECT_EQ(std::get<PathLiteral>(src.path.segments[1]).value, "README.md");
 }
 
 TEST(ParserTest, FileWithAlias) {
-    auto stmt = parse_file("file readme.md content \"# hi\" as readme\n");
+    auto stmt = parse_file("file \"readme.md\" content \"# hi\" as readme\n");
     auto& file = std::get<FileStmt>(stmt->data);
     ASSERT_TRUE(file.alias.has_value());
     EXPECT_EQ(*file.alias, "readme");
@@ -924,7 +949,7 @@ TEST(ParserTest, FileWithAlias) {
 
 TEST(ParserTest, FileAppendViaAlias) {
     auto program = parse_program(
-        "file project_dir/README.md content \"# Project\" as readme\n"
+        "file \"project_dir/README.md\" content \"# Project\" as readme\n"
         "file readme append content \"## Notes\" when use_notes\n"
         "file readme append content \"## Testing\" when use_tests\n");
     ASSERT_EQ(program.statements.size(), 3u);
@@ -964,7 +989,7 @@ static StmtPtr parse_copy(const std::string& input) {
 }
 
 TEST(ParserTest, CopyBasic) {
-    auto stmt = parse_copy("copy standard_templates into templatepath\n");
+    auto stmt = parse_copy("copy \"standard_templates\" into \"templatepath\"\n");
     auto& cp = std::get<CopyStmt>(stmt->data);
     ASSERT_EQ(cp.source.segments.size(), 1u);
     EXPECT_EQ(std::get<PathLiteral>(cp.source.segments[0]).value, "standard_templates");
@@ -976,7 +1001,7 @@ TEST(ParserTest, CopyBasic) {
 
 TEST(ParserTest, CopyWithWhen) {
     auto stmt =
-        parse_copy("copy philosophy_templates into templatepath when use_philosophy\n");
+        parse_copy("copy \"philosophy_templates\" into \"templatepath\" when use_philosophy\n");
     auto& cp = std::get<CopyStmt>(stmt->data);
     ASSERT_TRUE(cp.when_clause.has_value());
     auto& cond = std::get<IdentifierExpr>((*cp.when_clause)->data);
@@ -985,30 +1010,30 @@ TEST(ParserTest, CopyWithWhen) {
 
 TEST(ParserTest, CopyVerbatimWithNestedDestination) {
     auto program = parse_program(
-        "mkdir static as staticpath\n"
-        "copy assets into staticpath/assets verbatim\n");
+        "mkdir \"static\" as staticpath\n"
+        "copy \"assets\" into staticpath/\"assets\" verbatim\n");
     ASSERT_EQ(program.statements.size(), 2u);
     auto& cp = std::get<CopyStmt>(program.statements[1]->data);
     EXPECT_TRUE(cp.verbatim);
     ASSERT_EQ(cp.destination.segments.size(), 2u);
     EXPECT_EQ(std::get<PathVar>(cp.destination.segments[0]).name, "staticpath");
-    EXPECT_EQ(std::get<PathLiteral>(cp.destination.segments[1]).value, "/assets");
+    EXPECT_EQ(std::get<PathLiteral>(cp.destination.segments[1]).value, "assets");
 }
 
 TEST(ParserTest, CopyMissingInto) {
-    EXPECT_THROW(parse_copy("copy src dest\n"), ParseError);
+    EXPECT_THROW(parse_copy("copy \"src\" \"dest\"\n"), ParseError);
 }
 
 TEST(ParserTest, CopyMissingSource) {
-    EXPECT_THROW(parse_copy("copy into dest\n"), ParseError);
+    EXPECT_THROW(parse_copy("copy into \"dest\"\n"), ParseError);
 }
 
 TEST(ParserTest, CopyMissingDestination) {
-    EXPECT_THROW(parse_copy("copy src into\n"), ParseError);
+    EXPECT_THROW(parse_copy("copy \"src\" into\n"), ParseError);
 }
 
 TEST(ParserTest, MkdirFromBasic) {
-    auto stmt = parse_mkdir("mkdir templates from base_templates\n");
+    auto stmt = parse_mkdir("mkdir \"templates\" from \"base_templates\"\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_EQ(mk.path.segments.size(), 1u);
     EXPECT_EQ(std::get<PathLiteral>(mk.path.segments[0]).value, "templates");
@@ -1020,7 +1045,7 @@ TEST(ParserTest, MkdirFromBasic) {
 
 TEST(ParserTest, MkdirFromVerbatimWhenAs) {
     auto stmt = parse_mkdir(
-        "mkdir templates from base_templates verbatim when use_templates as templatepath\n");
+        "mkdir \"templates\" from \"base_templates\" verbatim when use_templates as templatepath\n");
     auto& mk = std::get<MkdirStmt>(stmt->data);
     ASSERT_TRUE(mk.from_source.has_value());
     EXPECT_TRUE(mk.verbatim);
@@ -1030,7 +1055,7 @@ TEST(ParserTest, MkdirFromVerbatimWhenAs) {
 }
 
 TEST(ParserTest, MkdirFromMissingSourcePath) {
-    EXPECT_THROW(parse_mkdir("mkdir templates from\n"), ParseError);
+    EXPECT_THROW(parse_mkdir("mkdir \"templates\" from\n"), ParseError);
 }
 
 // --- Program parsing tests ---
@@ -1360,7 +1385,7 @@ TEST(ParserTest, RunStringLiteral) {
 }
 
 TEST(ParserTest, RunWithInClause) {
-    auto stmt = parse_run("run \"git init\" in myapp\n");
+    auto stmt = parse_run("run \"git init\" in \"myapp\"\n");
     auto& r = std::get<spudplate::RunStmt>(stmt->data);
     ASSERT_TRUE(r.cwd.has_value());
     ASSERT_EQ(r.cwd->segments.size(), 1u);
@@ -1369,14 +1394,14 @@ TEST(ParserTest, RunWithInClause) {
 }
 
 TEST(ParserTest, RunWithInAndWhen) {
-    auto stmt = parse_run("run \"git init\" in myapp when use_git\n");
+    auto stmt = parse_run("run \"git init\" in \"myapp\" when use_git\n");
     auto& r = std::get<spudplate::RunStmt>(stmt->data);
     ASSERT_TRUE(r.cwd.has_value());
     ASSERT_TRUE(r.when_clause.has_value());
 }
 
 TEST(ParserTest, RunInClauseAcceptsInterpolation) {
-    auto stmt = parse_run("run \"git init\" in {dir}\n");
+    auto stmt = parse_run("run \"git init\" in \"{dir}\"\n");
     auto& r = std::get<spudplate::RunStmt>(stmt->data);
     ASSERT_TRUE(r.cwd.has_value());
     ASSERT_EQ(r.cwd->segments.size(), 1u);
@@ -1405,7 +1430,7 @@ TEST(ParserTest, RunWithTimeout) {
 
 TEST(ParserTest, RunWithInTimeoutAndWhen) {
     auto stmt = parse_run(
-        "run \"slow\" in dir timeout 30 when use_slow\n");
+        "run \"slow\" in \"dir\" timeout 30 when use_slow\n");
     auto& r = std::get<spudplate::RunStmt>(stmt->data);
     ASSERT_TRUE(r.cwd.has_value());
     ASSERT_TRUE(r.timeout.has_value());

--- a/tests/validator_test.cpp
+++ b/tests/validator_test.cpp
@@ -159,7 +159,7 @@ TEST(ValidatorTest, AskInRepeatShadowingIteratorIsError) {
 TEST(ValidatorTest, RepeatBodyWithNonAskStatementsValidates) {
     auto program = parse(
         "ask n \"Count?\" int\n"
-        "mkdir base\n"
+        "mkdir \"base\"\n"
         "repeat n as i\n"
         "  mkdir \"m_{i}\"\n"
         "  file \"m_{i}/README.md\" content \"hi\"\n"
@@ -294,7 +294,7 @@ TEST(ValidatorTest, AliasBoundInsideRepeatReferencedOutsideIsError) {
         "repeat n as i\n"
         "  mkdir \"foo\" as bar\n"
         "end\n"
-        "mkdir bar/sub\n");
+        "mkdir bar/\"sub\"\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
@@ -349,17 +349,17 @@ TEST(ValidatorTest, WhenClauseReferencingPoppedBindingIsError) {
         "repeat n as i\n"
         "  let x = 1\n"
         "end\n"
-        "mkdir stuff when x\n");
+        "mkdir \"stuff\" when x\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
 TEST(ValidatorTest, PathInterpReferencingPoppedIteratorIsError) {
-    // Unquoted path so `{i}` is parsed as a PathInterp segment.
+    // Quoted path with `{i}` interpolation referencing a popped iterator.
     auto program = parse(
         "ask n \"Count?\" int\n"
         "repeat n as i\n"
         "end\n"
-        "mkdir week_{i}\n");
+        "mkdir \"week_{i}\"\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
@@ -476,40 +476,40 @@ TEST(NormalizeTest, IntComparisonDiffersFromBoolComparison) {
 TEST(ValidatorTest, AliasBoundWhenXReferencedWhenXValid) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir bar/sub when x\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir bar/\"sub\" when x\n");
     EXPECT_NO_THROW(validate(program));
 }
 
 TEST(ValidatorTest, AliasBoundWhenXReferencedWhenXEqualsTrueValid) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir bar/sub when x == true\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir bar/\"sub\" when x == true\n");
     EXPECT_NO_THROW(validate(program));
 }
 
 TEST(ValidatorTest, AliasBoundWhenXEqualsTrueReferencedWhenXValid) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x == true as bar\n"
-        "mkdir bar/sub when x\n");
+        "mkdir \"foo\" when x == true as bar\n"
+        "mkdir bar/\"sub\" when x\n");
     EXPECT_NO_THROW(validate(program));
 }
 
 TEST(ValidatorTest, AliasBoundWhenXReferencedWhenXEqualsFalseIsError) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir bar/sub when x == false\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir bar/\"sub\" when x == false\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
 TEST(ValidatorTest, AliasBoundWhenXReferencedWhenNotXIsError) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir bar/sub when not x\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir bar/\"sub\" when not x\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
@@ -518,31 +518,31 @@ TEST(ValidatorTest, AliasBoundWhenAAndBReferencedWhenBAndAIsError) {
     auto program = parse(
         "ask a \"a?\" bool\n"
         "ask b \"b?\" bool\n"
-        "mkdir foo when a and b as bar\n"
-        "mkdir bar/sub when b and a\n");
+        "mkdir \"foo\" when a and b as bar\n"
+        "mkdir bar/\"sub\" when b and a\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
 TEST(ValidatorTest, AliasBoundWhenXReferencedWithNoWhenIsError) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir bar/sub\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir bar/\"sub\"\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
 TEST(ValidatorTest, UnconditionalAliasReferencedWhenXValid) {
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo as bar\n"
-        "mkdir bar/sub when x\n");
+        "mkdir \"foo\" as bar\n"
+        "mkdir bar/\"sub\" when x\n");
     EXPECT_NO_THROW(validate(program));
 }
 
 TEST(ValidatorTest, UnconditionalAliasReferencedUnconditionallyValid) {
     auto program = parse(
-        "mkdir foo as bar\n"
-        "mkdir bar/sub\n");
+        "mkdir \"foo\" as bar\n"
+        "mkdir bar/\"sub\"\n");
     EXPECT_NO_THROW(validate(program));
 }
 
@@ -550,8 +550,8 @@ TEST(ValidatorTest, ConditionalAliasReferenceInFilePath) {
     // Exercises the file.path reference site.
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "file bar/readme content \"hi\" when x\n");
+        "mkdir \"foo\" when x as bar\n"
+        "file bar/\"readme\" content \"hi\" when x\n");
     EXPECT_NO_THROW(validate(program));
 }
 
@@ -559,9 +559,9 @@ TEST(ValidatorTest, ConditionalAliasReferenceInCopySource) {
     // Exercises the copy.source reference site.
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir dest\n"
-        "copy bar into dest when x\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir \"dest\"\n"
+        "copy bar into \"dest\" when x\n");
     EXPECT_NO_THROW(validate(program));
 }
 
@@ -569,9 +569,9 @@ TEST(ValidatorTest, ConditionalAliasReferenceInCopyDestinationMismatch) {
     // Exercises copy.destination + mismatched condition.
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir src\n"
-        "copy src into bar when not x\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir \"src\"\n"
+        "copy \"src\" into bar when not x\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
 
@@ -579,8 +579,8 @@ TEST(ValidatorTest, ConditionalAliasReferenceInMkdirFromSource) {
     // Exercises mkdir.from_source reference site.
     auto program = parse(
         "ask x \"x?\" bool\n"
-        "mkdir foo when x as bar\n"
-        "mkdir new from bar when x\n");
+        "mkdir \"foo\" when x as bar\n"
+        "mkdir \"new\" from bar when x\n");
     EXPECT_NO_THROW(validate(program));
 }
 
@@ -592,9 +592,9 @@ TEST(ValidatorTest, RepeatWhenNotFoldedIntoAliasCondition) {
     auto program = parse(
         "ask x \"x?\" bool\n"
         "ask n \"n?\" int\n"
-        "mkdir foo when x as bar\n"
+        "mkdir \"foo\" when x as bar\n"
         "repeat n as i when x\n"
-        "  mkdir bar/dup_{i}\n"
+        "  mkdir bar/\"dup_{i}\"\n"
         "end\n");
     EXPECT_THROW(validate(program), SemanticError);
 }
@@ -628,7 +628,7 @@ TEST(ValidatorTest, RunReferencesIteratorOutsideRepeatIsError) {
 
 TEST(ValidatorTest, RunInClauseReferencesAlias) {
     auto program = parse(
-        "mkdir myapp as proj\n"
+        "mkdir \"myapp\" as proj\n"
         "run \"git init\" in proj\n");
     EXPECT_NO_THROW(validate(program));
 }
@@ -637,7 +637,7 @@ TEST(ValidatorTest, RunInClauseReferencesPoppedAliasIsError) {
     auto program = parse(
         "let n = 1\n"
         "repeat n as i\n"
-        "  mkdir foo as bar\n"
+        "  mkdir \"foo\" as bar\n"
         "end\n"
         "run \"echo hi\" in bar\n");
     EXPECT_THROW(validate(program), spudplate::SemanticError);
@@ -675,7 +675,7 @@ TEST(ValidatorTest, ReassignAskAnswerIsError) {
 
 TEST(ValidatorTest, ReassignPathAliasIsError) {
     auto program = parse(
-        "mkdir foo as bar\n"
+        "mkdir \"foo\" as bar\n"
         "bar = \"baz\"\n");
     EXPECT_THROW(validate(program), spudplate::SemanticError);
 }
@@ -737,16 +737,65 @@ TEST(ValidatorTest, TemplateInWhenInRunIsWalked) {
     EXPECT_THROW(validate(program), spudplate::SemanticError);
 }
 
+// --- Path identifier resolution ---
+
+TEST(ValidatorTest, UnresolvedPathIdentifierRejected) {
+    auto program = parse("mkdir notes\n");
+    try {
+        validate(program);
+        FAIL() << "expected SemanticError";
+    } catch (const SemanticError& e) {
+        EXPECT_NE(std::string(e.what()).find("unresolved path identifier"),
+                  std::string::npos);
+        EXPECT_NE(std::string(e.what()).find("'notes'"), std::string::npos);
+        EXPECT_NE(std::string(e.what()).find("use quotes"), std::string::npos);
+    }
+}
+
+TEST(ValidatorTest, LetStringInPathPasses) {
+    auto program = parse(
+        "let dir = \"notes\"\n"
+        "mkdir dir\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
+TEST(ValidatorTest, LetIntInPathRejected) {
+    auto program = parse(
+        "let n = 1\n"
+        "mkdir n\n");
+    try {
+        validate(program);
+        FAIL() << "expected SemanticError";
+    } catch (const SemanticError& e) {
+        EXPECT_NE(std::string(e.what()).find("must be a string"),
+                  std::string::npos);
+    }
+}
+
+TEST(ValidatorTest, LetBoolInPathRejected) {
+    auto program = parse(
+        "let flag = true\n"
+        "mkdir flag\n");
+    EXPECT_THROW(validate(program), SemanticError);
+}
+
+TEST(ValidatorTest, AskStringAnswerInPathPasses) {
+    auto program = parse(
+        "ask name \"Name?\" string\n"
+        "mkdir name\n");
+    EXPECT_NO_THROW(validate(program));
+}
+
 TEST(ValidatorTest, ComposedRulesEndToEnd) {
     // Exercises Part A (repeat when), Part B (no ask-in-repeat - valid case),
     // Part C (nested let scoping), and Part E (bool-equivalent alias when).
     auto program = parse(
         "ask use_ci \"use ci?\" bool\n"
         "ask n \"n?\" int\n"
-        "mkdir ci_dir when use_ci as ci_path\n"
+        "mkdir \"ci_dir\" when use_ci as ci_path\n"
         "repeat n as i when use_ci\n"
         "  let j = i + 1\n"
         "end\n"
-        "mkdir ci_path/out when use_ci == true\n");
+        "mkdir ci_path/\"out\" when use_ci == true\n");
     EXPECT_NO_THROW(validate(program));
 }


### PR DESCRIPTION
## Summary

Reworks path expressions in `mkdir`, `file`, and `copy`. Each path is now a slash-separated sequence of segments, and each segment is either a bare identifier (always a variable reference) or a quoted string (always a literal). Closes #61.

This is a breaking change. Existing templates that relied on bare-identifier literals like `mkdir static/notes` will fail to validate; they need to be quoted.

## Changes

- Parser is stateless on bindings. A bare identifier in path position is always emitted as a path variable, and a quoted string in path position is split on `/` into one or more literal segments. Segments may carry `{var}` interpolation only inside quoted strings; bare `{var}` outside quotes is now a parse error.
- Validator type-tracks `let` bindings and rejects bare-identifier segments that do not resolve to a path alias or a string-typed `let`. Diagnostic: `unresolved path identifier '<name>' (use quotes for a literal directory name)`.
- Interpreter's `evaluate_path` joins segments with `/` and falls back to the environment when a bare identifier is not in the alias map. A non-string runtime value in a path segment surfaces a clear runtime error.
- Bundler joins literal segments with `/` and synthesises the trailing `/` before the first dynamic segment. The split-on-`/` parser keeps separators out of segment values, so the bundler builds the static prefix from joined components.
- Inline test fixtures across parser, validator, interpreter, bundler, and CLI suites are migrated to the new syntax.
- Docs (`README.md`, `docs/syntax.md`, `docs/index.md`, `docs/getting-started.md`) are updated with the new model and the let-string-as-path-root convenience.

## Test plan

- `ctest --test-dir build` passes (666 tests, 13 new).
- Parser: bare identifier emits a path variable, quoted strings split on `/`, brace interpolation outside quotes rejected, mixed alias and let and literal segments parse together.
- Validator: unresolved bare identifier surfaces the new diagnostic; `let`-bound string passes; non-string `let` rejected.
- Interpreter: bare identifier falls back to a `let`-bound string; a let value with embedded slashes is appended verbatim; a non-string value in a path raises a runtime error.