### PR TITLE
feat: shell completion and CLI polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(spudplate VERSION 0.2.1 LANGUAGES CXX)
+project(spudplate VERSION 0.2.2 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/install.sh
+++ b/install.sh
@@ -85,6 +85,8 @@ main() {
     info ""
     info "installed to $install_path"
 
+    install_completions "$install_path"
+
     case ":$PATH:" in
         *":$PREFIX/bin:"*) ;;
         *)
@@ -94,6 +96,31 @@ main() {
             info "  export PATH=\"$PREFIX/bin:\$PATH\""
             ;;
     esac
+}
+
+install_completions() {
+    bin="$1"
+    bash_dir="$HOME/.local/share/bash-completion/completions"
+    zsh_dir="$HOME/.zsh/completions"
+    if ! mkdir -p "$bash_dir" "$zsh_dir" 2>/dev/null; then
+        info "note: could not create completion directories; skipping completion install"
+        return 0
+    fi
+    if ! "$bin" completion bash >"$bash_dir/spudplate" 2>/dev/null; then
+        info "note: could not install bash completion"
+        return 0
+    fi
+    if ! "$bin" completion zsh >"$zsh_dir/_spudplate" 2>/dev/null; then
+        info "note: could not install zsh completion"
+        return 0
+    fi
+    info ""
+    info "shell completion installed:"
+    info "  bash: $bash_dir/spudplate"
+    info "  zsh:  $zsh_dir/_spudplate"
+    info ""
+    info "zsh users: ensure $zsh_dir is on your fpath, e.g. in ~/.zshrc:"
+    info "  fpath=($zsh_dir \$fpath); autoload -U compinit && compinit"
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -26,72 +26,39 @@ info() {
     printf '%s\n' "$*"
 }
 
-detect_target() {
+if command -v curl >/dev/null 2>&1; then
+    fetch() { curl -fsSL -o "$1" "$2"; }
+elif command -v wget >/dev/null 2>&1; then
+    fetch() { wget -qO "$1" "$2"; }
+else
+    err "neither curl nor wget is installed"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256() { sha256sum "$1" | awk '{ print $1 }'; }
+elif command -v shasum >/dev/null 2>&1; then
+    sha256() { shasum -a 256 "$1" | awk '{ print $1 }'; }
+else
+    err "no shasum or sha256sum available to verify the download"
+fi
+
+main() {
     os=$(uname -s)
     arch=$(uname -m)
-    case "$os" in
-        Linux)  os_tag=linux ;;
-        Darwin) os_tag=darwin ;;
-        *)      err "unsupported OS: $os" ;;
+    case "$os $arch" in
+        "Linux x86_64"|"Linux amd64")    target=spudplate-linux-x86_64 ;;
+        "Darwin arm64"|"Darwin aarch64") target=spudplate-darwin-arm64 ;;
+        "Linux "*)  err "no Linux $arch build yet — build from source: https://github.com/$REPO" ;;
+        "Darwin "*) err "no macOS $arch build yet — build from source: https://github.com/$REPO" ;;
+        *)          err "unsupported OS: $os" ;;
     esac
-    case "$arch" in
-        x86_64|amd64)  arch_tag=x86_64 ;;
-        arm64|aarch64) arch_tag=arm64 ;;
-        *)             err "unsupported architecture: $arch" ;;
-    esac
-    if [ "$os_tag" = linux ] && [ "$arch_tag" != x86_64 ]; then
-        err "no Linux $arch_tag build yet — build from source: https://github.com/$REPO"
-    fi
-    if [ "$os_tag" = darwin ] && [ "$arch_tag" != arm64 ]; then
-        err "no macOS $arch_tag build yet — build from source: https://github.com/$REPO"
-    fi
-    target="spudplate-${os_tag}-${arch_tag}"
-}
 
-resolve_urls() {
     if [ "$VERSION" = latest ]; then
         base="https://github.com/$REPO/releases/latest/download"
     else
         base="https://github.com/$REPO/releases/download/$VERSION"
     fi
-    binary_url="$base/$target"
-    sums_url="$base/SHA256SUMS"
-}
 
