### PR TITLE
feat: include with bundled deps and v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+This file records notable changes per release. Older versions live on the
+[GitHub Releases](https://github.com/spuddydev/spudplate/releases) page.
+
+## v0.4.0
+
+### include statements run in place against bundled dependencies
+
+`include` is no longer a stub. The statement now:
+
+- Bundles the named dependency's bytes into the parent at install time, so a
+  template you share carries every template it depends on. The recipient
+  does not need the dependency installed separately.
+- Runs the dependency inline at the include point, with isolated variable
+  scope. Prompts interleave with the parent's in source order, and
+  filesystem operations join the parent's deferred queue, so the whole tree
+  either commits together or leaves the disk untouched.
+
+```
+ask use_claude "Set up Claude config?" bool default false
+include claude_setup when use_claude
+ask name "Project name?" string
+```
+
+The `when` clause is evaluated at runtime and skips the entire dependency
+when false. Nested includes are capped at sixteen levels deep.
+
+### Spudpack format v3
+
+The spudpack on-disk format gains a real dependency section. Each dep is a
+bare-identifier name plus the full bytes of another spudpack. v1 and v2
+packs still decode unchanged and continue to require `dep_count == 0`. See
+the [Spudpack Binary Format](docs/spudpack-format.md) reference for the
+full layout.
+
+### Author guidance
+
+If you ship a template that uses `include`, install the dependency first,
+then install your parent. The parent is then self-contained and can be
+shared as a single `.spp`.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
-project(spudplate VERSION 0.3.1 LANGUAGES CXX)
+project(spudplate VERSION 0.4.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/docs/lang/best-practices.md
+++ b/docs/lang/best-practices.md
@@ -290,7 +290,7 @@ ask use_claude "Set up Claude config?" bool default false
 include claude_setup when use_claude
 ```
 
-The included template runs as its own subprocess, asks its own questions, and stays maintainable independently.
+The included template runs inline at the include point, asks its own questions in source order, and stays maintainable independently. Its bytes are bundled into the parent at install time, so the recipient does not need the dependency installed separately.
 
 ### Keep includes opt-in
 

--- a/docs/lang/statements/include.md
+++ b/docs/lang/statements/include.md
@@ -4,26 +4,31 @@
 include <name> [when <condition>]
 ```
 
-Runs another installed spudplate template by name, as an **independent subprocess**. The included template has its own questions, its own filesystem operations, and no shared scope with the caller.
+Runs another installed spudplate template by name, **inline at the include point**. The included template has isolated variable scope, but its prompts and filesystem operations interleave with the caller's in source order.
 
 [TOC]
 
-## Subprocess semantics
+## In-place semantics
 
-`include` is not source-level inlining. The named template is invoked as a fresh `spudplate run`, with its own:
+`include` is not source-level inlining and it is not a subprocess. It runs the named template as a child of the current run, at the position where the `include` statement appears, with:
 
-- Variable scope. Nothing the caller has bound is visible inside; nothing the includee binds leaks back out.
-- Prompt sequence. The user answers the includee's questions in addition to the caller's.
-- Filesystem flush. The includee writes its own files independently, in whichever directory it was designed to use.
+- **Isolated variable scope.** Nothing the caller has bound is visible inside; nothing the includee binds leaks back out.
+- **In-place prompts.** Statements run top to bottom across the parent and the includee, so the user answers the includee's questions at exactly the point the `include` appears.
+- **Shared filesystem flush.** The includee's `mkdir`, `file`, and `copy` operations join the parent's deferred queue. The whole run either commits or makes no changes.
 
-This isolation makes templates composable: a `claude_setup` template can be included by both a Python project template and a Rust project template without either knowing how the other works.
+The result is composable templates: a `claude_setup` template can be included by both a Python project template and a Rust project template without either knowing how the other works.
+
+```
+ask use_claude "Set up Claude config?" bool default false
+include claude_setup when use_claude
+ask name "Project name?" string
+```
+
+The user is prompted for `use_claude`, then (if true) for whatever questions `claude_setup` defines, then for `name`.
 
 ## Resolving the name
 
-The argument to `include` is a bare identifier (no quotes). It is matched against installed templates:
-
-- When running a `.spud` file directly, the name is looked up in the install registry (`$SPUDPLATE_HOME`, `$XDG_DATA_HOME/spudplate`, or `~/.local/share/spudplate`). The named template must already be installed.
-- When running an installed `.spp`, the bundler may have copied the dependency into the bundle's `_deps/` slot at export time, so the recipient does not need a separate install. (The current bundler does not yet do this; see `_deps` in @ref lang_reference "Language Reference".)
+The argument to `include` is a bare identifier (no quotes). At install time, the named template must already be installed under the install root (`$SPUDPLATE_HOME`, `$XDG_DATA_HOME/spudplate`, or `~/.local/share/spudplate`). The bundler reads the bytes of `<install-root>/<name>.spp` and embeds them inside the parent spudpack as a dependency. At run time the parent reads the dep from its own bundle, so the recipient does not need the dep separately installed.
 
 ## when
 
@@ -36,12 +41,17 @@ include claude_setup when use_claude
 
 If `use_claude` is `false`, the includee is not invoked and asks no questions.
 
+## Limits
+
+- Nested includes are capped at sixteen levels deep. Hitting the cap is almost always a self-include cycle that snuck past install-time checks; raise it only with care.
+- A dep that fails to decode, deserialise, or validate at run time produces a runtime error tagged with the include site.
+
 ## Why no source inlining
 
 Source inlining was deliberately excluded. The reasons:
 
 - **Author independence.** A team can ship `claude_setup` and a Python template independently; the Python template's stability does not depend on `claude_setup`'s source not changing.
-- **Trust boundaries.** Each `.spud` runs as itself, so the user's "do you trust this template?" prompt is per-template.
+- **Trust boundaries.** Each `.spud` is validated and its `run` clauses are surfaced for explicit consent; isolated scope keeps each template's questions and bindings clearly its own.
 - **Scoping clarity.** With no shared scope, there is no ambiguity about whose `let` or `ask` is whose.
 
 If you want shared logic across templates, factor it into a small standalone template and `include` it.

--- a/docs/lang/statements/index.md
+++ b/docs/lang/statements/index.md
@@ -15,7 +15,7 @@ A spudlang program is a sequence of statements that the interpreter executes top
 | @subpage lang_stmt_copy    | Merge a source directory into an existing destination                  |
 | @subpage lang_stmt_repeat  | Loop a block N times, with a per-iteration index                       |
 | @subpage lang_stmt_if      | Run a block when a condition is true                                   |
-| @subpage lang_stmt_include | Run another installed template as a subprocess                         |
+| @subpage lang_stmt_include | Run another bundled template inline with isolated variable scope        |
 | @subpage lang_stmt_run     | Execute a shell command after explicit user authorisation              |
 
 ## What should I use?
@@ -61,14 +61,14 @@ Use `repeat` with an `int` count. The iterator is local to the loop body. `ask` 
 
 | If you want to...                                              | Use                                       |
 |----------------------------------------------------------------|-------------------------------------------|
-| Run another spudplate template as a subprocess                  | `include`                                 |
+| Run another bundled template inline at this point               | `include`                                 |
 | Run a shell command after the user authorises                   | `run`                                     |
 
 ## Execution model
 
 Filesystem actions (`mkdir`, `file`, `copy`) are queued during execution and flushed at the end of the run. Internal state (variables, loop counters, `if` and `when` evaluations) runs throughout, so a `let` based on an `ask` answer is bound the moment the answer is received, not at flush time.
 
-`run` and `include` execute in source order alongside the queued filesystem operations during the flush. A failed `run` aborts the rest of the flush; operations queued before the failure remain on disk.
+`include` runs the bundled child template inline at the include point, so its prompts interleave with the parent's in source order; the child's filesystem operations join the parent's deferred queue. `run` executes during the flush. A failed `run` aborts the rest of the flush; operations queued before the failure remain on disk.
 
 If the user aborts at any prompt, no flush happens and the filesystem is untouched.
 

--- a/docs/spudpack-format.md
+++ b/docs/spudpack-format.md
@@ -10,7 +10,7 @@ This document is the on-disk contract. The encoder lives in `src/spudpack.cpp`; 
 
 ```
 magic    "SPUD"        4 bytes
-version  u8            1 byte    currently 2; 1 still accepted on decode
+version  u8            1 byte    currently 3; 1 and 2 still accepted on decode
 flags    u8            1 byte    must be 0
 source   length+bytes            varint length, raw UTF-8 source
 program  length+bytes            varint length, opaque AST bytes
@@ -19,7 +19,10 @@ per asset:
   path   length+bytes            varint length, normalised path
   mode   u16 LE                  POSIX mode bits, masked to 0o0777
   data   length+bytes            varint length, raw bytes
-dep_count varint                  reserved, must be 0
+dep_count varint                  number of dependency records (must be 0 in v1/v2)
+per dep:
+  name   length+bytes            varint length, bare identifier
+  blob   length+bytes            varint length, full bytes of another spudpack
 trailer  u32 LE                  CRC32 over [0, size-4)
 ```
 
@@ -33,8 +36,9 @@ All multi-byte integers are little-endian. Variable-length integers (`varint`) a
 |---------|--------|
 | 1 | Original format. |
 | 2 | `RunStmt` gains a trailing optional `timeout` field (one present-flag byte plus, if set, the encoded expression). Packs without `run` statements are byte-identical to v1 once the version byte is bumped. |
+| 3 | `dep_count` may be nonzero. Each dep is a bare-identifier name plus the full bytes of another spudpack. v1 and v2 packs still require `dep_count == 0`. |
 
-The encoder always writes the latest version. The decoder accepts v1 and v2; the version is threaded through to the binary deserialiser so trailing-optional fields decode correctly across versions. Adding a future v3 is mechanical: append the new fields, bump `kVersion`, branch the decoder.
+The encoder always writes the latest version. The decoder accepts every version in `[kMinVersion, kVersion]`; the version is threaded through to the binary deserialiser so trailing-optional fields decode correctly across versions.
 
 ---
 
@@ -45,8 +49,10 @@ The decoder rejects malformed input before any allocation. Every cap below is en
 | Cap | Value |
 |-----|-------|
 | Per-asset bytes | 256 MiB |
+| Per-dep bytes | 256 MiB |
 | Total file size | 2 GiB |
 | Asset count | 2^20 (1,048,576) |
+| Dep count | 1024 |
 | Varint length | 10 bytes |
 | Recursion depth (binary AST) | 256 |
 
@@ -94,7 +100,9 @@ Common failure cases:
 - `spudpack truncated` - length read past the end.
 - `spudpack varint exceeds 10 bytes` - oversize varint.
 - `asset_count exceeds maximum` - hostile asset count.
-- `spudpack does not support deps` - non-zero `dep_count`.
+- `spudpack vN does not support deps` - non-zero `dep_count` in a v1 or v2 pack.
+- `dep_count exceeds maximum` - hostile dep count.
+- `spudpack dep name is not a bare identifier` - dep name contains `/`, NUL, or is `.` / `..`.
 - `spudpack CRC mismatch` - trailer does not match recomputed CRC.
 
 ---
@@ -103,4 +111,3 @@ Common failure cases:
 
 - **Compression.** Assets are stored uncompressed. A future version may add a flag bit and a compressed-asset variant.
 - **Signatures.** There is no signing or authentication. The CRC is integrity, not authenticity.
-- **Dependencies.** `dep_count` is reserved at 0 today; the planned `include` bundling work will use it.

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -315,12 +315,17 @@ struct RunStmt {
 };
 
 /**
- * @brief An `include` statement - runs another installed template as a subprocess.
+ * @brief An `include` statement - runs another bundled template inline.
  *
  * Example: `include claude_setup when use_claude`
  *
- * The named template is referenced by its installed name and runs in its own
- * scope at runtime. The optional `when` clause skips the include if false.
+ * At install time the bundler reads the bytes of the named installed
+ * template and embeds them as a dep inside the parent spudpack. At run
+ * time the include site decodes the dep, deserialises and validates the
+ * dep program, and runs it inline at the include point with isolated
+ * variable scope. Prompts interleave with the parent's in source order;
+ * filesystem operations join the parent's deferred queue. The optional
+ * `when` clause skips the include entirely if false.
  */
 struct IncludeStmt {
     std::string name;                    ///< Name of the installed template to run.

--- a/include/spudplate/bundler.h
+++ b/include/spudplate/bundler.h
@@ -12,16 +12,22 @@
 namespace spudplate {
 
 /**
- * @brief The set of assets a parsed program references on disk.
+ * @brief The set of assets and dependencies a parsed program references.
  *
  * Asset paths are normalised (forward-slash separators, no leading `/`,
  * no `.` or `..` segments, no embedded NUL) and deduped by path - entries
  * with the same normalised path are collapsed iff their bytes and mode
  * match. A trailing `/` on a path means "empty leaf directory" and the
  * data field is empty.
+ *
+ * Deps are the bytes of every installed `.spp` referenced by an `include`
+ * statement, deduped by name. Deps appear in source-order of their first
+ * include site so error messages for cross-dep clashes name the earliest
+ * point where a name became live.
  */
 struct BundleResult {
     std::vector<SpudpackAsset> assets;  ///< Deduped, normalised assets ready to embed in a spudpack.
+    std::vector<SpudpackDep> deps;      ///< Deduped, name-keyed dependencies ready to embed in a spudpack.
 };
 
 /**
@@ -45,12 +51,20 @@ class BundleError : public std::runtime_error {
 };
 
 /**
- * @brief Walk a parsed program and collect every asset it references.
+ * @brief Walk a parsed program and collect every asset and dependency it references.
  *
  * `source_root` is the directory the source `.spud` lives in - relative
  * source paths in `file ... from`, `mkdir ... from`, and `copy` resolve
- * against it. The bundler dereferences symlinks, breaks loops on
- * canonical directory paths, and rejects:
+ * against it.
+ *
+ * `install_root` is the directory installed templates live in. Each
+ * `include <name>` statement resolves to `<install_root>/<name>.spp` and
+ * the file's bytes are attached as a dep. An empty `install_root` means
+ * the caller is not in install mode and any `include` statement is a
+ * `BundleError`.
+ *
+ * The bundler dereferences symlinks, breaks loops on canonical directory
+ * paths, and rejects:
  *   - source paths whose first segment is dynamic (interpolation or alias)
  *   - dynamic segments that splice mid-filename
  *   - `copy` sources that resolve to a regular file
@@ -58,9 +72,13 @@ class BundleError : public std::runtime_error {
  *   - entries whose canonical target falls outside canonical source_root
  *   - duplicates with the same normalised path but conflicting bytes or
  *     mode
+ *   - `include` whose name is not installed under `install_root`
+ *   - `include` whose resolved file is not a regular file or fails to
+ *     decode as a valid spudpack
  */
 BundleResult bundle_assets(const Program& program,
-                           const std::filesystem::path& source_root);
+                           const std::filesystem::path& source_root,
+                           const std::filesystem::path& install_root = {});
 
 }  // namespace spudplate
 

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -291,11 +291,19 @@ class AssetMapSourceProvider final : public SourceProvider {
  * per-`run` timeout enforcement entirely - both the 60-second default and
  * any per-statement `timeout <int>` clause. Useful for known-slow templates
  * and CI runs where an outer scheduler already enforces wall-clock limits.
+ *
+ * `deps` is the dependency vector decoded from the parent spudpack. Each
+ * `include <name>` statement looks the name up here, decodes the bundled
+ * `.spp` bytes, and runs the dependency inline at the include point with
+ * isolated variable scope. A null `deps` argument means the program may
+ * not contain any `include` statements; one that does will throw
+ * `RuntimeError` at the include site.
  */
 void run(const Program& program, Prompter& prompter,
          bool skip_authorization = false,
          const SourceProvider* source = nullptr,
-         bool timeouts_disabled = false);
+         bool timeouts_disabled = false,
+         const std::vector<SpudpackDep>* deps = nullptr);
 
 /**
  * @brief Test-only entry point: like `run`, but returns the final environment.
@@ -304,7 +312,8 @@ void run(const Program& program, Prompter& prompter,
  * on bindings without relying on filesystem side effects.
  */
 Environment run_for_tests(const Program& program, Prompter& prompter,
-                          const SourceProvider* source = nullptr);
+                          const SourceProvider* source = nullptr,
+                          const std::vector<SpudpackDep>* deps = nullptr);
 
 /**
  * @brief Run a program without touching the filesystem.
@@ -324,7 +333,8 @@ Environment run_for_tests(const Program& program, Prompter& prompter,
  */
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
              bool ascii_only = false,
-             const SourceProvider* source = nullptr);
+             const SourceProvider* source = nullptr,
+             const std::vector<SpudpackDep>* deps = nullptr);
 
 /**
  * @brief Heuristic check: does the current environment look UTF-8 capable?

--- a/include/spudplate/spudpack.h
+++ b/include/spudplate/spudpack.h
@@ -26,8 +26,23 @@ struct SpudpackAsset {
 };
 
 /**
+ * @brief One bundled dependency inside a spudpack.
+ *
+ * Each dep is the complete byte stream of another spudpack referenced by an
+ * `include <name>` statement in the parent program. Names match the bare
+ * identifier used in `include` and follow the same rules as installed
+ * template names: nonempty, no `/`, no NUL, not `.` or `..`. Bytes are kept
+ * opaque - the consumer decodes them through `spudpack_decode` when an
+ * `include` statement actually fires at runtime.
+ */
+struct SpudpackDep {
+    std::string name;                ///< Bare include name, matching `<name>.spp` on the install root.
+    std::vector<std::uint8_t> bytes; ///< Full byte stream of the bundled dep's spudpack.
+};
+
+/**
  * @brief A decoded spudpack - the source text, the opaque compiled program,
- * and every bundled asset.
+ * every bundled asset, and every bundled dependency.
  *
  * `program_bytes` is held opaquely; this header does not include the
  * binary-serializer header so the codec stays decoupled from the AST.
@@ -37,7 +52,8 @@ struct Spudpack {
     std::string source;                       ///< Original `.spud` source text.
     std::vector<std::uint8_t> program_bytes;  ///< Opaque serialised AST; decoded by the binary serializer.
     std::vector<SpudpackAsset> assets;        ///< Every bundled asset referenced by the program.
-    std::uint8_t version{2};                  ///< Spudpack format version that produced these bytes. Threaded into the binary serializer so trailing-optional fields decode correctly across versions.
+    std::vector<SpudpackDep> deps;            ///< Every bundled dependency referenced by `include` statements.
+    std::uint8_t version{3};                  ///< Spudpack format version that produced these bytes. Threaded into the binary serializer so trailing-optional fields decode correctly across versions.
 };
 
 /**
@@ -60,11 +76,13 @@ class SpudpackError : public std::runtime_error {
 /**
  * @brief Encode a `Spudpack` into a tightly packed byte stream.
  *
- * Layout: magic `"SPUD"` (4 bytes), version `u8` (currently `2`; `1` is
- * still accepted on decode for backward compatibility), flags `u8 = 0`,
- * `varint`+`bytes` source, `varint`+`bytes` program, `varint` asset_count,
- * per asset (`varint`+`bytes` path, `u16 LE` mode, `varint`+`bytes` data),
- * `varint` dep_count `= 0`, `u32 LE` CRC32 over `[0, size-4)`.
+ * Layout: magic `"SPUD"` (4 bytes), version `u8` (currently `3`; `1` and
+ * `2` are still accepted on decode for backward compatibility), flags
+ * `u8 = 0`, `varint`+`bytes` source, `varint`+`bytes` program, `varint`
+ * asset_count, per asset (`varint`+`bytes` path, `u16 LE` mode,
+ * `varint`+`bytes` data), `varint` dep_count, per dep (`varint`+`bytes`
+ * name, `varint`+`bytes` blob), `u32 LE` CRC32 over `[0, size-4)`. Packs
+ * decoded as v1 or v2 must report `dep_count = 0`; v3 may carry deps.
  */
 std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack);
 
