### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(spudplate VERSION 0.2.0 LANGUAGES CXX)
+project(spudplate VERSION 0.2.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
## Summary

Patch release. Picks up the new help and -h flag support across the CLI.

## Changes

- Project version bumped from 0.2.0 to 0.2.1.

## Test plan

- After merge, tag v0.2.1 on main to trigger the release workflow.