-download() {
-    url="$1"
-    out="$2"
-    if command -v curl >/dev/null 2>&1; then
-        curl -fsSL -o "$out" "$url"
-    elif command -v wget >/dev/null 2>&1; then
-        wget -qO "$out" "$url"
-    else
-        err "neither curl nor wget is installed"
-    fi
-}
-
-verify_checksum() {
-    file="$1"
-    sums="$2"
-    expected=$(awk -v t="$target" '$2 == t || $2 == "*"t { print $1; exit }' "$sums")
-    if [ -z "$expected" ]; then
-        err "no checksum entry for $target in SHA256SUMS"
-    fi
-    if command -v shasum >/dev/null 2>&1; then
-        actual=$(shasum -a 256 "$file" | awk '{ print $1 }')
-    elif command -v sha256sum >/dev/null 2>&1; then
-        actual=$(sha256sum "$file" | awk '{ print $1 }')
-    else
-        err "no shasum or sha256sum available to verify the download"
-    fi
-    if [ "$expected" != "$actual" ]; then
-        err "checksum mismatch: expected $expected, got $actual"
-    fi
-}
-
-main() {
-    detect_target
-    resolve_urls
     info "spudplate installer"
     info "  target:  $target"
     info "  version: $VERSION"
@@ -100,12 +67,15 @@ main() {
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT INT TERM
 
-    info "downloading $binary_url"
-    download "$binary_url" "$tmp/$target"
+    info "downloading $base/$target"
+    fetch "$tmp/$target" "$base/$target"
     info "downloading checksums"
-    download "$sums_url" "$tmp/SHA256SUMS"
+    fetch "$tmp/SHA256SUMS" "$base/SHA256SUMS"
 
-    verify_checksum "$tmp/$target" "$tmp/SHA256SUMS"
+    expected=$(awk -v t="$target" '$2 == t || $2 == "*"t { print $1; exit }' "$tmp/SHA256SUMS")
+    [ -n "$expected" ] || err "no checksum entry for $target in SHA256SUMS"
+    actual=$(sha256 "$tmp/$target")
+    [ "$expected" = "$actual" ] || err "checksum mismatch: expected $expected, got $actual"
 
     mkdir -p "$PREFIX/bin"
     install_path="$PREFIX/bin/spudplate"

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -765,8 +765,18 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
             err << "legacy install '" << raw_arg << "'; reinstall to upgrade\n";
             return 1;
         }
-        if (std::filesystem::exists(file_path) &&
-            !std::filesystem::is_regular_file(file_path)) {
+        if (!std::filesystem::exists(file_path)) {
+            err << "'" << raw_arg << "' is not installed";
+            std::string suggestion =
+                suggest_template_name(raw_arg, list_installed_names(home));
+            if (!suggestion.empty()) {
+                err << ", did you mean '" << suggestion << "'?\n";
+            } else {
+                err << "; run 'spudplate list' to see available templates\n";
+            }
+            return 5;
+        }
+        if (!std::filesystem::is_regular_file(file_path)) {
             err << "refusing to read: '" << raw_arg
                 << ".spp' exists but is not a regular file\n";
             return 1;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -57,6 +57,7 @@ void print_usage(std::ostream& out) {
         << "  version                         print the spudplate version\n"
         << "  update [--yes] [--force]        fetch and install the latest spudplate "
            "release\n"
+        << "  completion <bash|zsh>           print a shell completion script\n"
         << "\n"
         << "Run 'spudplate <command> --help' for help on a specific command.\n"
         << "Use --help or -h at any level to see this guidance.\n";
@@ -121,6 +122,18 @@ void print_help_version(std::ostream& out) {
     out << "usage: spudplate version\n"
         << "\n"
         << "Print the spudplate version and exit.\n";
+}
+
+void print_help_completion(std::ostream& out) {
+    out << "usage: spudplate completion <bash|zsh>\n"
+        << "\n"
+        << "Print a shell completion script to stdout. Pipe the output\n"
+        << "into your completion directory to enable tab completion of\n"
+        << "subcommands, installed template names, and .spud files.\n"
+        << "\n"
+        << "Bash:  spudplate completion bash > "
+           "~/.local/share/bash-completion/completions/spudplate\n"
+        << "Zsh:   spudplate completion zsh  > ~/.zsh/completions/_spudplate\n";
 }
 
 void print_help_update(std::ostream& out) {
@@ -521,6 +534,115 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
 int cmd_version(std::ostream& out) {
     out << "spudplate v" << SPUDPLATE_VERSION_STRING << "\n";
     return 0;
+}
+
+const char* bash_completion_script() {
+    return R"BASH(_spudplate() {
+    local cur cword
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    cword=$COMP_CWORD
+
+    local subcommands="install run validate list inspect uninstall version update completion --help -h"
+
+    if [ "$cword" -eq 1 ]; then
+        COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
+        return
+    fi
+
+    local subcommand="${COMP_WORDS[1]}"
+    case "$subcommand" in
+        run)
+            local installed
+            installed=$(spudplate list 2>/dev/null)
+            COMPREPLY=( $(compgen -W "$installed" -- "$cur") )
+            COMPREPLY+=( $(compgen -f -X '!*.spud' -- "$cur") )
+            COMPREPLY+=( $(compgen -f -X '!*.spp' -- "$cur") )
+            ;;
+        inspect|uninstall)
+            local installed
+            installed=$(spudplate list 2>/dev/null)
+            COMPREPLY=( $(compgen -W "$installed" -- "$cur") )
+            ;;
+        install|validate)
+            COMPREPLY=( $(compgen -f -X '!*.spud' -- "$cur") )
+            ;;
+        completion)
+            COMPREPLY=( $(compgen -W "bash zsh" -- "$cur") )
+            ;;
+    esac
+}
+complete -F _spudplate spudplate
+)BASH";
+}
+
+const char* zsh_completion_script() {
+    return R"ZSH(#compdef spudplate
+
+_spudplate() {
+    local -a subcommands
+    subcommands=(
+        'install:validate and store a template'
+        'run:run an installed template by name or a .spud/.spp file'
+        'validate:parse and validate a template without installing'
+        'list:list installed templates'
+        'inspect:print the source of an installed template'
+        'uninstall:remove an installed template'
+        'version:print the spudplate version'
+        'update:fetch and install the latest spudplate'
+        'completion:print a shell completion script'
+    )
+
+    if (( CURRENT == 2 )); then
+        _describe 'subcommand' subcommands
+        return
+    fi
+
+    case "$words[2]" in
+        run)
+            local -a names
+            names=( ${(f)"$(spudplate list 2>/dev/null)"} )
+            _alternative \
+                "names:installed:($names)" \
+                'files:.spud or .spp:_files -g "*.(spud|spp)"'
+            ;;
+        inspect|uninstall)
+            local -a names
+            names=( ${(f)"$(spudplate list 2>/dev/null)"} )
+            _describe 'installed template' names
+            ;;
+        install|validate)
+            _files -g '*.spud'
+            ;;
+        completion)
+            _values 'shell' bash zsh
+            ;;
+    esac
+}
+
+_spudplate "$@"
+)ZSH";
+}
+
+int cmd_completion(int argc, char* argv[], std::ostream& out, std::ostream& err) {
+    if (argc >= 3 && is_help_flag(argv[2])) {
+        print_help_completion(out);
+        return 0;
+    }
+    if (argc != 3) {
+        print_help_completion(err);
+        return 1;
+    }
+    std::string shell{argv[2]};
+    if (shell == "bash") {
+        out << bash_completion_script();
+        return 0;
+    }
+    if (shell == "zsh") {
+        out << zsh_completion_script();
+        return 0;
+    }
+    err << "unknown shell '" << shell << "'; supported: bash, zsh\n";
+    return 1;
 }
 
 int cmd_update(int argc, char* argv[], std::ostream& out, std::ostream& err) {
@@ -967,6 +1089,9 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     }
     if (subcommand == "uninstall") {
         return cmd_uninstall(argc, argv, out, err);
+    }
+    if (subcommand == "completion") {
+        return cmd_completion(argc, argv, out, err);
     }
     print_usage(err);
     return 1;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cerrno>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