@@ -72,11 +90,12 @@ std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack);
  * @brief Decode a byte stream into a `Spudpack`.
  *
  * Validates magic, version, flags, every varint length against the input
- * bounds, the per-asset cap (256 MiB), the total file cap (2 GiB), the
- * asset-count cap (`1 << 20`), each asset path against the normalisation
- * rules, mode bits against `0o7777`, dep count `= 0`, and the trailing
- * CRC32. Every failure throws `SpudpackError` with the byte offset at
- * which decoding gave up.
+ * bounds, the per-asset and per-dep cap (256 MiB), the total file cap
+ * (2 GiB), the asset-count cap (`1 << 20`), the dep-count cap (`1 << 10`),
+ * each asset path against the normalisation rules, each dep name against
+ * the bare-identifier rules, mode bits against `0o7777`, and the trailing
+ * CRC32. v1 and v2 packs are rejected if `dep_count != 0`. Every failure
+ * throws `SpudpackError` with the byte offset at which decoding gave up.
  */
 Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size);
 

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -102,8 +102,9 @@ std::uint16_t disk_mode_to_asset_mode(fs::perms p) {
 
 class Bundler {
   public:
-    explicit Bundler(const fs::path& source_root)
-        : root_(fs::weakly_canonical(source_root)) {}
+    Bundler(const fs::path& source_root, const fs::path& install_root)
+        : root_(fs::weakly_canonical(source_root)),
+          install_root_(install_root) {}
 
     BundleResult run(const Program& program) {
         for (const auto& stmt : program.statements) {
@@ -113,6 +114,10 @@ class Bundler {
         out.assets.reserve(by_path_.size());
         for (const auto& key : insertion_order_) {
             out.assets.push_back(std::move(by_path_[key]));
+        }
+        out.deps.reserve(dep_order_.size());
+        for (const auto& name : dep_order_) {
+            out.deps.push_back(std::move(deps_[name]));
         }
         return out;
     }
@@ -143,11 +148,62 @@ class Bundler {
                     for (const auto& body : s.body) {
                         if (body) visit_stmt(*body);
                     }
+                } else if constexpr (std::is_same_v<T, IncludeStmt>) {
+                    process_include(s.name, s.line, s.column);
                 }
-                // AskStmt, LetStmt, AssignStmt, IncludeStmt, RunStmt carry
-                // no asset references and are intentionally skipped.
+                // AskStmt, LetStmt, AssignStmt, RunStmt carry no asset or
+                // dep references and are intentionally skipped.
             },
             stmt.data);
+    }
+
+    // Resolve `include <name>` against the install root, read the bundled
+    // `.spp` bytes, and attach them as a dep. Multiple includes of the
+    // same name dedupe to one record; the first encounter wins on order.
+    void process_include(const std::string& name, int line, int column) {
+        if (deps_.find(name) != deps_.end()) {
+            return;  // already collected
+        }
+        if (install_root_.empty()) {
+            throw BundleError(
+                "include '" + name +
+                    "' has no install root to resolve against",
+                line, column);
+        }
+        if (name.empty() || name.find('/') != std::string::npos ||
+            name.find('\0') != std::string::npos || name == "." ||
+            name == "..") {
+            throw BundleError(
+                "include name is not a bare identifier: '" + name + "'",
+                line, column);
+        }
+        fs::path dep_path = install_root_ / (name + ".spp");
+        std::error_code ec;
+        if (!fs::exists(dep_path, ec) || ec) {
+            throw BundleError(
+                "include '" + name + "' is not installed at " +
+                    dep_path.string(),
+                line, column);
+        }
+        if (!fs::is_regular_file(dep_path, ec) || ec) {
+            throw BundleError(
+                "include '" + name + "' is not a regular file at " +
+                    dep_path.string(),
+                line, column);
+        }
+        std::vector<std::uint8_t> bytes = read_file_bytes(dep_path, line, column);
+        try {
+            spudpack_decode(bytes.data(), bytes.size());
+        } catch (const SpudpackError& e) {
+            throw BundleError(
+                "include '" + name + "' is not a valid spudpack: " + e.what(),
+                line, column);
+        }
+        SpudpackDep dep;
+        dep.name = name;
+        dep.bytes = std::move(bytes);
+        deps_.emplace(name, std::move(dep));
+        dep_order_.push_back(name);
     }
 
     // `file ... from <path>` - the path may resolve to a regular file
@@ -403,14 +459,18 @@ class Bundler {
     }
 
     fs::path root_;
+    fs::path install_root_;
     std::unordered_map<std::string, SpudpackAsset> by_path_;
     std::vector<std::string> insertion_order_;
+    std::unordered_map<std::string, SpudpackDep> deps_;
+    std::vector<std::string> dep_order_;
 };
 
 }  // namespace
 
