### PR TITLE
feat: self-uninstall and zsh autosetup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(spudplate VERSION 0.2.2 LANGUAGES CXX)
+project(spudplate VERSION 0.3.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/install.sh
+++ b/install.sh
@@ -96,6 +96,9 @@ main() {
             info "  export PATH=\"$PREFIX/bin:\$PATH\""
             ;;
     esac
+
+    info ""
+    info "to uninstall later: spudplate self-uninstall (add --purge to also drop installed templates)"
 }
 
 install_completions() {

--- a/install.sh
+++ b/install.sh
@@ -118,9 +118,28 @@ install_completions() {
     info "shell completion installed:"
     info "  bash: $bash_dir/spudplate"
     info "  zsh:  $zsh_dir/_spudplate"
+
+    setup_zshrc
+}
+
+setup_zshrc() {
+    [ "$(basename "${SHELL:-}")" = zsh ] || return 0
+    zshrc="$HOME/.zshrc"
+    marker_start="# >>> spudplate completion >>>"
+    marker_end="# <<< spudplate completion <<<"
+    if [ -f "$zshrc" ] && grep -qF "$marker_start" "$zshrc"; then
+        return 0
+    fi
+    {
+        printf '\n%s\n' "$marker_start"
+        # shellcheck disable=SC2016  # written verbatim into .zshrc; zsh expands $fpath at startup
+        printf '%s\n' 'fpath=(~/.zsh/completions $fpath)'
+        printf '%s\n' 'autoload -U compinit && compinit'
+        printf '%s\n' "$marker_end"
+    } >>"$zshrc"
     info ""
-    info "zsh users: ensure $zsh_dir is on your fpath, e.g. in ~/.zshrc:"
-    info "  fpath=($zsh_dir \$fpath); autoload -U compinit && compinit"
+    info "added zsh completion setup to $zshrc"
+    info "open a new shell or run 'source $zshrc' to enable"
 }
 
 main "$@"

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -16,6 +16,12 @@
 #include <system_error>
 #include <vector>
 
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "spudplate/binary_serializer.h"
 #include "spudplate/bundler.h"
 #include "spudplate/cli_internal.h"
@@ -58,6 +64,9 @@ void print_usage(std::ostream& out) {
         << "  update [--yes] [--force]        fetch and install the latest spudplate "
            "release\n"
         << "  completion <bash|zsh>           print a shell completion script\n"
+        << "  self-uninstall [--purge] [-y]   remove spudplate, its completion files,\n"
+        << "                                  and its block in ~/.zshrc; --purge also\n"
+        << "                                  deletes every installed template\n"
         << "\n"
         << "Run 'spudplate <command> --help' for help on a specific command.\n"
         << "Use --help or -h at any level to see this guidance.\n";
@@ -122,6 +131,18 @@ void print_help_version(std::ostream& out) {
     out << "usage: spudplate version\n"
         << "\n"
         << "Print the spudplate version and exit.\n";
+}
+
+void print_help_self_uninstall(std::ostream& out) {
+    out << "usage: spudplate self-uninstall [--purge] [--yes]\n"
+        << "\n"
+        << "Remove the spudplate binary, its shell completion files, and\n"
+        << "the completion block in ~/.zshrc added at install time.\n"
+        << "\n"
+        << "Options:\n"
+        << "  --purge         also delete every installed template "
+           "(.spp files)\n"
+        << "  --yes, -y       skip the confirmation prompt\n";
 }
 
 void print_help_completion(std::ostream& out) {
@@ -623,6 +644,209 @@ _spudplate "$@"
 )ZSH";
 }
 
+// Resolve the absolute path of the running binary. `SPUDPLATE_SELF_BINARY`
+// overrides for tests. On Linux we use `/proc/self/exe`; on macOS the
+// dyld API. Returns an empty path on failure (in which case the caller
+// reports and skips binary removal).
+std::filesystem::path resolve_self_path() {
+    if (const char* env = std::getenv("SPUDPLATE_SELF_BINARY");
+        env != nullptr && *env != '\0') {
+        return env;
+    }
+#ifdef __APPLE__
+    char buf[4096];
+    uint32_t size = sizeof(buf);
+    if (_NSGetExecutablePath(buf, &size) != 0) {
+        return {};
+    }
+    std::error_code ec;
+    auto canon = std::filesystem::canonical(buf, ec);
+    return ec ? std::filesystem::path{buf} : canon;
+#else
+    char buf[4096];
+    ssize_t n = readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+    if (n <= 0) {
+        return {};
+    }
+    buf[n] = '\0';
+    return buf;
+#endif
+}
+
+std::filesystem::path home_dir() {
+    if (const char* h = std::getenv("HOME"); h != nullptr && *h != '\0') {
+        return h;
+    }
+    return {};
+}
+
+// Remove the spudplate completion block (delimited by the markers
+// `setup_zshrc` writes in install.sh) from `zshrc`. Returns true if a
+// block was found and removed. Does nothing and returns false if the
+// file does not exist or contains no marker.
+bool remove_zshrc_block(const std::filesystem::path& zshrc) {
+    if (!std::filesystem::is_regular_file(zshrc)) {
+        return false;
+    }
+    std::ifstream in(zshrc);
+    if (!in) {
+        return false;
+    }
+    std::string content((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    in.close();
+    const std::string start_marker = "# >>> spudplate completion >>>";
+    const std::string end_marker = "# <<< spudplate completion <<<";
+    auto start = content.find(start_marker);
+    if (start == std::string::npos) {
+        return false;
+    }
+    auto end = content.find(end_marker, start);
+    if (end == std::string::npos) {
+        return false;
+    }
+    end += end_marker.size();
+    if (end < content.size() && content[end] == '\n') {
+        ++end;
+    }
+    if (start > 0 && content[start - 1] == '\n') {
+        --start;
+    }
+    content.erase(start, end - start);
+    std::ofstream out(zshrc);
+    if (!out) {
+        return false;
+    }
+    out << content;
+    return true;
+}
+
+std::vector<std::filesystem::path> list_installed_spp_paths(
+    const std::filesystem::path& home) {
+    std::vector<std::filesystem::path> paths;
+    if (!std::filesystem::is_directory(home)) {
+        return paths;
+    }
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
+        if (entry.is_regular_file() && ends_with_spp(entry.path())) {
+            paths.push_back(entry.path());
+        }
+    }
+    return paths;
+}
+
+int cmd_self_uninstall(int argc, char* argv[], std::ostream& out,
+                       std::ostream& err) {
+    bool purge = false;
+    bool skip_confirm = false;
+    int positional_start = 2;
+    while (positional_start < argc) {
+        std::string arg{argv[positional_start]};
+        if (is_help_flag(arg)) {
+            print_help_self_uninstall(out);
+            return 0;
+        }
+        if (arg == "--purge") {
+            purge = true;
+            ++positional_start;
+        } else if (arg == "--yes" || arg == "-y") {
+            skip_confirm = true;
+            ++positional_start;
+        } else {
+            break;
+        }
+    }
+    if (argc - positional_start != 0) {
+        print_usage(err);
+        return 1;
+    }
+
+    std::filesystem::path binary = resolve_self_path();
+    std::filesystem::path home = home_dir();
+    std::filesystem::path bash_completion;
+    std::filesystem::path zsh_completion;
+    std::filesystem::path zshrc;
+    if (!home.empty()) {
+        bash_completion = home / ".local" / "share" / "bash-completion" /
+                          "completions" / "spudplate";
+        zsh_completion = home / ".zsh" / "completions" / "_spudplate";
+        zshrc = home / ".zshrc";
+    }
+    std::filesystem::path templates_root = install_dir();
+
+    std::vector<std::filesystem::path> spp_paths;
+    if (purge) {
+        spp_paths = list_installed_spp_paths(templates_root);
+    }
+
+    out << "this will remove:\n";
+    if (!binary.empty() && std::filesystem::exists(binary)) {
+        out << "  binary:           " << binary.string() << "\n";
+    }
+    if (!bash_completion.empty() && std::filesystem::exists(bash_completion)) {
+        out << "  bash completion:  " << bash_completion.string() << "\n";
+    }
+    if (!zsh_completion.empty() && std::filesystem::exists(zsh_completion)) {
+        out << "  zsh completion:   " << zsh_completion.string() << "\n";
+    }
+    if (!zshrc.empty() && std::filesystem::is_regular_file(zshrc)) {
+        std::ifstream in(zshrc);
+        std::string contents((std::istreambuf_iterator<char>(in)),
+                             std::istreambuf_iterator<char>());
+        if (contents.find("# >>> spudplate completion >>>") !=
+            std::string::npos) {
+            out << "  zsh setup block:  in " << zshrc.string() << "\n";
+        }
+    }
+    if (purge && !spp_paths.empty()) {
+        out << "  installed templates: " << spp_paths.size() << " .spp file"
+            << (spp_paths.size() == 1 ? "" : "s") << " in "
+            << templates_root.string() << "\n";
+    } else if (!purge && !templates_root.empty()) {
+        out << "\ninstalled templates under " << templates_root.string()
+            << " will be preserved (pass --purge to remove them).\n";
+    }
+
+    if (!skip_confirm) {
+        const char* prompt =
+            purge ? "this is irreversible. continue? [y/N] " : "continue? [y/N] ";
+        if (!confirm_yes_no(out, prompt)) {
+            out << "aborted\n";
+            return 0;
+        }
+    }
+
+    std::error_code ec;
+    auto remove_if_exists = [&](const std::filesystem::path& p, const char* label) {
+        if (p.empty() || !std::filesystem::exists(p)) {
+            return;
+        }
+        if (std::filesystem::remove(p, ec)) {
+            out << "  removed " << label << ": " << p.string() << "\n";
+        } else {
+            err << "  failed to remove " << label << ": " << p.string() << ": "
+                << ec.message() << "\n";
+        }
+    };
+    remove_if_exists(bash_completion, "bash completion");
+    remove_if_exists(zsh_completion, "zsh completion");
+    if (!zshrc.empty() && remove_zshrc_block(zshrc)) {
+        out << "  removed zsh setup block from " << zshrc.string() << "\n";
+    }
+    if (purge) {
+        for (const auto& p : spp_paths) {
+            remove_if_exists(p, "template");
+        }
+    }
+    // Remove the binary last so any earlier-step failures still leave the
+    // user with a working binary they can re-invoke after fixing.
+    remove_if_exists(binary, "binary");
+
+    out << "done\n";
+    return 0;
+}
+
 int cmd_completion(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     if (argc >= 3 && is_help_flag(argv[2])) {
         print_help_completion(out);
@@ -1092,6 +1316,9 @@ int cli_main(int argc, char* argv[], std::ostream& out, std::ostream& err,
     }
     if (subcommand == "completion") {
         return cmd_completion(argc, argv, out, err);
+    }
+    if (subcommand == "self-uninstall") {
+        return cmd_self_uninstall(argc, argv, out, err);
     }
     print_usage(err);
     return 1;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -808,10 +808,12 @@ int cmd_self_uninstall(int argc, char* argv[], std::ostream& out,
             << " will be preserved (pass --purge to remove them).\n";
     }
 
+    if (purge) {
+        out << "\nwarning: --purge will permanently delete every installed "
+               "template; this is irreversible\n";
+    }
     if (!skip_confirm) {
-        const char* prompt =
-            purge ? "this is irreversible. continue? [y/N] " : "continue? [y/N] ";
-        if (!confirm_yes_no(out, prompt)) {
+        if (!confirm_yes_no(out, "continue? [y/N] ")) {
             out << "aborted\n";
             return 0;
         }

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -1242,3 +1242,157 @@ TEST(CliTest, TopLevelUsageMentionsCompletion) {
     EXPECT_EQ(code, 0);
     EXPECT_NE(out.str().find("completion"), std::string::npos);
 }
+
+// --- self-uninstall ---
+
+namespace {
+struct SelfUninstallEnv {
+    TmpDir td;
+    std::filesystem::path home;
+    std::filesystem::path bin;
+    std::filesystem::path bash_completion;
+    std::filesystem::path zsh_completion;
+    std::filesystem::path zshrc;
+    std::filesystem::path templates;
+    ScopedEnv home_env{"HOME"};
+    ScopedEnv self_bin{"SPUDPLATE_SELF_BINARY"};
+    ScopedHome spudhome;
+
+    SelfUninstallEnv() : home(td.path() / "home"), templates(home / "templates"),
+                         spudhome(templates) {
+        bin = home / ".local" / "bin" / "spudplate";
+        bash_completion = home / ".local" / "share" / "bash-completion" /
+                          "completions" / "spudplate";
+        zsh_completion = home / ".zsh" / "completions" / "_spudplate";
+        zshrc = home / ".zshrc";
+        std::filesystem::create_directories(bin.parent_path());
+        std::filesystem::create_directories(bash_completion.parent_path());
+        std::filesystem::create_directories(zsh_completion.parent_path());
+        std::filesystem::create_directories(templates);
+        std::ofstream(bin) << "fake-binary\n";
+        std::ofstream(bash_completion) << "fake-bash-completion\n";
+        std::ofstream(zsh_completion) << "fake-zsh-completion\n";
+        write_zshrc_with_block();
+        home_env.set(home.string());
+        self_bin.set(bin.string());
+    }
+
+    void write_zshrc_with_block() {
+        std::ofstream f(zshrc);
+        f << "# user config\n";
+        f << "alias ll=\"ls -la\"\n";
+        f << "\n";
+        f << "# >>> spudplate completion >>>\n";
+        f << "fpath=(~/.zsh/completions $fpath)\n";
+        f << "autoload -U compinit && compinit\n";
+        f << "# <<< spudplate completion <<<\n";
+        f << "\n";
+        f << "export EDITOR=vim\n";
+    }
+
+    void add_template(const std::string& name) {
+        std::ofstream(templates / (name + ".spp")) << "fake-spp\n";
+    }
+};
+}  // namespace
+
+TEST(CliTest, SelfUninstallRemovesBinaryAndCompletions) {
+    SelfUninstallEnv env;
+    Argv args({"spudplate", "self-uninstall", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_FALSE(std::filesystem::exists(env.bin));
+    EXPECT_FALSE(std::filesystem::exists(env.bash_completion));
+    EXPECT_FALSE(std::filesystem::exists(env.zsh_completion));
+    std::ifstream in(env.zshrc);
+    std::string content((std::istreambuf_iterator<char>(in)),
+                        std::istreambuf_iterator<char>());
+    EXPECT_EQ(content.find("spudplate completion"), std::string::npos)
+        << content;
+    EXPECT_NE(content.find("alias ll"), std::string::npos) << content;
+    EXPECT_NE(content.find("EDITOR=vim"), std::string::npos) << content;
+}
+
+TEST(CliTest, SelfUninstallDefaultPreservesTemplates) {
+    SelfUninstallEnv env;
+    env.add_template("alpha");
+    env.add_template("beta");
+    Argv args({"spudplate", "self-uninstall", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_TRUE(std::filesystem::exists(env.templates / "alpha.spp"));
+    EXPECT_TRUE(std::filesystem::exists(env.templates / "beta.spp"));
+    EXPECT_NE(out.str().find("will be preserved"), std::string::npos);
+}
+
+TEST(CliTest, SelfUninstallPurgeRemovesTemplates) {
+    SelfUninstallEnv env;
+    env.add_template("alpha");
+    env.add_template("beta");
+    Argv args({"spudplate", "self-uninstall", "--purge", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_FALSE(std::filesystem::exists(env.templates / "alpha.spp"));
+    EXPECT_FALSE(std::filesystem::exists(env.templates / "beta.spp"));
+    EXPECT_NE(out.str().find("2 .spp files"), std::string::npos);
+}
+
+TEST(CliTest, SelfUninstallPurgeWarnsIrreversibleEvenWithYes) {
+    SelfUninstallEnv env;
+    env.add_template("alpha");
+    Argv args({"spudplate", "self-uninstall", "--purge", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("irreversible"), std::string::npos);
+}
+
+TEST(CliTest, SelfUninstallDeclinedPromptAbortsCleanly) {
+    SelfUninstallEnv env;
+    Argv args({"spudplate", "self-uninstall"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_TRUE(std::filesystem::exists(env.bin));
+    EXPECT_TRUE(std::filesystem::exists(env.bash_completion));
+    EXPECT_TRUE(std::filesystem::exists(env.zsh_completion));
+    EXPECT_NE(out.str().find("aborted"), std::string::npos);
+}
+
+TEST(CliTest, SelfUninstallIdempotentWhenNothingPresent) {
+    SelfUninstallEnv env;
+    std::filesystem::remove(env.bin);
+    std::filesystem::remove(env.bash_completion);
+    std::filesystem::remove(env.zsh_completion);
+    std::filesystem::remove(env.zshrc);
+    Argv args({"spudplate", "self-uninstall", "--yes"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("done"), std::string::npos);
+}
+
+TEST(CliTest, SelfUninstallHelpPrintsToStdout) {
+    Argv args({"spudplate", "self-uninstall", "--help"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0);
+    EXPECT_NE(out.str().find("usage: spudplate self-uninstall"), std::string::npos);
+}


### PR DESCRIPTION
## Summary

Adds a self-uninstall path so users can remove spudplate cleanly, and makes zsh tab completion work without manual rc edits.

## Changes

- New `spudplate self-uninstall` subcommand removes the binary, both completion files, and the spudplate-managed block in `~/.zshrc`. Adds `--purge` to also delete every installed template, with an unconditional irreversibility warning. Adds `--yes` to skip the confirmation prompt. Excluded from tab completion lists (still listed in top-level help).
- The bootstrap installer now appends a marked block to `~/.zshrc` for users whose `$SHELL` is zsh, putting `~/.zsh/completions` on `fpath` and running `compinit`. Idempotent via marker grep so re-running install or update is safe.
- Installer prints a hint at the end pointing users at `spudplate self-uninstall`.
- Version bump to 0.3.0 since self-uninstall is a new feature.

## Test plan

- All 708 (7 new) tests pass locally.
- New tests cover default scope removal preserving templates, `--purge` removal of templates, irreversibility warning even with `--yes`, declined prompt aborting cleanly, idempotency on already-uninstalled state, and the help path.
- Manual smoke: end-to-end install of a template under a temp HOME, then `self-uninstall --purge --yes` against the v0.3.0 binary. Binary, completion files, zshrc block, and `.spp` files all removed; surrounding `.zshrc` content preserved.