### PR TITLE
ci: run on pushes to dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

Add `dev` to the CI push trigger so a long-lived integration branch builds and tests on every push.

## Changes

- `ci.yml` push trigger now lists `main` and `dev`. PR trigger unchanged.

## Test plan

- Existing checks still cover PRs into `main`.
- After merge, pushing to `dev` will trigger the build and test matrix.