-BundleResult bundle_assets(const Program& program, const fs::path& source_root) {
-    Bundler b(source_root);
+BundleResult bundle_assets(const Program& program, const fs::path& source_root,
+                           const fs::path& install_root) {
+    Bundler b(source_root, install_root);
     return b.run(program);
 }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -444,10 +444,20 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         return 3;
     }
 
+    std::filesystem::path home = install_dir();
+    if (home.empty()) {
+        err << "cannot determine install directory: set SPUDPLATE_HOME, "
+               "XDG_DATA_HOME, or HOME\n";
+        return 1;
+    }
+
     std::vector<SpudpackAsset> assets;
+    std::vector<spudplate::SpudpackDep> deps;
     try {
-        BundleResult bundled = bundle_assets(program, source_path.parent_path());
+        BundleResult bundled =
+            bundle_assets(program, source_path.parent_path(), home);
         assets = std::move(bundled.assets);
+        deps = std::move(bundled.deps);
     } catch (const BundleError& e) {
         print_error(err, source_path.string(), "bundle error", e.line(), e.column(),
                     e.what());
@@ -460,13 +470,6 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     } catch (const BinarySerializeError& e) {
         err << source_path.string() << ": " << e.what() << "\n";
         return 3;
-    }
-
-    std::filesystem::path home = install_dir();
-    if (home.empty()) {
-        err << "cannot determine install directory: set SPUDPLATE_HOME, "
-               "XDG_DATA_HOME, or HOME\n";
-        return 1;
     }
 
     std::string name = source_path.stem().string();