@@ -237,6 +238,56 @@ std::vector<std::string> list_installed_names(const std::filesystem::path& home)
         }
     }
     return names;
+}
+
+std::string strip_v_prefix(std::string s) {
+    if (!s.empty() && s.front() == 'v') {
+        s.erase(0, 1);
+    }
+    return s;
+}
+
+// Resolve the latest released version by following the redirect on
+// `releases/latest`. Returns the version string without a leading `v` on
+// success, or empty on failure.
+//
+// `SPUDPLATE_LATEST_VERSION` overrides the network call. The special
+// value `fail` simulates a resolve failure for tests that exercise the
+// fail-open path.
+std::string resolve_latest_version() {
+    if (const char* env = std::getenv("SPUDPLATE_LATEST_VERSION");
+        env != nullptr && *env != '\0') {
+        if (std::string{env} == "fail") {
+            return {};
+        }
+        return strip_v_prefix(env);
+    }
+    FILE* pipe = popen(
+        "curl -fsSLI -o /dev/null -w '%{url_effective}' "
+        "https://github.com/spuddydev/spudplate/releases/latest 2>/dev/null",
+        "r");
+    if (pipe == nullptr) {
+        return {};
+    }
+    std::string url;
+    char buf[256];
+    while (std::fgets(buf, sizeof(buf), pipe) != nullptr) {
+        url += buf;
+    }
+    int status = pclose(pipe);
+    if (status != 0) {
+        return {};
+    }
+    while (!url.empty() &&
+           (url.back() == '\n' || url.back() == '\r' ||
+            url.back() == ' ' || url.back() == '\t')) {
+        url.pop_back();
+    }
+    auto pos = url.rfind('/');
+    if (pos == std::string::npos || pos + 1 >= url.size()) {
+        return {};
+    }
+    return strip_v_prefix(url.substr(pos + 1));
 }
 
 // Returns the closest installed name to `target` if it is a clear winner

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -199,6 +200,75 @@ std::filesystem::path resolve_template_arg(const std::string& arg, std::ostream&
 // at `<install_dir>/<name>/template.spud`.
 bool legacy_install_exists(const std::filesystem::path& home, const std::string& name) {
     return std::filesystem::is_regular_file(home / name / "template.spud");
+}
+
+std::size_t levenshtein(std::string_view a, std::string_view b) {
+    if (a.size() < b.size()) {
+        std::swap(a, b);
+    }
+    if (b.empty()) {
+        return a.size();
+    }
+    std::vector<std::size_t> prev(b.size() + 1);
+    std::vector<std::size_t> curr(b.size() + 1);
+    for (std::size_t j = 0; j <= b.size(); ++j) {
+        prev[j] = j;
+    }
+    for (std::size_t i = 1; i <= a.size(); ++i) {
+        curr[0] = i;
+        for (std::size_t j = 1; j <= b.size(); ++j) {
+            std::size_t cost = a[i - 1] == b[j - 1] ? 0 : 1;
+            curr[j] = std::min({prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost});
+        }
+        prev.swap(curr);
+    }
+    return prev[b.size()];
+}
+
+std::vector<std::string> list_installed_names(const std::filesystem::path& home) {
+    std::vector<std::string> names;
+    if (!std::filesystem::is_directory(home)) {
+        return names;
+    }
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
+        if (entry.is_regular_file() && ends_with_spp(entry.path())) {
+            names.push_back(entry.path().stem().string());
+        }
+    }
+    return names;
+}
+
+// Returns the closest installed name to `target` if it is a clear winner
+// within a typo-distance threshold that scales with name length, or empty
+// otherwise. A second-best at the same distance is treated as ambiguous
+// and yields no suggestion.
+std::string suggest_template_name(const std::string& target,
+                                  const std::vector<std::string>& names) {
+    if (names.empty()) {
+        return {};
+    }
+    std::size_t threshold = std::max<std::size_t>(2, target.size() / 3);
+    std::size_t best = std::numeric_limits<std::size_t>::max();
+    std::size_t second = std::numeric_limits<std::size_t>::max();
+    std::string winner;
+    for (const auto& n : names) {
+        std::size_t d = levenshtein(target, n);
+        if (d < best) {
+            second = best;
+            best = d;
+            winner = n;
+        } else if (d < second) {
+            second = d;
+        }
+    }
+    if (best > threshold) {
+        return {};
+    }
+    if (second <= best) {
+        return {};
+    }
+    return winner;
 }
 
 // Parse and validate `source` so install rejects broken templates before

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -55,7 +55,7 @@ void print_usage(std::ostream& out) {
         << "  inspect <name>                  print the source of an installed template\n"
         << "  uninstall <name>                remove an installed template\n"
         << "  version                         print the spudplate version\n"
-        << "  update [--yes]                  fetch and install the latest spudplate "
+        << "  update [--yes] [--force]        fetch and install the latest spudplate "
            "release\n"
         << "\n"
         << "Run 'spudplate <command> --help' for help on a specific command.\n"
@@ -124,12 +124,14 @@ void print_help_version(std::ostream& out) {
 }
 
 void print_help_update(std::ostream& out) {
-    out << "usage: spudplate update [--yes]\n"
+    out << "usage: spudplate update [--yes] [--force]\n"
         << "\n"
-        << "Fetch and install the latest spudplate release.\n"
+        << "Fetch and install the latest spudplate release. Skips the\n"
+        << "download when already up to date.\n"
         << "\n"
         << "Options:\n"
-        << "  --yes, -y       skip the confirmation prompt\n";
+        << "  --yes, -y       skip the confirmation prompt\n"
+        << "  --force         download and install even if already up to date\n";
 }
 
 // Resolve the directory templates are installed into. Honours, in order:
@@ -523,6 +525,7 @@ int cmd_version(std::ostream& out) {
 
 int cmd_update(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     bool skip_confirm = false;
+    bool force = false;
     int positional_start = 2;
     while (positional_start < argc) {
         std::string arg{argv[positional_start]};
@@ -532,6 +535,9 @@ int cmd_update(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         }
         if (arg == "--yes" || arg == "-y") {
             skip_confirm = true;
+            ++positional_start;
+        } else if (arg == "--force") {
+            force = true;
             ++positional_start;
         } else {
             break;
@@ -543,6 +549,19 @@ int cmd_update(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     }
 
     out << "current version: v" << SPUDPLATE_VERSION_STRING << "\n";
+
+    if (!force) {
+        std::string latest = resolve_latest_version();
+        if (latest.empty()) {
+            err << "warning: could not resolve latest version, continuing anyway\n";
+        } else if (latest == SPUDPLATE_VERSION_STRING) {
+            out << "already up to date (v" << SPUDPLATE_VERSION_STRING << ")\n";
+            return 0;
+        } else {
+            out << "latest version:  v" << latest << "\n";
+        }
+    }
+
     if (!skip_confirm) {
         if (!confirm_yes_no(out,
                             "this will download and install the latest spudplate "

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -666,6 +666,8 @@ TEST(CliTest, VersionFlagAcceptsDoubleDash) {
 TEST(CliTest, UpdateWithYesRunsOverrideCommand) {
     ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
     override.set("true");  // /bin/true succeeds, no network access
+    ScopedEnv latest("SPUDPLATE_LATEST_VERSION");
+    latest.set("99.0.0");  // pretend a newer release exists
     Argv args({"spudplate", "update", "--yes"});
     std::stringstream out;
     std::stringstream err;
@@ -679,6 +681,8 @@ TEST(CliTest, UpdateWithYesRunsOverrideCommand) {
 TEST(CliTest, UpdateFailingCommandExitsOne) {
     ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
     override.set("false");  // /bin/false exits non-zero
+    ScopedEnv latest("SPUDPLATE_LATEST_VERSION");
+    latest.set("99.0.0");
     Argv args({"spudplate", "update", "--yes"});
     std::stringstream out;
     std::stringstream err;
@@ -693,6 +697,8 @@ TEST(CliTest, UpdateDeclinedPromptAbortsCleanly) {
     // Set to a command that would fail loudly so the test catches any
     // accidental fall-through to execution.
     override.set("false");
+    ScopedEnv latest("SPUDPLATE_LATEST_VERSION");
+    latest.set("99.0.0");
     Argv args({"spudplate", "update"});
     std::stringstream out;
     std::stringstream err;
@@ -700,6 +706,53 @@ TEST(CliTest, UpdateDeclinedPromptAbortsCleanly) {
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 0);
     EXPECT_NE(out.str().find("aborted"), std::string::npos);
+}
+
+TEST(CliTest, UpdateAlreadyUpToDateExitsZero) {
+    ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
+    // If the up-to-date short-circuit fails, this would run /bin/false
+    // and surface as exit code 1 — the EQ(code, 0) below would fail.
+    override.set("false");
+    ScopedEnv latest("SPUDPLATE_LATEST_VERSION");
+    latest.set(SPUDPLATE_VERSION_STRING);
+    Argv args({"spudplate", "update", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("already up to date"), std::string::npos);
+    EXPECT_EQ(out.str().find("running:"), std::string::npos) << out.str();
+}
+
+TEST(CliTest, UpdateForceBypassesUpToDateCheck) {
+    ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
+    override.set("true");
+    ScopedEnv latest("SPUDPLATE_LATEST_VERSION");
+    latest.set(SPUDPLATE_VERSION_STRING);  // would normally short-circuit
+    Argv args({"spudplate", "update", "--yes", "--force"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("running: true"), std::string::npos);
+    EXPECT_EQ(out.str().find("already up to date"), std::string::npos) << out.str();
+}
+
+TEST(CliTest, UpdateContinuesOnResolveFailure) {
+    ScopedEnv override("SPUDPLATE_UPDATE_COMMAND");
+    override.set("true");
+    ScopedEnv latest("SPUDPLATE_LATEST_VERSION");
+    latest.set("fail");
+    Argv args({"spudplate", "update", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(err.str().find("could not resolve latest version"), std::string::npos);
+    EXPECT_NE(out.str().find("running: true"), std::string::npos);
 }
 
 TEST(CliTest, ValidateMissingFileExitsFive) {

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -403,6 +403,17 @@ TEST(CliTest, InstallMissingFileExitsFive) {
     EXPECT_EQ(code, 5);
 }
 
+namespace {
+void install_template(const std::filesystem::path& src, const std::string& body) {
+    write_file(src, body);
+    Argv args({"spudplate", "install", src.string()});
+    std::stringstream o;
+    std::stringstream e;
+    ScriptedPrompter p({});
+    ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
+}
+}  // namespace
+
 // --- run by installed name ---
 
 TEST(CliTest, RunByNameLooksUpInstalledTemplate) {
@@ -440,18 +451,68 @@ TEST(CliTest, RunByUnknownNameExitsFive) {
     EXPECT_EQ(code, 5);
 }
 
-// --- list / inspect / uninstall ---
-
-namespace {
-void install_template(const std::filesystem::path& src, const std::string& body) {
-    write_file(src, body);
-    Argv args({"spudplate", "install", src.string()});
-    std::stringstream o;
-    std::stringstream e;
-    ScriptedPrompter p({});
-    ASSERT_EQ(cli_main(args.argc(), args.argv(), o, e, p), 0) << e.str();
+TEST(CliTest, RunByUnknownNameMessageNamesArgAndPointsAtList) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    Argv args({"spudplate", "run", "ghost"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+    EXPECT_NE(err.str().find("'ghost' is not installed"), std::string::npos)
+        << err.str();
+    EXPECT_NE(err.str().find("spudplate list"), std::string::npos) << err.str();
+    EXPECT_EQ(err.str().find("cannot open"), std::string::npos) << err.str();
 }
-}  // namespace
+
+TEST(CliTest, RunByUnknownNameSuggestsClosestInstalled) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "template.spud", "mkdir \"x\"\n");
+    Argv args({"spudplate", "run", "templat"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+    EXPECT_NE(err.str().find("did you mean 'template'?"), std::string::npos)
+        << err.str();
+}
+
+TEST(CliTest, RunByUnknownNameOmitsSuggestionForUnrelatedArg) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "template.spud", "mkdir \"x\"\n");
+    Argv args({"spudplate", "run", "wxyz123"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+    EXPECT_EQ(err.str().find("did you mean"), std::string::npos) << err.str();
+    EXPECT_NE(err.str().find("spudplate list"), std::string::npos) << err.str();
+}
+
+TEST(CliTest, RunByUnknownNameOmitsSuggestionWhenAmbiguous) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "cat.spud", "mkdir \"x\"\n");
+    install_template(td.path() / "bat.spud", "mkdir \"y\"\n");
+    Argv args({"spudplate", "run", "rat"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 5);
+    EXPECT_EQ(err.str().find("did you mean"), std::string::npos) << err.str();
+}
+
+// --- list / inspect / uninstall ---
 
 TEST(CliTest, ListEmptyProducesNoOutput) {
     TmpDir td;

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -1174,3 +1174,71 @@ TEST(CliTest, UpdateHelpDoesNotRunUpdate) {
     // The "current version" line is only printed by the real update path.
     EXPECT_EQ(out.str().find("current version"), std::string::npos);
 }
+
+// --- completion ---
+
+TEST(CliTest, CompletionBashEmitsBashScript) {
+    Argv args({"spudplate", "completion", "bash"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("_spudplate"), std::string::npos);
+    EXPECT_NE(out.str().find("complete -F _spudplate spudplate"), std::string::npos);
+    EXPECT_NE(out.str().find("compgen"), std::string::npos);
+    EXPECT_NE(out.str().find("install run validate list"), std::string::npos);
+}
+
+TEST(CliTest, CompletionZshEmitsZshScript) {
+    Argv args({"spudplate", "completion", "zsh"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("#compdef spudplate"), std::string::npos);
+    EXPECT_NE(out.str().find("_describe"), std::string::npos);
+    EXPECT_NE(out.str().find("_files"), std::string::npos);
+}
+
+TEST(CliTest, CompletionMissingShellPrintsUsage) {
+    Argv args({"spudplate", "completion"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("usage: spudplate completion"), std::string::npos);
+}
+
+TEST(CliTest, CompletionUnknownShellRejected) {
+    Argv args({"spudplate", "completion", "fish"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("unknown shell 'fish'"), std::string::npos);
+}
+
+TEST(CliTest, CompletionHelpPrintsToStdout) {
+    Argv args({"spudplate", "completion", "--help"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("usage: spudplate completion"), std::string::npos);
+    EXPECT_EQ(out.str().find("compgen"), std::string::npos);  // not the script
+}
+
+TEST(CliTest, TopLevelUsageMentionsCompletion) {
+    Argv args({"spudplate", "--help"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("completion"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

Adds shell completion for bash and zsh, a friendlier not-found message for `spudplate run`, and a quick up-to-date check on `spudplate update`. Also cleans up the bootstrap installer script.

## Changes

- `spudplate completion bash` and `spudplate completion zsh` print completion scripts to stdout. Completion handles subcommands (so `spudplate vali<tab>` expands to `validate`), installed template names for `run`, `inspect`, `uninstall`, and `*.spud` files for `install`, `validate`. `install.sh` writes the scripts to the standard XDG completion directories on install.
- `spudplate run unknownname` now prints `'unknownname' is not installed` and, when there is a clearly closest installed name within typo distance, suggests it. Falls back to a hint about `spudplate list` when there is no good suggestion.
- `spudplate update` resolves the latest released tag via the `releases/latest` redirect on github.com, short-circuits to `already up to date (vX.Y.Z)` when the local version matches, and adds `--force` to bypass the check. Fail-open on resolve failure with a stderr warning.
- `install.sh` cleanup: inline single-use helpers, collapse the OS and arch double-guard into one case, detect curl, wget, and the shasum tool once at startup. Net 30 lines smaller.
- Version bump to 0.2.2.

## Test plan

- All 701 (13 new) tests pass locally.
- New tests cover the not-found message and suggestion logic, the update version-check and `--force` paths, and the completion subcommand.
- Manual smoke: bash completion output passes `bash -n`. Running install.sh against a temp HOME exercised the graceful fallback when an installed binary lacks the `completion` subcommand.