@@ -513,6 +516,7 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     pack.source = std::move(source);
     pack.program_bytes = std::move(program_bytes);
     pack.assets = std::move(assets);
+    pack.deps = std::move(deps);
 
     try {
         spudpack_write_file(tmp_path, pack);

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1252,16 +1252,20 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
 
     std::optional<AssetMapSourceProvider> provider;
     const SourceProvider* source_ptr = nullptr;
+    const std::vector<spudplate::SpudpackDep>* deps_ptr = nullptr;
     if (have_pack) {
         provider.emplace(pack.assets);
         source_ptr = &*provider;
+        deps_ptr = &pack.deps;
     }
 
     try {
         if (dry_run_mode) {
-            dry_run(program, prompter, out, /*ascii_only=*/!locale_is_utf8(), source_ptr);
+            dry_run(program, prompter, out, /*ascii_only=*/!locale_is_utf8(),
+                    source_ptr, deps_ptr);
         } else {
-            run(program, prompter, skip_authorization, source_ptr, timeouts_disabled);
+            run(program, prompter, skip_authorization, source_ptr,
+                timeouts_disabled, deps_ptr);
         }
     } catch (const RuntimeError& e) {
         print_error(err, file_path.string(), "runtime error", e.line(), e.column(),

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -29,8 +29,10 @@
 #include <unistd.h>
 
 #include "spudplate/ast.h"
+#include "spudplate/binary_serializer.h"
 #include "spudplate/spudpack.h"
 #include "spudplate/token.h"
+#include "spudplate/validator.h"
 
 namespace spudplate {
 
@@ -797,10 +799,27 @@ Value eval_call(const FunctionCallExpr& fc, const Environment& env) {
     type_error("unknown function '" + fc.name + "'", fc.line, fc.column);
 }
 
+// Cap nested `include` chains. A reasonable template tree fits well under
+// this; deep nesting is almost always either a self-include cycle that
+// snuck past install-time checks (e.g. running directly off bundled bytes
+// without a fresh install) or a misuse that would blow the stack.
+constexpr int kMaxIncludeDepth = 16;
+
 class Interpreter {
   public:
-    Interpreter(Prompter& prompter, const SourceProvider& source)
-        : prompter_(prompter), source_(source) {}
+    Interpreter(Prompter& prompter, const SourceProvider& source,
+                const std::vector<SpudpackDep>* deps = nullptr,
+                int include_depth = 0)
+        : prompter_(prompter),
+          source_(source),
+          deps_(deps),
+          include_depth_(include_depth) {
+        if (deps_ != nullptr) {
+            for (const auto& dep : *deps_) {
+                dep_index_.emplace(dep.name, &dep);
+            }
+        }
+    }
 
     void set_ask_total(int total) { ask_total_ = total; }
     void set_timeouts_disabled(bool b) { timeouts_disabled_ = b; }
@@ -838,9 +857,7 @@ class Interpreter {
                 } else if constexpr (std::is_same_v<T, CopyStmt>) {
                     execute_copy(s);
                 } else if constexpr (std::is_same_v<T, IncludeStmt>) {
-                    throw RuntimeError(
-                        "statement 'include' not yet supported in this build",
-                        s.line, s.column);
+                    execute_include(s);
                 } else if constexpr (std::is_same_v<T, RunStmt>) {
                     execute_run(s);
                 } else if constexpr (std::is_same_v<T, IfStmt>) {
@@ -855,6 +872,15 @@ class Interpreter {
         return pending_;
     }
 
+    // Move-out hooks the include path uses to merge a child interpreter's
+    // queued ops and created-paths into the parent at the include site.
+    [[nodiscard]] std::vector<PendingOp> take_pending() {
+        return std::move(pending_);
+    }
+    [[nodiscard]] std::unordered_set<std::string> take_created_paths() {
+        return std::move(created_during_run_);
+    }
+
     void flush() {
         for (const auto& op : pending_) {
             std::visit([&](const auto& o) { run_op(o); }, op);
@@ -862,6 +888,98 @@ class Interpreter {
     }
 
   private:
+    // Decode a bundled dep, deserialise its program, validate it, and run
+    // it inline at the include point. The dep gets a fresh `Environment`
+    // (variable scope is isolated) and its own asset map (its `from`/`copy`
+    // sources resolve against bundled assets, not the parent's). Pending
+    // filesystem ops produced by the dep are appended to the parent's
+    // queue so the whole tree flushes atomically at the end of the run.
+    void execute_include(const IncludeStmt& s) {
+        if (!when_passes(s.when_clause, env_)) {
+            return;
+        }
+        if (include_depth_ >= kMaxIncludeDepth) {
+            throw RuntimeError("include nesting exceeds maximum depth",
+                               s.line, s.column);
+        }
+        auto it = dep_index_.find(s.name);
+        if (it == dep_index_.end()) {
+            throw RuntimeError(
+                "include '" + s.name +
+                    "' was not bundled into this template; reinstall the "
+                    "parent so the dep is captured",
+                s.line, s.column);
+        }
+        const SpudpackDep& dep = *it->second;
+
+        Spudpack dep_pack;
+        try {
+            dep_pack = spudpack_decode(dep.bytes.data(), dep.bytes.size());
+        } catch (const SpudpackError& e) {
+            throw RuntimeError(
+                "include '" + s.name + "' failed to decode: " + e.what(),
+                s.line, s.column);
+        }
+
+        Program dep_program;
+        try {
+            dep_program = deserialize_program(dep_pack.program_bytes.data(),
+                                              dep_pack.program_bytes.size(),
+                                              dep_pack.version);
+        } catch (const std::exception& e) {
+            throw RuntimeError(
+                "include '" + s.name + "' failed to deserialise: " + e.what(),
+                s.line, s.column);
+        }
+
+        try {
+            validate(dep_program);
+        } catch (const std::exception& e) {
+            throw RuntimeError(
+                "include '" + s.name + "' failed validation: " + e.what(),
+                s.line, s.column);
+        }
+
+        AssetMapSourceProvider dep_source(dep_pack.assets);
+        Interpreter child(prompter_, dep_source, &dep_pack.deps,
+                          include_depth_ + 1);
+        child.set_timeouts_disabled(timeouts_disabled_);
+        child.set_ask_total(count_ask_statements_local(dep_program));
+
+        try {
+            for (const auto& stmt : dep_program.statements) {
+                if (stmt) child.execute(*stmt);
+            }
+        } catch (...) {
+            // Drop the child's queued ops on error - we are propagating up
+            // to the parent's exception path which will short-circuit the
+            // flush. Keep the child's already-populated `pending_` out of
+            // the parent so a partial dep run never half-flushes.
+            throw;
+        }
+
+        std::vector<PendingOp> child_pending = child.take_pending();
+        for (auto&& op : child_pending) {
+            pending_.push_back(std::move(op));
+        }
+        std::unordered_set<std::string> child_created =
+            child.take_created_paths();
+        created_during_run_.merge(child_created);
+    }
+
+    // Same shape as the file-scope `count_ask_statements`, defined as a
+    // class member so the include path can call it without the lambda
+    // dance the file-scope helper would otherwise need.
+    static int count_ask_statements_local(const Program& program) {
+        int total = 0;
+        for (const auto& stmt : program.statements) {
+            if (stmt && std::holds_alternative<AskStmt>(stmt->data)) {
+                ++total;
+            }
+        }
+        return total;
+    }
+
     void execute_repeat(const RepeatStmt& s) {
         if (!when_passes(s.when_clause, env_)) {
             return;
@@ -1395,6 +1513,9 @@ class Interpreter {
     Environment env_;
     Prompter& prompter_;
     const SourceProvider& source_;
+    const std::vector<SpudpackDep>* deps_;
+    std::unordered_map<std::string, const SpudpackDep*> dep_index_;
+    int include_depth_;
     AliasMap alias_map_;
     std::vector<PendingOp> pending_;
     std::unordered_set<std::string> created_during_run_;
@@ -1672,7 +1793,8 @@ std::string value_to_string(const Value& value) {
 }
 
 void run(const Program& program, Prompter& prompter, bool skip_authorization,
-         const SourceProvider* source, bool timeouts_disabled) {
+         const SourceProvider* source, bool timeouts_disabled,
+         const std::vector<SpudpackDep>* deps) {
     if (!skip_authorization) {
         std::string summary = build_authorize_summary(program);
         if (!summary.empty() && !prompter.authorize(summary)) {
@@ -1680,15 +1802,18 @@ void run(const Program& program, Prompter& prompter, bool skip_authorization,
         }
     }
     Interpreter interp(prompter,
-                       source != nullptr ? *source : default_source_provider());
+                       source != nullptr ? *source : default_source_provider(),
+                       deps);
     interp.set_timeouts_disabled(timeouts_disabled);
     run_program(program, interp);
 }
 
 Environment run_for_tests(const Program& program, Prompter& prompter,
-                          const SourceProvider* source) {
+                          const SourceProvider* source,
+                          const std::vector<SpudpackDep>* deps) {
     Interpreter interp(prompter,
-                       source != nullptr ? *source : default_source_provider());
+                       source != nullptr ? *source : default_source_provider(),
+                       deps);
     run_program(program, interp);
     return std::move(interp.env());
 }
@@ -1863,9 +1988,11 @@ bool locale_is_utf8() {
 }
 
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
-             bool ascii_only, const SourceProvider* source) {
+             bool ascii_only, const SourceProvider* source,
+             const std::vector<SpudpackDep>* deps) {
     Interpreter interp(prompter,
-                       source != nullptr ? *source : default_source_provider());
+                       source != nullptr ? *source : default_source_provider(),
+                       deps);
     interp.set_ask_total(count_ask_statements(program));
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -19,18 +19,40 @@ namespace {
 constexpr std::array<std::uint8_t, 4> kMagic = {'S', 'P', 'U', 'D'};
 // v1: original format.
 // v2: RunStmt encoding gains a trailing optional `timeout` field; old packs
-// without it deserialise as nullopt. Encoder always writes v2; decoder
-// accepts both 1 and 2 for backward compatibility with shipped packs.
-constexpr std::uint8_t kVersion = 2;
+// without it deserialise as nullopt.
+// v3: dep_count may be nonzero. Per dep: varint name_len, name bytes,
+// varint blob_len, blob bytes. The blob is itself a complete spudpack
+// byte stream. v1 and v2 still require dep_count == 0.
+// Encoder always writes the highest supported version; decoder accepts
+// every version in [kMinVersion, kVersion].
+constexpr std::uint8_t kVersion = 3;
 constexpr std::uint8_t kMinVersion = 1;
+constexpr std::uint8_t kVersionDepsAllowed = 3;
 constexpr std::uint8_t kFlags = 0;
 
-// Per-asset and per-file caps. Both apply to declared lengths inside the
-// stream and are checked before any allocation so a malformed header
-// cannot trigger a multi-gigabyte `vector::reserve`.
+// Per-asset, per-dep, and per-file caps. All apply to declared lengths
+// inside the stream and are checked before any allocation so a malformed
+// header cannot trigger a multi-gigabyte `vector::reserve`. Dep blobs
+// reuse the per-asset cap since a dep is itself a small spudpack.
 constexpr std::size_t kMaxAssetBytes = std::size_t{256} * 1024 * 1024;
 constexpr std::size_t kMaxTotalBytes = std::size_t{2} * 1024 * 1024 * 1024;
 constexpr std::size_t kMaxAssetCount = std::size_t{1} << 20;
+constexpr std::size_t kMaxDepCount = std::size_t{1} << 10;
+constexpr std::size_t kMaxDepBytes = kMaxAssetBytes;
+
+// A dep name must be a bare identifier matching the rules already enforced
+// by `spudplate install` for installed template names. Specifically: it
+// must be nonempty, free of `/`, free of NUL, and must not be `.` or `..`.
+// Stricter constraints (e.g. shell-safe characters) are not enforced here -
+// the install-time path resolution is the source of truth.
+bool is_valid_dep_name(std::string_view name) noexcept {
+    if (name.empty()) return false;
+    if (name == "." || name == "..") return false;
+    for (char c : name) {
+        if (c == '/' || c == '\0') return false;
+    }
+    return true;
+}
 
 // Producer convention: spudplate's own bundler masks asset modes to 0o0777
 // before encode. The decoder additionally rejects anything outside 0o7777
@@ -270,10 +292,21 @@ std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack) {
         write_length_prefixed(out, asset.data.data(), asset.data.size());
     }
 
-    // dep_count: spudpack v1 does not bundle dependencies. Reserved as a
-    // varint (rather than a fixed byte) so a future version that wants
-    // hundreds of deps does not need a layout change.
-    write_varint(out, 0);
+    if (pack.deps.size() > kMaxDepCount) {
+        throw SpudpackError("spudpack dep_count exceeds maximum");
+    }
+    write_varint(out, static_cast<std::uint64_t>(pack.deps.size()));
+    for (const SpudpackDep& dep : pack.deps) {
+        if (!is_valid_dep_name(dep.name)) {
+            throw SpudpackError("spudpack dep name is not a bare identifier: " +
+                                dep.name);
+        }
+        if (dep.bytes.size() > kMaxDepBytes) {
+            throw SpudpackError("spudpack dep exceeds 256MiB cap: " + dep.name);
+        }
+        write_length_prefixed(out, dep.name.data(), dep.name.size());
+        write_length_prefixed(out, dep.bytes.data(), dep.bytes.size());
+    }
 
     if (out.size() + 4 > kMaxTotalBytes) {
         throw SpudpackError("spudpack exceeds 2GiB total cap");
@@ -363,9 +396,38 @@ Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size) {
     }
 
     std::size_t dep_at = r.offset();
-    std::uint64_t dep_count = r.read_varint();
-    if (dep_count != 0) {
-        throw SpudpackError("spudpack v1 does not support deps", dep_at);
+    std::uint64_t dep_count_raw = r.read_varint();
+    if (version < kVersionDepsAllowed && dep_count_raw != 0) {
+        throw SpudpackError(
+            "spudpack v" + std::to_string(version) + " does not support deps",
+            dep_at);
+    }
+    if (dep_count_raw > kMaxDepCount) {
+        throw SpudpackError("spudpack dep_count exceeds maximum", dep_at);
+    }
+    std::size_t dep_count = static_cast<std::size_t>(dep_count_raw);
+    pack.deps.reserve(dep_count);
+
+    for (std::size_t i = 0; i < dep_count; ++i) {
+        SpudpackDep dep;
+
+        std::size_t name_at = r.offset();
+        std::size_t name_len = r.read_checked_length();
+        r.read_bytes_into(dep.name, name_len);
+        if (!is_valid_dep_name(dep.name)) {
+            throw SpudpackError(
+                "spudpack dep name is not a bare identifier", name_at);
+        }
+
+        std::size_t blob_len_at = r.offset();
+        std::size_t blob_len = r.read_checked_length();
+        if (blob_len > kMaxDepBytes) {
+            throw SpudpackError(
+                "spudpack dep exceeds 256MiB cap", blob_len_at);
+        }
+        r.read_bytes_into(dep.bytes, blob_len);
+
+        pack.deps.push_back(std::move(dep));
     }
 
     if (r.remaining() != 0) {

--- a/tests/bundler_test.cpp
+++ b/tests/bundler_test.cpp
@@ -12,6 +12,7 @@
 
 #include "spudplate/lexer.h"
 #include "spudplate/parser.h"
+#include "spudplate/spudpack.h"
 #include "test_helpers.h"
 
 using spudplate::BundleError;
@@ -19,8 +20,11 @@ using spudplate::BundleResult;
 using spudplate::Lexer;
 using spudplate::Parser;
 using spudplate::Program;
+using spudplate::Spudpack;
 using spudplate::SpudpackAsset;
 using spudplate::bundle_assets;
+using spudplate::spudpack_encode;
+using spudplate::spudpack_write_file;
 using spudplate::test::TmpDir;
 
 namespace fs = std::filesystem;
@@ -111,12 +115,12 @@ TEST(Bundler, NonAssetStatementsAreSkipped) {
     Program p = parse(
         "ask name \"Name?\" string\n"
         "let upper_name = upper(name)\n"
-        "include foo when name == \"x\"\n"
         "run \"echo hi\"\n"
         "file \"inline.txt\" content \"hi\"\n");
 
     BundleResult r = bundle_assets(p, tmp.path());
     EXPECT_TRUE(r.assets.empty());
+    EXPECT_TRUE(r.deps.empty());
 }
 
 // --- path classification ---------------------------------------------------
@@ -234,4 +238,82 @@ TEST(Bundler, SymlinkLoopBroken) {
     } catch (const BundleError&) {
         // Acceptable - escaping or unsupported types may surface here.
     }
+}
+
+// --- include / dep collection ----------------------------------------------
+
+namespace {
+
+// Write a minimal valid `.spp` for `name` under `install_root` so the
+// bundler can resolve `include <name>`. The dep's program/assets are
+// empty - we only care that the bytes round-trip through the codec.
+void install_stub(const fs::path& install_root, const std::string& name) {
+    fs::create_directories(install_root);
+    Spudpack p;
+    p.source = "ask q \"q?\" string\n";
+    p.program_bytes = {};  // empty; bundler does not deserialise the dep
+    spudpack_write_file(install_root / (name + ".spp"), p);
+}
+
+}  // namespace
+
+TEST(Bundler, IncludeCollectsInstalledDep) {
+    TmpDir tmp;
+    fs::path install_root = tmp.path() / "install";
+    install_stub(install_root, "child");
+
+    Program p = parse("include child\n");
+    BundleResult r = bundle_assets(p, tmp.path(), install_root);
+    ASSERT_EQ(r.deps.size(), 1u);
+    EXPECT_EQ(r.deps[0].name, "child");
+    EXPECT_FALSE(r.deps[0].bytes.empty());
+}
+
+TEST(Bundler, IncludeDedupesByName) {
+    TmpDir tmp;
+    fs::path install_root = tmp.path() / "install";
+    install_stub(install_root, "shared");
+
+    Program p = parse(
+        "ask flag \"flag?\" bool default false\n"
+        "include shared\n"
+        "include shared when flag\n");
+    BundleResult r = bundle_assets(p, tmp.path(), install_root);
+    ASSERT_EQ(r.deps.size(), 1u);
+    EXPECT_EQ(r.deps[0].name, "shared");
+}
+
+TEST(Bundler, IncludeWithoutInstallRootIsAnError) {
+    TmpDir tmp;
+    Program p = parse("include foo\n");
+    EXPECT_THROW(bundle_assets(p, tmp.path()), BundleError);
+}
+
+TEST(Bundler, IncludeMissingDepIsAnError) {
+    TmpDir tmp;
+    fs::path install_root = tmp.path() / "install";
+    fs::create_directories(install_root);
+    Program p = parse("include not_installed\n");
+    EXPECT_THROW(bundle_assets(p, tmp.path(), install_root), BundleError);
+}
+
+TEST(Bundler, IncludeInsideRepeatAndIfIsCollected) {
+    TmpDir tmp;
+    fs::path install_root = tmp.path() / "install";
+    install_stub(install_root, "looped");
+    install_stub(install_root, "guarded");
+
+    Program p = parse(
+        "ask n \"n?\" int default 1\n"
+        "ask use_x \"use x?\" bool default false\n"
+        "repeat n as i\n"
+        "  include looped\n"
+        "end\n"
+        "if use_x\n"
+        "  include guarded\n"
+        "end\n");
+    BundleResult r = bundle_assets(p, tmp.path(), install_root);
+    ASSERT_EQ(r.deps.size(), 2u);
+    EXPECT_EQ(r.deps[0].name, "looped");
+    EXPECT_EQ(r.deps[1].name, "guarded");
 }

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -1387,3 +1387,88 @@ TEST(CliTest, SelfUninstallHelpPrintsToStdout) {
     EXPECT_EQ(code, 0);
     EXPECT_NE(out.str().find("usage: spudplate self-uninstall"), std::string::npos);
 }
+
+// --- include with bundled deps ---------------------------------------------
+
+TEST(CliTest, InstallParentBundlesIncludedDep) {
+    TmpDir td;
+    ScopedHome home(td.path() / "home");
+
+    write_file(td.path() / "child.spud", "ask greeting \"Greeting?\" string\n");
+    {
+        Argv args({"spudplate", "install", (td.path() / "child.spud").string()});
+        std::stringstream out;
+        std::stringstream err;
+        ScriptedPrompter prompter({});
+        int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+        ASSERT_EQ(code, 0) << err.str();
+    }
+
+    write_file(td.path() / "parent.spud",
+               "ask before \"Before?\" string\n"
+               "include child\n"
+               "ask after \"After?\" string\n");
+    {
+        Argv args({"spudplate", "install", (td.path() / "parent.spud").string()});
+        std::stringstream out;
+        std::stringstream err;
+        ScriptedPrompter prompter({});
+        int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+        ASSERT_EQ(code, 0) << err.str();
+    }
+
+    auto pack = spudplate::spudpack_read_file(td.path() / "home" / "parent.spp");
+    ASSERT_EQ(pack.deps.size(), 1u);
+    EXPECT_EQ(pack.deps[0].name, "child");
+}
+
+TEST(CliTest, RunInstalledParentPromptsInSourceOrder) {
+    TmpDir td;
+    ScopedHome home(td.path() / "home");
+
+    write_file(td.path() / "child.spud", "ask middle \"Middle?\" string\n");
+    {
+        Argv args({"spudplate", "install", (td.path() / "child.spud").string()});
+        std::stringstream out;
+        std::stringstream err;
+        ScriptedPrompter prompter({});
+        ASSERT_EQ(cli_main(args.argc(), args.argv(), out, err, prompter), 0)
+            << err.str();
+    }
+
+    write_file(td.path() / "parent.spud",
+               "ask before \"Before?\" string\n"
+               "include child\n"
+               "ask after \"After?\" string\n"
+               "mkdir \"{before}_{after}\"\n");
+    {
+        Argv args({"spudplate", "install", (td.path() / "parent.spud").string()});
+        std::stringstream out;
+        std::stringstream err;
+        ScriptedPrompter prompter({});
+        ASSERT_EQ(cli_main(args.argc(), args.argv(), out, err, prompter), 0)
+            << err.str();
+    }
+
+    // Uninstall the child to prove the parent is now self-contained: a
+    // freshly installed parent must run without the dep being separately
+    // present on the install root.
+    {
+        Argv args({"spudplate", "uninstall", "child"});
+        std::stringstream out;
+        std::stringstream err;
+        ScriptedPrompter prompter({});
+        ASSERT_EQ(cli_main(args.argc(), args.argv(), out, err, prompter), 0)
+            << err.str();
+    }
+
+    Argv run_args({"spudplate", "run", "parent"});
+    std::stringstream run_out;
+    std::stringstream run_err;
+    // Source order: before -> middle (from child) -> after.
+    ScriptedPrompter run_prompter({"start", "mid", "end"});
+    int code = cli_main(run_args.argc(), run_args.argv(), run_out, run_err,
+                        run_prompter);
+    EXPECT_EQ(code, 0) << run_err.str();
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "start_end"));
+}

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -15,9 +15,12 @@
 #include <utility>
 
 #include "spudplate/ast.h"
+#include "spudplate/binary_serializer.h"
 #include "spudplate/lexer.h"
 #include "spudplate/parser.h"
+#include "spudplate/spudpack.h"
 #include "spudplate/token.h"
+#include "spudplate/validator.h"
 #include "test_helpers.h"
 
 using spudplate::AliasMap;
@@ -48,10 +51,15 @@ using spudplate::run;
 using spudplate::run_for_tests;
 using spudplate::RuntimeError;
 using spudplate::ScriptedPrompter;
+using spudplate::serialize_program;
+using spudplate::Spudpack;
+using spudplate::SpudpackDep;
+using spudplate::spudpack_encode;
 using spudplate::StdinPrompter;
 using spudplate::StringLiteralExpr;
 using spudplate::TokenType;
 using spudplate::UnaryExpr;
+using spudplate::validate;
 using spudplate::Value;
 using spudplate::value_to_string;
 using spudplate::VarType;
@@ -224,16 +232,64 @@ TEST(InterpreterTest, EmptyProgramRunsCleanly) {
 
 // --- Statement types still pending an implementation ---
 
-TEST(InterpreterTest, IncludeThrowsNotYetSupported) {
-    auto program = parse(R"(include claude_setup
+// Build a self-contained dep blob from spudlang source. The dep has its
+// own asks but no `from`/`copy` references, so the bundler's asset map
+// is empty and the parent test does not need to fake disk state.
+std::vector<std::uint8_t> dep_bytes_from_source(const std::string& source) {
+    Program p = parse(source);
+    validate(p);
+    Spudpack pack;
+    pack.source = source;
+    pack.program_bytes = serialize_program(p);
+    return spudpack_encode(pack);
+}
+
+TEST(InterpreterTest, IncludeRunsDepInPlaceAndIsolatesScope) {
+    // Parent asks `before`, then includes a dep that asks `dep_q`, then
+    // asks `after`. With in-place semantics the user answers in source
+    // order: before -> dep_q -> after.
+    auto dep = dep_bytes_from_source(R"(ask dep_q "dep?" string default "x"
+)");
+    std::vector<SpudpackDep> deps;
+    deps.push_back({"child", dep});
+
+    auto program = parse(R"(ask before "before?" string default "a"
+include child
+ask after "after?" string default "b"
+)");
+    ScriptedPrompter prompter({"first", "middle", "last"});
+    Environment env =
+        run_for_tests(program, prompter, /*source=*/nullptr, &deps);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("before")), "first");
+    EXPECT_EQ(std::get<std::string>(*env.lookup("after")), "last");
+    // The dep's `dep_q` is bound only inside the dep's scope.
+    EXPECT_FALSE(env.lookup("dep_q").has_value());
+}
+
+TEST(InterpreterTest, IncludeRespectsWhenClauseFalse) {
+    auto dep = dep_bytes_from_source(R"(ask dep_q "dep?" string default "x"
+)");
+    std::vector<SpudpackDep> deps;
+    deps.push_back({"child", dep});
+
+    auto program = parse(R"(ask flag "flag?" bool default false
+include child when flag
+ask after "after?" string default "z"
+)");
+    // flag answered false; the dep's prompt must not fire.
+    ScriptedPrompter prompter({"n", "tail"});
+    Environment env =
+        run_for_tests(program, prompter, /*source=*/nullptr, &deps);
+    EXPECT_EQ(std::get<bool>(*env.lookup("flag")), false);
+    EXPECT_EQ(std::get<std::string>(*env.lookup("after")), "tail");
+}
+
+TEST(InterpreterTest, IncludeWithoutBundledDepIsRuntimeError) {
+    // No deps supplied; the include statement has nothing to resolve.
+    auto program = parse(R"(include missing
 )");
     NullPrompter prompter;
-    try {
-        run(program, prompter);
-        FAIL() << "expected RuntimeError";
-    } catch (const RuntimeError& e) {
-        EXPECT_NE(std::string(e.what()).find("include"), std::string::npos);
-    }
+    EXPECT_THROW(run(program, prompter), RuntimeError);
 }
 
 // --- run_for_tests returns the interpreter's environment ---

--- a/tests/spudpack_test.cpp
+++ b/tests/spudpack_test.cpp
@@ -13,6 +13,7 @@
 
 using spudplate::Spudpack;
 using spudplate::SpudpackAsset;
+using spudplate::SpudpackDep;
 using spudplate::SpudpackError;
 using spudplate::is_normalized_asset_path;
 using spudplate::normalize_asset_path;
@@ -163,20 +164,20 @@ TEST(SpudpackCodec, UnsupportedVersionZero) {
     }
 }
 
-TEST(SpudpackCodec, UnsupportedVersionThree) {
-    // v1 and v2 are accepted; v3 (and above) is not.
+TEST(SpudpackCodec, UnsupportedVersionFour) {
+    // v1, v2, and v3 are accepted; v4 (and above) is not.
     Spudpack in = make_simple();
     auto bytes = spudpack_encode(in);
-    bytes[4] = 3;
+    bytes[4] = 4;
     rewrite_crc(bytes);
     EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
 }
 
 TEST(SpudpackCodec, V1FixtureDecodes) {
-    // Encoder writes v2; flip the byte to 1 and rewrite the CRC. Decoding
-    // succeeds and the resulting Spudpack carries version=1 so downstream
-    // code (binary serialiser) can decode RunStmt without the trailing
-    // timeout field.
+    // Encoder writes the highest supported version; flip the byte to 1 and
+    // rewrite the CRC. Decoding succeeds and the resulting Spudpack carries
+    // version=1 so downstream code (binary serialiser) can decode RunStmt
+    // without the trailing timeout field.
     Spudpack in = make_simple();
     auto bytes = spudpack_encode(in);
     bytes[4] = 1;
@@ -184,6 +185,17 @@ TEST(SpudpackCodec, V1FixtureDecodes) {
     auto out = spudpack_decode(bytes.data(), bytes.size());
     EXPECT_EQ(out.version, 1u);
     EXPECT_EQ(out.source, in.source);
+}
+
+TEST(SpudpackCodec, V2FixtureDecodes) {
+    // v2 packs in the wild carry no deps - flip the byte to 2 and decode.
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    bytes[4] = 2;
+    rewrite_crc(bytes);
+    auto out = spudpack_decode(bytes.data(), bytes.size());
+    EXPECT_EQ(out.version, 2u);
+    EXPECT_TRUE(out.deps.empty());
 }
 
 TEST(SpudpackCodec, CrcMismatchDetected) {
@@ -201,8 +213,9 @@ TEST(SpudpackCodec, CrcMismatchDetected) {
     }
 }
 
-TEST(SpudpackCodec, DepCountNonZeroRejected) {
-    // Hand-craft a minimal valid header with dep_count = 1.
+TEST(SpudpackCodec, DepCountNonZeroInV1Rejected) {
+    // Hand-craft a minimal valid header with version=1 and dep_count=1.
+    // v1 packs in the wild never carry deps, so the decoder must refuse.
     std::vector<std::uint8_t> bytes;
     bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
     bytes.push_back(1);  // version
@@ -218,6 +231,95 @@ TEST(SpudpackCodec, DepCountNonZeroRejected) {
         FAIL() << "expected throw";
     } catch (const SpudpackError& e) {
         EXPECT_NE(std::string(e.what()).find("does not support deps"),
+                  std::string::npos);
+    }
+}
+
+TEST(SpudpackCodec, RoundTripWithDeps) {
+    // Build a self-contained dep blob first, then bundle two of them as
+    // deps of an outer pack. The dep bytes are stored opaquely so the
+    // outer encode/decode does not care about their internals.
+    Spudpack inner_a;
+    inner_a.source = "ask q \"q?\" string\n";
+    inner_a.program_bytes = {9, 9, 9};
+    auto inner_a_bytes = spudpack_encode(inner_a);
+
+    Spudpack inner_b;
+    inner_b.source = "let x = 1\n";
+    inner_b.program_bytes = {1, 1};
+    auto inner_b_bytes = spudpack_encode(inner_b);
+
+    Spudpack in = make_simple();
+    in.deps.push_back({"inner_a", inner_a_bytes});
+    in.deps.push_back({"inner_b", inner_b_bytes});
+    auto bytes = spudpack_encode(in);
+    Spudpack out = spudpack_decode(bytes.data(), bytes.size());
+    EXPECT_EQ(out.version, 3u);
+    ASSERT_EQ(out.deps.size(), 2u);
+    EXPECT_EQ(out.deps[0].name, "inner_a");
+    EXPECT_EQ(out.deps[0].bytes, inner_a_bytes);
+    EXPECT_EQ(out.deps[1].name, "inner_b");
+    EXPECT_EQ(out.deps[1].bytes, inner_b_bytes);
+
+    // The dep bytes must round-trip back through the codec untouched.
+    Spudpack a_decoded = spudpack_decode(out.deps[0].bytes.data(),
+                                         out.deps[0].bytes.size());
+    EXPECT_EQ(a_decoded.source, inner_a.source);
+}
+
+TEST(SpudpackCodec, EncodeRejectsDepNameWithSlash) {
+    Spudpack in;
+    in.deps.push_back({"a/b", {1, 2, 3}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsEmptyDepName) {
+    Spudpack in;
+    in.deps.push_back({"", {1, 2, 3}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsDepNameDotDot) {
+    Spudpack in;
+    in.deps.push_back({"..", {1, 2, 3}});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, DecodeRejectsDepNameWithSlash) {
+    // Build a v3 pack and patch the dep name in place to "a/b".
+    Spudpack in;
+    in.deps.push_back({"abc", {1, 2, 3}});
+    auto bytes = spudpack_encode(in);
+    // After magic(4)+version(1)+flags(1)+source_len(1)+program_len(1)+
+    // asset_count(1)+dep_count(1)+name_len(1), the next 3 bytes are "abc".
+    std::size_t name_off = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 1;
+    bytes[name_off] = 'a';
+    bytes[name_off + 1] = '/';
+    bytes[name_off + 2] = 'b';
+    rewrite_crc(bytes);
+    EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
+}
+
+TEST(SpudpackCodec, DecodeRejectsHugeDepCount) {
+    // Hand-craft a v3 pack with dep_count = (1 << 16), well above the cap.
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(3);  // version
+    bytes.push_back(0);  // flags
+    bytes.push_back(0);  // source_len = 0
+    bytes.push_back(0);  // program_len = 0
+    bytes.push_back(0);  // asset_count = 0
+    // varint 1<<16 -> 0x80 0x80 0x04
+    bytes.push_back(0x80);
+    bytes.push_back(0x80);
+    bytes.push_back(0x04);
+    bytes.insert(bytes.end(), 4, 0);
+    rewrite_crc(bytes);
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("dep_count exceeds maximum"),
                   std::string::npos);
     }
 }


### PR DESCRIPTION
## Summary

`include` now runs in place against bundled dependencies. The named template's questions interleave with the parent's in source order, the dependency's bytes are embedded inside the parent at install time, and the recipient does not need the dep separately installed.

## Changes

- Spudpack format bumped to v3. The `dep_count` slot now actually carries data: a varint name and a varint blob per dep, where the blob is the full bytes of another spudpack. v1 and v2 packs still decode unchanged and continue to require `dep_count == 0`.
- The bundler walks `include` statements at install time, resolves each name against the install root, and attaches the bundled `.spp` bytes as a dep on the parent. Multiple includes of the same name dedupe; missing or non-installed deps surface as a bundle error tagged with the include site.
- The interpreter replaces the previous include stub with a real implementation. At each include site it decodes the bundled dep, deserialises and validates the dep program, and runs it inline with isolated variable scope. Pending filesystem ops are appended to the parent's deferred queue so the whole tree commits or makes no changes. Recursion is capped at sixteen levels.
- CLI plumbs decoded deps from the run-time spudpack through `run` and `dry_run`. The `install` path threads the install root into the bundler so dependency resolution happens at install time.
- New `CHANGELOG.md` describes the user-facing changes.
- Version bumped to 0.4.0.
- Reference docs (statement page, statements index, best practices, spudpack format, AST docstring) rewritten to match the new behaviour. The "future feature" note for `_deps` is gone.

## Test plan

- All 723 (12 new) tests pass locally.
- New coverage spans:
  - Spudpack codec: round-trip with deps, v3 acceptance, v1/v2 still rejecting deps, encoder rejects bad dep names, decoder rejects an oversized dep count, decoder rejects names that fail bare-identifier rules.
  - Bundler: include collects an installed dep, dedupes by name, errors without an install root, errors on a missing dep, walks includes nested in `repeat` and `if` bodies.
  - Interpreter: include runs the dep in source order with isolated scope, respects a false `when` clause, and errors at runtime when no dep is bundled.
  - CLI end to end: install a child, install a parent that includes it, then uninstall the child and run the parent off bundled bytes alone.
- Smoke ran the rebuilt binary at v0.4.0 to confirm the version banner.