### PR TITLE
feat: include counter and template version tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,63 @@ full layout.
 If you ship a template that uses `include`, install the dependency first,
 then install your parent. The parent is then self-contained and can be
 shared as a single `.spp`.
+
+### Prompt counter follows includes
+
+`(n/m)` is now one denominator across the whole include tree. A prompt
+in a bundled dep continues the parent's count toward the same total, and
+sits at one nesting level deeper of indent. Nested includes stack the
+indent further so the user can see the depth at a glance.
+
+### Monotonic version tags
+
+Every installed template carries a `version_tag` that increments on each
+install whose content differs from what is already on disk:
+
+- First install of a name is v1.
+- Reinstalling identical content is a no-op and prints `already up to
+  date`.
+- Reinstalling changed content bumps to v2, v3, and so on.
+- The previous on-disk pack is copied to `<install-root>/.archive/<name>.v<N>.spp`
+  before being overwritten.
+
+`spudplate list` prints `name (vN)` per line. `spudplate inspect <name>`
+prints the template's version, the version of every bundled dep, and
+the original source.
+
+### Sticky dependencies and the `--update-deps` flag
+
+When reinstalling a parent, the bundler defaults to reusing the dep
+bytes the previous parent already carried. Editing the parent's source
+without otherwise touching its deps no longer silently swaps a dep for
+the latest installed version. To opt in to a refresh:
+
+```
+spudplate install bar.spud --update-deps foo,baz
+```
+
+lists the unpinned deps to re-read from the install root.
+
+### Hard pins in source
+
+`include foo@N` resolves to that exact version. The bundler tries the
+current install root first; if its `version_tag` is not `N`, it falls
+back to `<install-root>/.archive/foo.vN.spp`. If neither carries the
+pinned version, the install fails. Pinned deps are unaffected by
+`--update-deps`; the flag is silently ignored for them with a one-line
+note.
+
+### Drift warning at run time
+
+`spudplate run <name>` compares each top-level bundled dep's
+`version_tag` against the currently-installed copy at
+`<install-root>/<name>.spp`. A mismatch produces one warning line per
+drifted dep. The bundled bytes always run regardless; the warning is
+informational and points out that reinstalling the parent will pick up
+the newer (or older) dep.
+
+### `uninstall` clears archive entries
+
+`spudplate uninstall foo` now also removes
+`<install-root>/.archive/foo.v*.spp`. Archives for other names are
+untouched.

--- a/README.md
+++ b/README.md
@@ -37,19 +37,22 @@ Alternatives:
 ```
 spudplate install my_template.spud      # bundle assets, write <name>.spp under the install root
 spudplate install --yes my_template.spud  # overwrite an existing install without prompting
+spudplate install --update-deps a,b ... # refresh the listed unpinned deps from the install root
 spudplate validate my_template.spud     # parse and validate without installing (also: `check`)
 spudplate run my_template               # run by installed name
 spudplate run path/to/file.spud         # or run a file directly (cwd-relative assets)
 spudplate run path/to/file.spp          # or run a built spudpack directly
-spudplate list                          # list installed templates
-spudplate inspect my_template           # print the source captured at install time
-spudplate uninstall my_template         # remove
+spudplate list                          # list installed templates with their version tag
+spudplate inspect my_template           # print the version, dep versions, and source
+spudplate uninstall my_template         # remove (also clears archived previous versions)
 
 spudplate version                       # print the spudplate version
 spudplate update                        # fetch and install the latest spudplate release
 ```
 
 `install` prompts before overwriting an existing template. Pass `--yes` to skip the prompt (useful for scripts and CI). `update` fetches the latest release of spudplate itself by re-running the install script.
+
+Each install carries a monotonic `version_tag` that bumps on every reinstall whose content differs. Reinstalling identical content is a no-op (`already up to date`). The previous on-disk pack is archived under `<install-root>/.archive/<name>.v<N>.spp` before being overwritten. Bundled deps are sticky on reinstall: a parent keeps the dep bytes it previously bundled unless `--update-deps` lists the dep, or unless the source pins it with `include foo@N`.
 
 To share a template, send the `<name>.spp` file. The recipient runs it with `spudplate run path/to/template.spp`. (Direct `install` from a `.spp` is intentionally not supported in this version - share the source instead, or run the spudpack directly.)
 

--- a/docs/lang/statements/include.md
+++ b/docs/lang/statements/include.md
@@ -1,7 +1,7 @@
 # include {#lang_stmt_include}
 
 ```
-include <name> [when <condition>]
+include <name>[@<int>] [when <condition>]
 ```
 
 Runs another installed spudplate template by name, **inline at the include point**. The included template has isolated variable scope, but its prompts and filesystem operations interleave with the caller's in source order.
@@ -29,6 +29,24 @@ The user is prompted for `use_claude`, then (if true) for whatever questions `cl
 ## Resolving the name
 
 The argument to `include` is a bare identifier (no quotes). At install time, the named template must already be installed under the install root (`$SPUDPLATE_HOME`, `$XDG_DATA_HOME/spudplate`, or `~/.local/share/spudplate`). The bundler reads the bytes of `<install-root>/<name>.spp` and embeds them inside the parent spudpack as a dependency. At run time the parent reads the dep from its own bundle, so the recipient does not need the dep separately installed.
+
+When reinstalling a parent without `--update-deps`, the bundler reuses whatever dep bytes the previous parent bundled (sticky default). To refresh from the install root explicitly:
+
+```
+spudplate install bar.spud --update-deps foo,baz
+```
+
+## Pinning a dep to a specific version
+
+Each installed template carries a monotonic `version_tag` that bumps on every install whose content differs from what is on disk. To require a specific version, use `@N` in the source:
+
+```
+include claude_setup@3
+```
+
+The bundler tries `<install-root>/claude_setup.spp` first; if its `version_tag` is not `3`, it falls back to `<install-root>/.archive/claude_setup.v3.spp`. If neither carries v3, the install fails with a clear error pointing to both paths it tried.
+
+Pinned deps are unaffected by `--update-deps`; the flag is silently no-op for them with a one-line `note: '<name>' is pinned in source; --update-deps ignored`.
 
 ## when
 

--- a/docs/spudpack-format.md
+++ b/docs/spudpack-format.md
@@ -9,21 +9,23 @@ This document is the on-disk contract. The encoder lives in `src/spudpack.cpp`; 
 ## At a glance
 
 ```
-magic    "SPUD"        4 bytes
-version  u8            1 byte    currently 3; 1 and 2 still accepted on decode
-flags    u8            1 byte    must be 0
-source   length+bytes            varint length, raw UTF-8 source
-program  length+bytes            varint length, opaque AST bytes
-asset_count varint                number of asset records
+magic       "SPUD"     4 bytes
+version     u8         1 byte    currently 4; 1, 2, 3 still accepted on decode
+flags       u8         1 byte    must be 0
+version_tag u32 LE     4 bytes   v4 only; monotonic install counter; >= 1
+source      length+bytes         varint length, raw UTF-8 source
+program     length+bytes         varint length, opaque AST bytes
+asset_count varint               number of asset records
 per asset:
-  path   length+bytes            varint length, normalised path
-  mode   u16 LE                  POSIX mode bits, masked to 0o0777
-  data   length+bytes            varint length, raw bytes
-dep_count varint                  number of dependency records (must be 0 in v1/v2)
+  path      length+bytes         varint length, normalised path
+  mode      u16 LE               POSIX mode bits, masked to 0o0777
+  data      length+bytes         varint length, raw bytes
+dep_count   varint               number of dependency records (must be 0 in v1/v2)
 per dep:
-  name   length+bytes            varint length, bare identifier
-  blob   length+bytes            varint length, full bytes of another spudpack
-trailer  u32 LE                  CRC32 over [0, size-4)
+  name      length+bytes         varint length, bare identifier
+  version_tag u32 LE             v4 only; the dep's version_tag at bundle time; >= 1
+  blob      length+bytes         varint length, full bytes of another spudpack
+trailer     u32 LE               CRC32 over [0, size-4)
 ```
 
 All multi-byte integers are little-endian. Variable-length integers (`varint`) are unsigned LEB128 capped at 10 bytes.
@@ -37,6 +39,7 @@ All multi-byte integers are little-endian. Variable-length integers (`varint`) a
 | 1 | Original format. |
 | 2 | `RunStmt` gains a trailing optional `timeout` field (one present-flag byte plus, if set, the encoded expression). Packs without `run` statements are byte-identical to v1 once the version byte is bumped. |
 | 3 | `dep_count` may be nonzero. Each dep is a bare-identifier name plus the full bytes of another spudpack. v1 and v2 packs still require `dep_count == 0`. |
+| 4 | Pack-level `version_tag: u32 LE` written immediately after the flags byte; per-dep `version_tag: u32 LE` written between the dep name and the dep blob. Both must be `>= 1`. The `IncludeStmt` AST also gains a trailing optional `version_pin` (one present-flag byte plus, if set, a varint version number) inside the binary AST stream. v1, v2, and v3 decodes leave both tags at the default of 1 and any `version_pin` at nullopt. |
 
 The encoder always writes the latest version. The decoder accepts every version in `[kMinVersion, kVersion]`; the version is threaded through to the binary deserialiser so trailing-optional fields decode correctly across versions.
 
@@ -103,6 +106,7 @@ Common failure cases:
 - `spudpack vN does not support deps` - non-zero `dep_count` in a v1 or v2 pack.
 - `dep_count exceeds maximum` - hostile dep count.
 - `spudpack dep name is not a bare identifier` - dep name contains `/`, NUL, or is `.` / `..`.
+- `spudpack version_tag must be >= 1` - pack-level or per-dep tag is zero.
 - `spudpack CRC mismatch` - trailer does not match recomputed CRC.
 
 ---

--- a/include/spudplate/ast.h
+++ b/include/spudplate/ast.h
@@ -1,6 +1,7 @@
 #ifndef SPUDPLATE_AST_H
 #define SPUDPLATE_AST_H
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -328,8 +329,9 @@ struct RunStmt {
  * `when` clause skips the include entirely if false.
  */
 struct IncludeStmt {
-    std::string name;                    ///< Name of the installed template to run.
-    std::optional<ExprPtr> when_clause;  ///< Optional condition guarding the include.
+    std::string name;                          ///< Name of the installed template to run.
+    std::optional<std::uint32_t> version_pin;  ///< Optional `@N` pin from source. Bundler resolves to that exact installed/archived version.
+    std::optional<ExprPtr> when_clause;        ///< Optional condition guarding the include.
     int line;    ///< 1-based source line where this node begins.
     int column;  ///< 1-based source column where this node begins.
 };

--- a/include/spudplate/binary_serializer.h
+++ b/include/spudplate/binary_serializer.h
@@ -120,7 +120,7 @@ std::vector<std::uint8_t> serialize_program(const Program& program);
  *   - tag values outside the legal range for their position
  */
 Program deserialize_program(const std::uint8_t* data, std::size_t size,
-                            std::uint8_t pack_version = 2);
+                            std::uint8_t pack_version = 4);
 
 }  // namespace spudplate
 

--- a/include/spudplate/bundler.h
+++ b/include/spudplate/bundler.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "spudplate/ast.h"
@@ -51,6 +52,36 @@ class BundleError : public std::runtime_error {
 };
 
 /**
+ * @brief Optional inputs shaping how `bundle_assets` resolves `include` deps.
+ *
+ * `existing_parent`, when non-null, supplies the previously-installed
+ * parent's bundled deps so the bundler can default to "sticky" - reusing
+ * the bytes the parent already carried instead of re-fetching from the
+ * install root. This preserves the author's choice of dep version across
+ * source-only edits to the parent.
+ *
+ * `update_deps`, when non-null, names the unpinned deps the caller wants
+ * refreshed from the current install root despite sticky default. Pinned
+ * deps (those with `version_pin` in source) are unaffected by this set;
+ * resolution always honours the pin.
+ */
+struct BundleOptions {
+    const Spudpack* existing_parent = nullptr;
+    const std::unordered_set<std::string>* update_deps = nullptr;
+};
+
+/**
+ * @brief Notes the bundler emits as side outputs during a run.
+ *
+ * Today it carries the names of pinned deps that were also listed in
+ * `--update-deps`, so the CLI can print the "pinned, --update-deps
+ * ignored" hint without the bundler having to take a stream parameter.
+ */
+struct BundleNotes {
+    std::vector<std::string> ignored_update_pins;
+};
+
+/**
  * @brief Walk a parsed program and collect every asset and dependency it references.
  *
  * `source_root` is the directory the source `.spud` lives in - relative
@@ -62,6 +93,21 @@ class BundleError : public std::runtime_error {
  * the file's bytes are attached as a dep. An empty `install_root` means
  * the caller is not in install mode and any `include` statement is a
  * `BundleError`.
+ *
+ * `options` carries the existing parent (for sticky default) and the
+ * `--update-deps` set. See `BundleOptions`.
+ *
+ * `notes`, when non-null, receives advisory output (e.g. pinned deps
+ * listed in `--update-deps`) the caller may wish to relay.
+ *
+ * Dep resolution rules:
+ *   - Pinned `include foo@N`: read `<install_root>/foo.spp` if it has
+ *     `version_tag == N`; otherwise read `<install_root>/.archive/foo.vN.spp`.
+ *     If neither carries N, raise `BundleError`.
+ *   - Unpinned `include foo`: if the existing parent carries `foo`, reuse
+ *     its bundled bytes (sticky default). If `update_deps` lists `foo`,
+ *     refresh from `<install_root>/foo.spp` instead. First install of the
+ *     parent (no existing parent) always reads from the install root.
  *
  * The bundler dereferences symlinks, breaks loops on canonical directory
  * paths, and rejects:
@@ -78,7 +124,9 @@ class BundleError : public std::runtime_error {
  */
 BundleResult bundle_assets(const Program& program,
                            const std::filesystem::path& source_root,
-                           const std::filesystem::path& install_root = {});
+                           const std::filesystem::path& install_root = {},
+                           const BundleOptions& options = {},
+                           BundleNotes* notes = nullptr);
 
 }  // namespace spudplate
 

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -183,6 +183,12 @@ class ScriptedPrompter : public Prompter {
         return last_;
     }
 
+    /** @brief Every request seen so far, in order. Useful for asserting on
+     *         counter, indent, or iteration sequences across a multi-prompt run. */
+    [[nodiscard]] const std::vector<PromptRequest>& requests() const {
+        return requests_;
+    }
+
     /** @brief Set what `authorize` returns. Defaults to true (accept). */
     void set_authorize_response(bool value) { authorize_response_ = value; }
 
@@ -195,6 +201,7 @@ class ScriptedPrompter : public Prompter {
     std::vector<std::string> answers_;
     std::size_t index_{0};
     std::optional<PromptRequest> last_;
+    std::vector<PromptRequest> requests_;
     bool authorize_response_{true};
     std::optional<std::string> last_authorize_summary_;
 };

--- a/include/spudplate/spudpack.h
+++ b/include/spudplate/spudpack.h
@@ -34,10 +34,16 @@ struct SpudpackAsset {
  * template names: nonempty, no `/`, no NUL, not `.` or `..`. Bytes are kept
  * opaque - the consumer decodes them through `spudpack_decode` when an
  * `include` statement actually fires at runtime.
+ *
+ * `version_tag` is the monotonic install counter the dep carried at the
+ * time the parent was bundled. Used for drift comparison against the
+ * currently-installed dep at run time. v3 packs decode with `version_tag = 1`
+ * by default; v4 reads the field explicitly.
  */
 struct SpudpackDep {
     std::string name;                ///< Bare include name, matching `<name>.spp` on the install root.
     std::vector<std::uint8_t> bytes; ///< Full byte stream of the bundled dep's spudpack.
+    std::uint32_t version_tag{1};    ///< Monotonic install counter the dep carried when bundled. Defaults to 1 for v3 decodes.
 };
 
 /**
@@ -53,7 +59,8 @@ struct Spudpack {
     std::vector<std::uint8_t> program_bytes;  ///< Opaque serialised AST; decoded by the binary serializer.
     std::vector<SpudpackAsset> assets;        ///< Every bundled asset referenced by the program.
     std::vector<SpudpackDep> deps;            ///< Every bundled dependency referenced by `include` statements.
-    std::uint8_t version{3};                  ///< Spudpack format version that produced these bytes. Threaded into the binary serializer so trailing-optional fields decode correctly across versions.
+    std::uint8_t version{4};                  ///< Spudpack format version that produced these bytes. Threaded into the binary serializer so trailing-optional fields decode correctly across versions.
+    std::uint32_t version_tag{1};             ///< Monotonic install counter for this template. Bumped on each install that produces different content. v3 decodes default to 1.
 };
 
 /**
@@ -76,13 +83,15 @@ class SpudpackError : public std::runtime_error {
 /**
  * @brief Encode a `Spudpack` into a tightly packed byte stream.
  *
- * Layout: magic `"SPUD"` (4 bytes), version `u8` (currently `3`; `1` and
- * `2` are still accepted on decode for backward compatibility), flags
- * `u8 = 0`, `varint`+`bytes` source, `varint`+`bytes` program, `varint`
- * asset_count, per asset (`varint`+`bytes` path, `u16 LE` mode,
- * `varint`+`bytes` data), `varint` dep_count, per dep (`varint`+`bytes`
- * name, `varint`+`bytes` blob), `u32 LE` CRC32 over `[0, size-4)`. Packs
- * decoded as v1 or v2 must report `dep_count = 0`; v3 may carry deps.
+ * Layout: magic `"SPUD"` (4 bytes), version `u8` (currently `4`; `1`, `2`,
+ * and `3` are still accepted on decode for backward compatibility), flags
+ * `u8 = 0`, `u32 LE` version_tag (v4 only; default 1 for older decodes),
+ * `varint`+`bytes` source, `varint`+`bytes` program, `varint` asset_count,
+ * per asset (`varint`+`bytes` path, `u16 LE` mode, `varint`+`bytes` data),
+ * `varint` dep_count, per dep (`varint`+`bytes` name, `u32 LE` dep
+ * version_tag (v4 only; default 1), `varint`+`bytes` blob), `u32 LE` CRC32
+ * over `[0, size-4)`. Packs decoded as v1 or v2 must report
+ * `dep_count = 0`; v3 may carry deps but no version_tag fields.
  */
 std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack);
 
@@ -93,9 +102,11 @@ std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack);
  * bounds, the per-asset and per-dep cap (256 MiB), the total file cap
  * (2 GiB), the asset-count cap (`1 << 20`), the dep-count cap (`1 << 10`),
  * each asset path against the normalisation rules, each dep name against
- * the bare-identifier rules, mode bits against `0o7777`, and the trailing
- * CRC32. v1 and v2 packs are rejected if `dep_count != 0`. Every failure
- * throws `SpudpackError` with the byte offset at which decoding gave up.
+ * the bare-identifier rules, mode bits against `0o7777`, version_tag
+ * fields against the `>= 1` requirement (v4 only), and the trailing
+ * CRC32. v1 and v2 packs are rejected if `dep_count != 0`; v1, v2, and
+ * v3 packs decode with `version_tag = 1` defaults. Every failure throws
+ * `SpudpackError` with the byte offset at which decoding gave up.
  */
 Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size);
 

--- a/include/spudplate/spudpack.h
+++ b/include/spudplate/spudpack.h
@@ -140,6 +140,37 @@ std::string normalize_asset_path(std::string_view raw);
  */
 bool is_normalized_asset_path(std::string_view path) noexcept;
 
+/**
+ * @brief Validate a dep name against the bare-identifier rules.
+ *
+ * A valid name is nonempty, contains no `/` or NUL, and is not `.` or
+ * `..`. The codec, the bundler, and the install layer all share this
+ * predicate so they reject the same set of inputs.
+ */
+bool is_valid_dep_name(std::string_view name) noexcept;
+
+/**
+ * @brief Subdirectory of the install root that holds archived previous
+ * versions of installed templates.
+ *
+ * One file per `(name, version_tag)` pair, named `<name>.v<N>.spp`. The
+ * install layer copies the previous on-disk pack here before
+ * overwriting; the bundler reads it back when an `include foo@N` pin
+ * cannot be satisfied by the current install.
+ */
+inline constexpr std::string_view kArchiveDir = ".archive";
+
+/**
+ * @brief Path of an archived previous version under `<install_root>`.
+ *
+ * Exists only as a sibling to the live `<install_root>/<name>.spp` and
+ * is computed identically by every caller, so the format is encoded
+ * once here.
+ */
+std::filesystem::path archive_path_for(const std::filesystem::path& install_root,
+                                       std::string_view name,
+                                       std::uint32_t version_tag);
+
 }  // namespace spudplate
 
 #endif  // SPUDPLATE_SPUDPACK_H

--- a/include/spudplate/token.h
+++ b/include/spudplate/token.h
@@ -73,6 +73,7 @@ enum class TokenType {
     RBRACE,   ///< `}` - close inline interpolation in path expressions
     DOT,      ///< `.` - separator in path expressions (e.g. `README.md`)
     COMMA,    ///< `,` - argument separator in function calls
+    AT,       ///< `@` - dep version pin marker in `include foo@N`
 
     // Special
     EOF_TOKEN,  ///< End of input
@@ -199,6 +200,8 @@ inline std::string tokenTypeToString(TokenType type) {
             return "DOT";
         case TokenType::COMMA:
             return "COMMA";
+        case TokenType::AT:
+            return "AT";
         case TokenType::EOF_TOKEN:
             return "EOF_TOKEN";
         case TokenType::ERROR:

--- a/src/binary_serializer.cpp
+++ b/src/binary_serializer.cpp
@@ -1,6 +1,8 @@
 #include "spudplate/binary_serializer.h"
 
 #include <cstring>
+#include <limits>
+#include <stdexcept>
 #include <type_traits>
 #include <variant>
 
@@ -65,7 +67,7 @@ class Writer {
 class Reader {
   public:
     Reader(const std::uint8_t* data, std::size_t size,
-           std::uint8_t pack_version = 2)
+           std::uint8_t pack_version = 4)
         : data_(data), size_(size), pack_version_(pack_version) {}
 
     std::size_t pos() const noexcept { return pos_; }
@@ -632,6 +634,12 @@ void encode_stmt(Writer& w, const Stmt& s) {
             } else if constexpr (std::is_same_v<T, IncludeStmt>) {
                 w.write_string(node.name);
                 encode_opt_expr(w, node.when_clause);
+                // Trailing field added with pack v4. Earlier packs leave
+                // it absent and decode as nullopt.
+                w.write_bool(node.version_pin.has_value());
+                if (node.version_pin.has_value()) {
+                    w.write_varint(*node.version_pin);
+                }
             } else if constexpr (std::is_same_v<T, RunStmt>) {
                 encode_expr(w, *node.command);
                 encode_opt_path_expr(w, node.cwd);
@@ -774,9 +782,21 @@ StmtPtr decode_stmt(Reader& r) {
         case StmtTag::Include: {
             std::string name = r.read_string();
             auto when_clause = decode_opt_expr(r);
+            // Trailing field added with pack v4. v3 and earlier do not
+            // carry it and decode as nullopt.
+            std::optional<std::uint32_t> version_pin;
+            if (r.pack_version() >= 4 && r.read_bool()) {
+                std::uint64_t v = r.read_varint();
+                if (v == 0 || v > std::numeric_limits<std::uint32_t>::max()) {
+                    throw std::runtime_error(
+                        "include version_pin out of range");
+                }
+                version_pin = static_cast<std::uint32_t>(v);
+            }
             const int line = static_cast<int>(r.read_zigzag());
             const int column = static_cast<int>(r.read_zigzag());
             return wrap(IncludeStmt{.name = std::move(name),
+                                    .version_pin = version_pin,
                                     .when_clause = std::move(when_clause),
                                     .line = line,
                                     .column = column});

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -102,9 +102,19 @@ std::uint16_t disk_mode_to_asset_mode(fs::perms p) {
 
 class Bundler {
   public:
-    Bundler(const fs::path& source_root, const fs::path& install_root)
+    Bundler(const fs::path& source_root, const fs::path& install_root,
+            const BundleOptions& options, BundleNotes* notes)
         : root_(fs::weakly_canonical(source_root)),
-          install_root_(install_root) {}
+          install_root_(install_root),
+          existing_parent_(options.existing_parent),
+          update_deps_(options.update_deps),
+          notes_(notes) {
+        if (existing_parent_ != nullptr) {
+            for (const auto& d : existing_parent_->deps) {
+                existing_dep_index_.emplace(d.name, &d);
+            }
+        }
+    }
 
     BundleResult run(const Program& program) {
         for (const auto& stmt : program.statements) {
@@ -149,7 +159,7 @@ class Bundler {
                         if (body) visit_stmt(*body);
                     }
                 } else if constexpr (std::is_same_v<T, IncludeStmt>) {
-                    process_include(s.name, s.line, s.column);
+                    process_include(s);
                 }
                 // AskStmt, LetStmt, AssignStmt, RunStmt carry no asset or
                 // dep references and are intentionally skipped.
@@ -157,19 +167,16 @@ class Bundler {
             stmt.data);
     }
 
-    // Resolve `include <name>` against the install root, read the bundled
-    // `.spp` bytes, and attach them as a dep. Multiple includes of the
-    // same name dedupe to one record; the first encounter wins on order.
-    void process_include(const std::string& name, int line, int column) {
-        if (deps_.find(name) != deps_.end()) {
-            return;  // already collected
-        }
-        if (install_root_.empty()) {
-            throw BundleError(
-                "include '" + name +
-                    "' has no install root to resolve against",
-                line, column);
-        }
+    // Resolve `include <name>[@N]` against the install root, the install
+    // root's archive, or the existing parent's bundled deps. Multiple
+    // includes of the same name dedupe to one record; the first
+    // encounter wins on dep order. If a later encounter pins a different
+    // version than the earlier one, that is rejected as inconsistent.
+    void process_include(const IncludeStmt& s) {
+        const std::string& name = s.name;
+        int line = s.line;
+        int column = s.column;
+
         if (name.empty() || name.find('/') != std::string::npos ||
             name.find('\0') != std::string::npos || name == "." ||
             name == "..") {
@@ -177,7 +184,54 @@ class Bundler {
                 "include name is not a bare identifier: '" + name + "'",
                 line, column);
         }
-        fs::path dep_path = install_root_ / (name + ".spp");
+
+        auto it_existing = deps_.find(name);
+        if (it_existing != deps_.end()) {
+            // Already collected. If both encounters carry pins, the pins
+            // must match - we cannot bundle a single name at two
+            // different versions.
+            if (s.version_pin.has_value()) {
+                std::uint32_t prev_pin = it_existing->second.version_tag;
+                if (*s.version_pin != prev_pin) {
+                    throw BundleError(
+                        "include '" + name + "' is bundled at v" +
+                            std::to_string(prev_pin) +
+                            " but a later include pins v" +
+                            std::to_string(*s.version_pin),
+                        line, column);
+                }
+            }
+            return;
+        }
+
+        if (install_root_.empty()) {
+            throw BundleError(
+                "include '" + name +
+                    "' has no install root to resolve against",
+                line, column);
+        }
+
+        SpudpackDep dep;
+        dep.name = name;
+
+        if (s.version_pin.has_value()) {
+            dep.bytes = resolve_pinned_dep(name, *s.version_pin, line, column);
+            dep.version_tag = *s.version_pin;
+        } else {
+            auto resolved = resolve_unpinned_dep(name, line, column);
+            dep.bytes = std::move(resolved.first);
+            dep.version_tag = resolved.second;
+        }
+
+        deps_.emplace(name, std::move(dep));
+        dep_order_.push_back(name);
+    }
+
+    // Read+verify a spudpack from disk. Used both by pin and by sticky
+    // refresh paths.
+    std::vector<std::uint8_t> read_dep_pack(const std::string& name,
+                                            const fs::path& dep_path,
+                                            int line, int column) {
         std::error_code ec;
         if (!fs::exists(dep_path, ec) || ec) {
             throw BundleError(
@@ -191,19 +245,76 @@ class Bundler {
                     dep_path.string(),
                 line, column);
         }
-        std::vector<std::uint8_t> bytes = read_file_bytes(dep_path, line, column);
+        std::vector<std::uint8_t> bytes =
+            read_file_bytes(dep_path, line, column);
         try {
             spudpack_decode(bytes.data(), bytes.size());
         } catch (const SpudpackError& e) {
             throw BundleError(
-                "include '" + name + "' is not a valid spudpack: " + e.what(),
+                "include '" + name + "' at " + dep_path.string() +
+                    " is not a valid spudpack: " + e.what(),
                 line, column);
         }
-        SpudpackDep dep;
-        dep.name = name;
-        dep.bytes = std::move(bytes);
-        deps_.emplace(name, std::move(dep));
-        dep_order_.push_back(name);
+        return bytes;
+    }
+
+    // Resolve a hard pin: try the install root first, then the archive.
+    // Returns the dep's full byte stream. Throws if no installed or
+    // archived copy carries the pinned version.
+    std::vector<std::uint8_t> resolve_pinned_dep(const std::string& name,
+                                                 std::uint32_t pin,
+                                                 int line, int column) {
+        fs::path dep_path = install_root_ / (name + ".spp");
+        std::error_code ec;
+        if (fs::exists(dep_path, ec) && !ec &&
+            fs::is_regular_file(dep_path, ec) && !ec) {
+            std::vector<std::uint8_t> bytes =
+                read_file_bytes(dep_path, line, column);
+            try {
+                Spudpack p =
+                    spudpack_decode(bytes.data(), bytes.size());
+                if (p.version_tag == pin) {
+                    return bytes;
+                }
+            } catch (const SpudpackError& e) {
+                throw BundleError(
+                    "include '" + name + "' at " + dep_path.string() +
+                        " is not a valid spudpack: " + e.what(),
+                    line, column);
+            }
+        }
+        fs::path archive_path = install_root_ / ".archive" /
+                                (name + ".v" + std::to_string(pin) + ".spp");
+        if (fs::exists(archive_path, ec) && !ec) {
+            return read_dep_pack(name, archive_path, line, column);
+        }
+        throw BundleError(
+            "include '" + name + "' version pin v" + std::to_string(pin) +
+                " is not installed (looked at " + dep_path.string() +
+                " and " + archive_path.string() + ")",
+            line, column);
+    }
+
+    // Resolve an unpinned include: sticky reuse from existing parent
+    // unless `--update-deps` requested refresh, falling back to a fresh
+    // install-root read on first install or when no existing dep
+    // matches.
+    std::pair<std::vector<std::uint8_t>, std::uint32_t> resolve_unpinned_dep(
+        const std::string& name, int line, int column) {
+        bool wants_refresh =
+            update_deps_ != nullptr && update_deps_->count(name) > 0;
+        if (!wants_refresh) {
+            auto it = existing_dep_index_.find(name);
+            if (it != existing_dep_index_.end()) {
+                return {it->second->bytes, it->second->version_tag};
+            }
+        }
+        fs::path dep_path = install_root_ / (name + ".spp");
+        std::vector<std::uint8_t> bytes =
+            read_dep_pack(name, dep_path, line, column);
+        std::uint32_t tag =
+            spudpack_decode(bytes.data(), bytes.size()).version_tag;
+        return {std::move(bytes), tag};
     }
 
     // `file ... from <path>` - the path may resolve to a regular file
@@ -460,17 +571,57 @@ class Bundler {
 
     fs::path root_;
     fs::path install_root_;
+    const Spudpack* existing_parent_;
+    const std::unordered_set<std::string>* update_deps_;
+    BundleNotes* notes_;
+    std::unordered_map<std::string, const SpudpackDep*> existing_dep_index_;
     std::unordered_map<std::string, SpudpackAsset> by_path_;
     std::vector<std::string> insertion_order_;
     std::unordered_map<std::string, SpudpackDep> deps_;
     std::vector<std::string> dep_order_;
 };
 
+// Walk the program once and surface any dep names that the user listed in
+// --update-deps but the source pinned with `@N`. The bundler honours the
+// pin (refresh is meaningless against a pinned dep), and the CLI relays
+// these names so users learn why their flag did nothing.
+void note_ignored_update_pins(const Program& program,
+                              const std::unordered_set<std::string>& update_deps,
+                              std::vector<std::string>& out) {
+    std::unordered_set<std::string> seen;
+    auto walk = [&](auto& self, const std::vector<StmtPtr>& body) -> void {
+        for (const auto& sp : body) {
+            if (!sp) continue;
+            std::visit(
+                [&](const auto& s) {
+                    using T = std::decay_t<decltype(s)>;
+                    if constexpr (std::is_same_v<T, IncludeStmt>) {
+                        if (s.version_pin.has_value() &&
+                            update_deps.count(s.name) > 0 &&
+                            seen.insert(s.name).second) {
+                            out.push_back(s.name);
+                        }
+                    } else if constexpr (std::is_same_v<T, RepeatStmt> ||
+                                         std::is_same_v<T, IfStmt>) {
+                        self(self, s.body);
+                    }
+                },
+                sp->data);
+        }
+    };
+    walk(walk, program.statements);
+}
+
 }  // namespace
 
 BundleResult bundle_assets(const Program& program, const fs::path& source_root,
-                           const fs::path& install_root) {
-    Bundler b(source_root, install_root);
+                           const fs::path& install_root,
+                           const BundleOptions& options, BundleNotes* notes) {
+    if (notes != nullptr && options.update_deps != nullptr) {
+        note_ignored_update_pins(program, *options.update_deps,
+                                 notes->ignored_update_pins);
+    }
+    Bundler b(source_root, install_root, options, notes);
     return b.run(program);
 }
 

--- a/src/bundler.cpp
+++ b/src/bundler.cpp
@@ -177,9 +177,7 @@ class Bundler {
         int line = s.line;
         int column = s.column;
 
-        if (name.empty() || name.find('/') != std::string::npos ||
-            name.find('\0') != std::string::npos || name == "." ||
-            name == "..") {
+        if (!is_valid_dep_name(name)) {
             throw BundleError(
                 "include name is not a bare identifier: '" + name + "'",
                 line, column);
@@ -227,11 +225,13 @@ class Bundler {
         dep_order_.push_back(name);
     }
 
-    // Read+verify a spudpack from disk. Used both by pin and by sticky
-    // refresh paths.
-    std::vector<std::uint8_t> read_dep_pack(const std::string& name,
-                                            const fs::path& dep_path,
-                                            int line, int column) {
+    struct ReadDep {
+        std::vector<std::uint8_t> bytes;
+        std::uint32_t version_tag;
+    };
+
+    ReadDep read_dep_pack(const std::string& name, const fs::path& dep_path,
+                          int line, int column) {
         std::error_code ec;
         if (!fs::exists(dep_path, ec) || ec) {
             throw BundleError(
@@ -245,22 +245,21 @@ class Bundler {
                     dep_path.string(),
                 line, column);
         }
-        std::vector<std::uint8_t> bytes =
-            read_file_bytes(dep_path, line, column);
+        ReadDep out;
+        out.bytes = read_file_bytes(dep_path, line, column);
         try {
-            spudpack_decode(bytes.data(), bytes.size());
+            Spudpack decoded =
+                spudpack_decode(out.bytes.data(), out.bytes.size());
+            out.version_tag = decoded.version_tag;
         } catch (const SpudpackError& e) {
             throw BundleError(
                 "include '" + name + "' at " + dep_path.string() +
                     " is not a valid spudpack: " + e.what(),
                 line, column);
         }
-        return bytes;
+        return out;
     }
 
-    // Resolve a hard pin: try the install root first, then the archive.
-    // Returns the dep's full byte stream. Throws if no installed or
-    // archived copy carries the pinned version.
     std::vector<std::uint8_t> resolve_pinned_dep(const std::string& name,
                                                  std::uint32_t pin,
                                                  int line, int column) {
@@ -268,25 +267,15 @@ class Bundler {
         std::error_code ec;
         if (fs::exists(dep_path, ec) && !ec &&
             fs::is_regular_file(dep_path, ec) && !ec) {
-            std::vector<std::uint8_t> bytes =
-                read_file_bytes(dep_path, line, column);
-            try {
-                Spudpack p =
-                    spudpack_decode(bytes.data(), bytes.size());
-                if (p.version_tag == pin) {
-                    return bytes;
-                }
-            } catch (const SpudpackError& e) {
-                throw BundleError(
-                    "include '" + name + "' at " + dep_path.string() +
-                        " is not a valid spudpack: " + e.what(),
-                    line, column);
+            ReadDep r = read_dep_pack(name, dep_path, line, column);
+            if (r.version_tag == pin) {
+                return std::move(r.bytes);
             }
         }
-        fs::path archive_path = install_root_ / ".archive" /
-                                (name + ".v" + std::to_string(pin) + ".spp");
+        fs::path archive_path = archive_path_for(install_root_, name, pin);
         if (fs::exists(archive_path, ec) && !ec) {
-            return read_dep_pack(name, archive_path, line, column);
+            return std::move(
+                read_dep_pack(name, archive_path, line, column).bytes);
         }
         throw BundleError(
             "include '" + name + "' version pin v" + std::to_string(pin) +
@@ -295,10 +284,6 @@ class Bundler {
             line, column);
     }
 
-    // Resolve an unpinned include: sticky reuse from existing parent
-    // unless `--update-deps` requested refresh, falling back to a fresh
-    // install-root read on first install or when no existing dep
-    // matches.
     std::pair<std::vector<std::uint8_t>, std::uint32_t> resolve_unpinned_dep(
         const std::string& name, int line, int column) {
         bool wants_refresh =
@@ -310,11 +295,8 @@ class Bundler {
             }
         }
         fs::path dep_path = install_root_ / (name + ".spp");
-        std::vector<std::uint8_t> bytes =
-            read_dep_pack(name, dep_path, line, column);
-        std::uint32_t tag =
-            spudpack_decode(bytes.data(), bytes.size()).version_tag;
-        return {std::move(bytes), tag};
+        ReadDep r = read_dep_pack(name, dep_path, line, column);
+        return {std::move(r.bytes), r.version_tag};
     }
 
     // `file ... from <path>` - the path may resolve to a regular file

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1398,6 +1398,50 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
         return 3;
     }
 
+    // Drift warnings: for each top-level bundled dep, compare its tag
+    // against the currently-installed copy under the install root (only
+    // when running an installed .spp by name - direct .spud and .spp
+    // paths are not necessarily anchored to any install root). Mismatch
+    // surfaces as a non-fatal warning; a missing or unreadable installed
+    // copy is silent (the bundled bytes always run).
+    if (have_pack && shape == RunShape::InstalledSpp && !pack.deps.empty()) {
+        std::filesystem::path drift_home = install_dir();
+        if (!drift_home.empty()) {
+            for (const auto& dep : pack.deps) {
+                std::filesystem::path dep_path =
+                    drift_home / (dep.name + ".spp");
+                std::error_code drift_ec;
+                if (!std::filesystem::is_regular_file(dep_path, drift_ec) ||
+                    drift_ec) {
+                    continue;
+                }
+                std::vector<std::uint8_t> dep_bytes;
+                try {
+                    dep_bytes = read_all_bytes(dep_path);
+                } catch (...) {
+                    continue;
+                }
+                Spudpack installed;
+                try {
+                    installed = spudpack_decode(dep_bytes.data(),
+                                                dep_bytes.size());
+                } catch (...) {
+                    continue;
+                }
+                if (installed.version_tag == dep.version_tag) continue;
+                err << "warning: dep '" << dep.name << "' is bundled at v"
+                    << dep.version_tag << ", installed v"
+                    << installed.version_tag;
+                if (installed.version_tag > dep.version_tag) {
+                    err << " (newer; reinstall this template to update)\n";
+                } else {
+                    err << " (older than what this template was built "
+                           "against)\n";
+                }
+            }
+        }
+    }
+
     std::optional<AssetMapSourceProvider> provider;
     const SourceProvider* source_ptr = nullptr;
     const std::vector<spudplate::SpudpackDep>* deps_ptr = nullptr;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -22,6 +22,8 @@
 #include <unistd.h>
 #endif
 
+#include <unordered_set>
+
 #include "spudplate/binary_serializer.h"
 #include "spudplate/bundler.h"
 #include "spudplate/cli_internal.h"
@@ -47,6 +49,26 @@ RenameFn& install_rename_fn() {
 
 namespace {
 
+std::vector<std::uint8_t> read_all_bytes(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        throw std::runtime_error("could not open: " + path.string());
+    }
+    in.seekg(0, std::ios::end);
+    auto end = in.tellg();
+    if (end < 0) {
+        throw std::runtime_error("could not size: " + path.string());
+    }
+    std::vector<std::uint8_t> out(static_cast<std::size_t>(end));
+    in.seekg(0, std::ios::beg);
+    in.read(reinterpret_cast<char*>(out.data()),
+            static_cast<std::streamsize>(out.size()));
+    if (in.gcount() != static_cast<std::streamsize>(out.size())) {
+        throw std::runtime_error("short read on: " + path.string());
+    }
+    return out;
+}
+
 void print_usage(std::ostream& out) {
     out << "usage: spudplate <command> [args...]\n"
         << "\n"
@@ -70,13 +92,27 @@ bool is_help_flag(std::string_view arg) {
 }
 
 void print_help_install(std::ostream& out) {
-    out << "usage: spudplate install [--yes] <file.spud>\n"
+    out << "usage: spudplate install [--yes] [--update-deps NAMES] "
+           "<file.spud>\n"
         << "\n"
         << "Validate a .spud template and store it under the install root\n"
         << "as <name>.spp. Prompts before overwriting an existing template.\n"
         << "\n"
+        << "Each install carries a monotonic version tag. First install of\n"
+        << "a name is v1; subsequent installs that change the content bump\n"
+        << "by one. Reinstalling identical content is a no-op.\n"
+        << "\n"
+        << "Bundled dependencies are sticky by default: reinstalling a\n"
+        << "parent reuses the dep bytes the previous install bundled.\n"
+        << "Use --update-deps to refresh listed deps from the install root.\n"
+        << "Pinned deps (include foo at version N in source) ignore the\n"
+        << "flag - they always resolve through the pin.\n"
+        << "\n"
         << "Options:\n"
-        << "  --yes, -y       skip the overwrite confirmation\n";
+        << "  --yes, -y                 skip the overwrite confirmation\n"
+        << "  --update-deps NAMES       comma-separated list of unpinned\n"
+        << "                            deps to refresh from the install\n"
+        << "                            root\n";
 }
 
 void print_help_run(std::ostream& out) {
@@ -392,6 +428,7 @@ bool confirm_yes_no(std::ostream& out, const std::string& prompt) {
 
 int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     bool skip_confirm = false;
+    std::unordered_set<std::string> update_deps;
     int positional_start = 2;
     while (positional_start < argc) {
         std::string arg{argv[positional_start]};
@@ -402,9 +439,29 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         if (arg == "--yes" || arg == "-y") {
             skip_confirm = true;
             ++positional_start;
-        } else {
-            break;
+            continue;
         }
+        if (arg == "--update-deps") {
+            if (positional_start + 1 >= argc) {
+                err << "--update-deps requires a comma-separated list of "
+                       "names\n";
+                return 1;
+            }
+            std::string raw{argv[positional_start + 1]};
+            std::size_t i = 0;
+            while (i < raw.size()) {
+                std::size_t comma = raw.find(',', i);
+                if (comma == std::string::npos) comma = raw.size();
+                std::string name = raw.substr(i, comma - i);
+                if (!name.empty()) {
+                    update_deps.insert(std::move(name));
+                }
+                i = comma + 1;
+            }
+            positional_start += 2;
+            continue;
+        }
+        break;
     }
     if (argc - positional_start != 1) {
         print_usage(err);
@@ -451,27 +508,6 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         return 1;
     }
 
-    std::vector<SpudpackAsset> assets;
-    std::vector<spudplate::SpudpackDep> deps;
-    try {
-        BundleResult bundled =
-            bundle_assets(program, source_path.parent_path(), home);
-        assets = std::move(bundled.assets);
-        deps = std::move(bundled.deps);
-    } catch (const BundleError& e) {
-        print_error(err, source_path.string(), "bundle error", e.line(), e.column(),
-                    e.what());
-        return 3;
-    }
-
-    std::vector<std::uint8_t> program_bytes;
-    try {
-        program_bytes = serialize_program(program);
-    } catch (const BinarySerializeError& e) {
-        err << source_path.string() << ": " << e.what() << "\n";
-        return 3;
-    }
-
     std::string name = source_path.stem().string();
     if (name.empty()) {
         err << source_path.string() << ": cannot derive template name\n";
@@ -489,9 +525,9 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     std::filesystem::path final_path = home / (name + ".spp");
     std::filesystem::path tmp_path = home / (name + ".spp.tmp");
 
-    // Step 7a - refuse to clobber a stray non-regular file/dir that
-    // happens to sit at the destination. Surfacing this here gives a
-    // friendlier diagnostic than letting the rename fail later.
+    // Refuse to clobber a stray non-regular file/dir that happens to sit
+    // at the destination. Surfacing this here gives a friendlier
+    // diagnostic than letting the rename fail later.
     if (std::filesystem::exists(final_path) &&
         !std::filesystem::is_regular_file(final_path)) {
         err << "refusing to install: '" << final_path.filename().string()
@@ -499,11 +535,82 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         return 1;
     }
 
-    // Step 7b - overwrite prompt fires when either form (`<name>.spp` or
-    // legacy `<name>/`) is present. Capture the legacy flag now so the
-    // step-11 cleanup runs even when the prompt is suppressed by `--yes`.
+    // Decode the existing parent if present. Drives sticky-dep
+    // resolution and the next version_tag value.
+    std::optional<Spudpack> existing_parent;
+    std::vector<std::uint8_t> existing_bytes;
     bool spp_existed = std::filesystem::exists(final_path);
+    if (spp_existed) {
+        try {
+            existing_bytes = read_all_bytes(final_path);
+            existing_parent =
+                spudpack_decode(existing_bytes.data(), existing_bytes.size());
+        } catch (const std::exception& e) {
+            err << final_path.string() << ": cannot read existing install: "
+                << e.what() << "\n";
+            return 1;
+        }
+    }
+
+    BundleOptions bopts;
+    bopts.existing_parent =
+        existing_parent.has_value() ? &*existing_parent : nullptr;
+    bopts.update_deps = update_deps.empty() ? nullptr : &update_deps;
+    BundleNotes bnotes;
+
+    std::vector<SpudpackAsset> assets;
+    std::vector<spudplate::SpudpackDep> deps;
+    try {
+        BundleResult bundled = bundle_assets(
+            program, source_path.parent_path(), home, bopts, &bnotes);
+        assets = std::move(bundled.assets);
+        deps = std::move(bundled.deps);
+    } catch (const BundleError& e) {
+        print_error(err, source_path.string(), "bundle error", e.line(), e.column(),
+                    e.what());
+        return 3;
+    }
+
+    for (const auto& pinned : bnotes.ignored_update_pins) {
+        err << "note: '" << pinned
+            << "' is pinned in source; --update-deps ignored\n";
+    }
+
+    std::vector<std::uint8_t> program_bytes;
+    try {
+        program_bytes = serialize_program(program);
+    } catch (const BinarySerializeError& e) {
+        err << source_path.string() << ": " << e.what() << "\n";
+        return 3;
+    }
+
     bool legacy_existed = legacy_install_exists(home, name);
+
+    Spudpack pack;
+    pack.source = std::move(source);
+    pack.program_bytes = std::move(program_bytes);
+    pack.assets = std::move(assets);
+    pack.deps = std::move(deps);
+    // Tentatively encode at the existing version tag. If the resulting
+    // bytes match the existing install, this was a no-op reinstall and
+    // we can short-circuit. Otherwise we bump and re-encode.
+    pack.version_tag =
+        existing_parent.has_value() ? existing_parent->version_tag : 1;
+
+    std::vector<std::uint8_t> tentative_bytes;
+    try {
+        tentative_bytes = spudpack_encode(pack);
+    } catch (const std::exception& e) {
+        err << final_path.string() << ": cannot encode: " << e.what() << "\n";
+        return 1;
+    }
+
+    if (spp_existed && tentative_bytes == existing_bytes) {
+        out << name << " is already up to date (v" << pack.version_tag
+            << ")\n";
+        return 0;
+    }
+
     if ((spp_existed || legacy_existed) && !skip_confirm) {
         if (!confirm_yes_no(out, "this will overwrite the existing '" + name +
                                      "' template. continue? [y/N] ")) {
@@ -512,14 +619,55 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         }
     }
 
-    Spudpack pack;
-    pack.source = std::move(source);
-    pack.program_bytes = std::move(program_bytes);
-    pack.assets = std::move(assets);
-    pack.deps = std::move(deps);
+    if (existing_parent.has_value()) {
+        pack.version_tag = existing_parent->version_tag + 1;
+    }
+
+    std::vector<std::uint8_t> final_bytes;
+    try {
+        final_bytes = spudpack_encode(pack);
+    } catch (const std::exception& e) {
+        err << final_path.string() << ": cannot encode: " << e.what() << "\n";
+        return 1;
+    }
+
+    // Archive the previous install before clobbering. Failures here are
+    // non-fatal but loud - the install proceeds, but the user gets told
+    // their archive may be incomplete.
+    if (existing_parent.has_value()) {
+        std::filesystem::path archive_dir = home / ".archive";
+        std::error_code adir_ec;
+        std::filesystem::create_directories(archive_dir, adir_ec);
+        if (adir_ec) {
+            err << "warning: cannot create archive directory "
+                << archive_dir.string() << ": " << adir_ec.message() << "\n";
+        } else {
+            std::filesystem::path archive_path =
+                archive_dir / (name + ".v" +
+                               std::to_string(existing_parent->version_tag) +
+                               ".spp");
+            std::error_code cp_ec;
+            std::filesystem::copy_file(
+                final_path, archive_path,
+                std::filesystem::copy_options::overwrite_existing, cp_ec);
+            if (cp_ec) {
+                err << "warning: could not archive previous v"
+                    << existing_parent->version_tag << ": " << cp_ec.message()
+                    << "\n";
+            }
+        }
+    }
 
     try {
-        spudpack_write_file(tmp_path, pack);
+        std::ofstream tmp_out(tmp_path, std::ios::binary | std::ios::trunc);
+        if (!tmp_out) {
+            throw std::runtime_error("could not open temp file");
+        }
+        tmp_out.write(reinterpret_cast<const char*>(final_bytes.data()),
+                      static_cast<std::streamsize>(final_bytes.size()));
+        if (!tmp_out) {
+            throw std::runtime_error("write failed");
+        }
     } catch (const std::exception& e) {
         std::filesystem::remove(tmp_path, ec);
         err << final_path.string() << ": cannot write: " << e.what() << "\n";
@@ -545,7 +693,7 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     }
 
     out << (spp_existed ? "reinstalled " : "installed ") << name << " to "
-        << final_path.string() << "\n";
+        << final_path.string() << " (v" << pack.version_tag << ")\n";
     return 0;
 }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -141,13 +141,14 @@ void print_help_validate(std::ostream& out) {
 void print_help_list(std::ostream& out) {
     out << "usage: spudplate list\n"
         << "\n"
-        << "List installed templates by name, one per line.\n";
+        << "List installed templates as 'name (vN)', one per line.\n";
 }
 
 void print_help_inspect(std::ostream& out) {
     out << "usage: spudplate inspect <name>\n"
         << "\n"
-        << "Print the original .spud source of an installed template.\n";
+        << "Print the version of an installed template, the version of\n"
+        << "every dep it bundles, and the original .spud source.\n";
 }
 
 void print_help_uninstall(std::ostream& out) {
@@ -1134,33 +1135,60 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     if (!std::filesystem::is_directory(home)) {
         return 0;  // No installs yet - empty output, success.
     }
-    std::vector<std::string> names;
+    struct Entry {
+        std::string name;
+        std::optional<std::uint32_t> version_tag;
+    };
+    std::vector<Entry> entries;
     std::vector<std::string> shadowed_legacy;
     std::vector<std::string> only_legacy;
     std::error_code ec;
     for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
         if (entry.is_regular_file() && ends_with_spp(entry.path())) {
-            names.push_back(entry.path().stem().string());
+            Entry e{entry.path().stem().string(), std::nullopt};
+            try {
+                Spudpack p = spudpack_read_file(entry.path());
+                e.version_tag = p.version_tag;
+            } catch (...) {
+                // Unreadable pack: list the name without a version. The
+                // user can still see it exists and act on it.
+            }
+            entries.push_back(std::move(e));
         }
     }
     for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
         if (!entry.is_directory())
             continue;
         std::string n = entry.path().filename().string();
+        // Skip the archive directory - it holds historical .spp files,
+        // not installable templates.
+        if (n == ".archive") continue;
         if (!std::filesystem::is_regular_file(entry.path() / "template.spud")) {
             continue;
         }
-        if (std::find(names.begin(), names.end(), n) != names.end()) {
+        bool already_listed = false;
+        for (const auto& e : entries) {
+            if (e.name == n) {
+                already_listed = true;
+                break;
+            }
+        }
+        if (already_listed) {
             shadowed_legacy.push_back(n);
         } else {
             only_legacy.push_back(n);
         }
     }
-    std::sort(names.begin(), names.end());
+    std::sort(entries.begin(), entries.end(),
+              [](const Entry& a, const Entry& b) { return a.name < b.name; });
     std::sort(shadowed_legacy.begin(), shadowed_legacy.end());
     std::sort(only_legacy.begin(), only_legacy.end());
-    for (const auto& n : names) {
-        out << n << "\n";
+    for (const auto& e : entries) {
+        out << e.name;
+        if (e.version_tag.has_value()) {
+            out << " (v" << *e.version_tag << ")";
+        }
+        out << "\n";
     }
     for (const auto& n : shadowed_legacy) {
         err << "warning: legacy install '" << n << "' is shadowed by '" << n << ".spp'\n";
@@ -1208,6 +1236,16 @@ int cmd_inspect(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     }
     try {
         Spudpack pack = spudpack_read_file(spp_path);
+        out << name << " (v" << pack.version_tag << ")\n";
+        if (!pack.deps.empty()) {
+            out << "\nDependencies:\n";
+            for (const auto& dep : pack.deps) {
+                out << "  " << dep.name << " (v" << dep.version_tag << ")\n";
+            }
+            out << "\n";
+        } else {
+            out << "\n";
+        }
         out.write(pack.source.data(), static_cast<std::streamsize>(pack.source.size()));
     } catch (const SpudpackError& e) {
         err << name << ": " << e.what() << "\n";

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -69,6 +69,33 @@ std::vector<std::uint8_t> read_all_bytes(const std::filesystem::path& path) {
     return out;
 }
 
+// Missing or unreadable installed copies are silent: the bundled bytes
+// always run, the warning is purely informational.
+void warn_on_dep_drift(std::ostream& err, const Spudpack& pack,
+                       const std::filesystem::path& home) {
+    if (home.empty()) return;
+    for (const auto& dep : pack.deps) {
+        std::filesystem::path dep_path = home / (dep.name + ".spp");
+        std::error_code ec;
+        if (!std::filesystem::is_regular_file(dep_path, ec) || ec) continue;
+        Spudpack installed;
+        try {
+            std::vector<std::uint8_t> bytes = read_all_bytes(dep_path);
+            installed = spudpack_decode(bytes.data(), bytes.size());
+        } catch (...) {
+            continue;
+        }
+        if (installed.version_tag == dep.version_tag) continue;
+        err << "warning: dep '" << dep.name << "' is bundled at v"
+            << dep.version_tag << ", installed v" << installed.version_tag;
+        if (installed.version_tag > dep.version_tag) {
+            err << " (newer; reinstall this template to update)\n";
+        } else {
+            err << " (older than what this template was built against)\n";
+        }
+    }
+}
+
 void print_usage(std::ostream& out) {
     out << "usage: spudplate <command> [args...]\n"
         << "\n"
@@ -636,17 +663,15 @@ int cmd_install(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     // non-fatal but loud - the install proceeds, but the user gets told
     // their archive may be incomplete.
     if (existing_parent.has_value()) {
-        std::filesystem::path archive_dir = home / ".archive";
+        std::filesystem::path archive_dir = home / kArchiveDir;
         std::error_code adir_ec;
         std::filesystem::create_directories(archive_dir, adir_ec);
         if (adir_ec) {
             err << "warning: cannot create archive directory "
                 << archive_dir.string() << ": " << adir_ec.message() << "\n";
         } else {
-            std::filesystem::path archive_path =
-                archive_dir / (name + ".v" +
-                               std::to_string(existing_parent->version_tag) +
-                               ".spp");
+            std::filesystem::path archive_path = archive_path_for(
+                home, name, existing_parent->version_tag);
             std::error_code cp_ec;
             std::filesystem::copy_file(
                 final_path, archive_path,
@@ -1162,7 +1187,7 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         std::string n = entry.path().filename().string();
         // Skip the archive directory - it holds historical .spp files,
         // not installable templates.
-        if (n == ".archive") continue;
+        if (n == kArchiveDir) continue;
         if (!std::filesystem::is_regular_file(entry.path() / "template.spud")) {
             continue;
         }
@@ -1297,12 +1322,10 @@ int cmd_uninstall(int argc, char* argv[], std::ostream& out, std::ostream& err) 
         removed_anything = true;
     }
 
-    // Sweep any archived previous versions of this name. Pattern is
-    // `<name>.v<N>.spp` under `<home>/.archive/`. We do a safe prefix
-    // match so we do not accidentally remove an unrelated archive entry
-    // whose name happens to start with the same letters (`foobar` vs
-    // `foo`).
-    std::filesystem::path archive_dir = home / ".archive";
+    // Prefix-match must include the trailing `.v` and the `.spp` suffix
+    // with all-digits middle, otherwise `foobar.v1.spp` is wrongly swept
+    // by `uninstall foo`.
+    std::filesystem::path archive_dir = home / kArchiveDir;
     if (std::filesystem::is_directory(archive_dir, ec)) {
         std::string prefix = name + ".v";
         std::string suffix = ".spp";
@@ -1316,7 +1339,6 @@ int cmd_uninstall(int argc, char* argv[], std::ostream& out, std::ostream& err) 
             if (fname.compare(fname.size() - suffix.size(), suffix.size(),
                               suffix) != 0)
                 continue;
-            // Middle bytes must be all digits to qualify as a version.
             std::string mid = fname.substr(
                 prefix.size(), fname.size() - prefix.size() - suffix.size());
             bool all_digits = !mid.empty();
@@ -1478,48 +1500,8 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
         return 3;
     }
 
-    // Drift warnings: for each top-level bundled dep, compare its tag
-    // against the currently-installed copy under the install root (only
-    // when running an installed .spp by name - direct .spud and .spp
-    // paths are not necessarily anchored to any install root). Mismatch
-    // surfaces as a non-fatal warning; a missing or unreadable installed
-    // copy is silent (the bundled bytes always run).
     if (have_pack && shape == RunShape::InstalledSpp && !pack.deps.empty()) {
-        std::filesystem::path drift_home = install_dir();
-        if (!drift_home.empty()) {
-            for (const auto& dep : pack.deps) {
-                std::filesystem::path dep_path =
-                    drift_home / (dep.name + ".spp");
-                std::error_code drift_ec;
-                if (!std::filesystem::is_regular_file(dep_path, drift_ec) ||
-                    drift_ec) {
-                    continue;
-                }
-                std::vector<std::uint8_t> dep_bytes;
-                try {
-                    dep_bytes = read_all_bytes(dep_path);
-                } catch (...) {
-                    continue;
-                }
-                Spudpack installed;
-                try {
-                    installed = spudpack_decode(dep_bytes.data(),
-                                                dep_bytes.size());
-                } catch (...) {
-                    continue;
-                }
-                if (installed.version_tag == dep.version_tag) continue;
-                err << "warning: dep '" << dep.name << "' is bundled at v"
-                    << dep.version_tag << ", installed v"
-                    << installed.version_tag;
-                if (installed.version_tag > dep.version_tag) {
-                    err << " (newer; reinstall this template to update)\n";
-                } else {
-                    err << " (older than what this template was built "
-                           "against)\n";
-                }
-            }
-        }
+        warn_on_dep_drift(err, pack, install_dir());
     }
 
     std::optional<AssetMapSourceProvider> provider;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1296,6 +1296,48 @@ int cmd_uninstall(int argc, char* argv[], std::ostream& out, std::ostream& err) 
         }
         removed_anything = true;
     }
+
+    // Sweep any archived previous versions of this name. Pattern is
+    // `<name>.v<N>.spp` under `<home>/.archive/`. We do a safe prefix
+    // match so we do not accidentally remove an unrelated archive entry
+    // whose name happens to start with the same letters (`foobar` vs
+    // `foo`).
+    std::filesystem::path archive_dir = home / ".archive";
+    if (std::filesystem::is_directory(archive_dir, ec)) {
+        std::string prefix = name + ".v";
+        std::string suffix = ".spp";
+        std::error_code it_ec;
+        for (const auto& ent :
+             std::filesystem::directory_iterator(archive_dir, it_ec)) {
+            if (!ent.is_regular_file()) continue;
+            std::string fname = ent.path().filename().string();
+            if (fname.size() <= prefix.size() + suffix.size()) continue;
+            if (fname.compare(0, prefix.size(), prefix) != 0) continue;
+            if (fname.compare(fname.size() - suffix.size(), suffix.size(),
+                              suffix) != 0)
+                continue;
+            // Middle bytes must be all digits to qualify as a version.
+            std::string mid = fname.substr(
+                prefix.size(), fname.size() - prefix.size() - suffix.size());
+            bool all_digits = !mid.empty();
+            for (char c : mid) {
+                if (c < '0' || c > '9') {
+                    all_digits = false;
+                    break;
+                }
+            }
+            if (!all_digits) continue;
+            std::error_code rm_ec;
+            std::filesystem::remove(ent.path(), rm_ec);
+            if (rm_ec) {
+                err << name
+                    << ": cannot remove archive " << ent.path().string()
+                    << ": " << rm_ec.message() << "\n";
+                return 1;
+            }
+            removed_anything = true;
+        }
+    }
     if (!removed_anything) {
         err << name << ": not installed\n";
         return 5;

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1780,6 +1780,7 @@ bool StdinPrompter::authorize(const std::string& summary) {
 
 std::string ScriptedPrompter::prompt(const PromptRequest& req) {
     last_ = req;
+    requests_.push_back(req);
     if (index_ >= answers_.size()) {
         throw std::logic_error("ScriptedPrompter exhausted");
     }

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -824,6 +824,20 @@ class Interpreter {
     void set_ask_total(int total) { ask_total_ = total; }
     void set_timeouts_disabled(bool b) { timeouts_disabled_ = b; }
 
+    // The include path uses these to thread the parent's prompt counter,
+    // indent baseline, and enclosing-repeat state into a child interpreter
+    // so dep prompts continue the parent's `(n/m)` and inherit indent.
+    void set_ask_index(int index) { ask_index_ = index; }
+    [[nodiscard]] int ask_index() const { return ask_index_; }
+    void set_indent_floor(int floor) { indent_floor_ = floor; }
+    void set_enclosing_repeat_depth(int depth) {
+        enclosing_repeat_depth_ = depth;
+    }
+    void set_inherited_iters(
+        std::vector<std::pair<std::int64_t, std::int64_t>> iters) {
+        inherited_iters_ = std::move(iters);
+    }
+
     void execute(const Stmt& stmt) {
         std::visit(
             [&](const auto& s) {
@@ -831,17 +845,24 @@ class Interpreter {
                 if constexpr (std::is_same_v<T, AskStmt>) {
                     // ask_index_ counts top-level (static) prompts only - the
                     // same static `ask` repeated in a `repeat` body should not
-                    // bump the counter past `ask_total_`. Inside a repeat the
+                    // bump the counter past `ask_total_`. Inside a repeat
+                    // (here or in a parent that included us) the
                     // already-incremented index is reused so the renderer can
                     // still show "(N/M)" as a positional anchor alongside any
                     // iteration counter the prompter assembles.
-                    if (ask_total_ > 0 && repeat_depth_ == 0) {
+                    if (ask_total_ > 0 && repeat_depth_ == 0 &&
+                        enclosing_repeat_depth_ == 0) {
                         ++ask_index_;
                     }
                     int index = ask_total_ > 0 ? ask_index_ : 0;
                     int total = ask_total_;
-                    execute_ask(s, env_, prompter_, index, total,
-                                repeat_depth_, repeat_iters_);
+                    int indent = indent_floor_ + repeat_depth_;
+                    std::vector<std::pair<std::int64_t, std::int64_t>> iters =
+                        inherited_iters_;
+                    iters.insert(iters.end(), repeat_iters_.begin(),
+                                 repeat_iters_.end());
+                    execute_ask(s, env_, prompter_, index, total, indent,
+                                iters);
                 } else if constexpr (std::is_same_v<T, LetStmt>) {
                     Value v = evaluate_expr(*s.value, env_);
                     env_.declare(s.name, std::move(v));
@@ -944,7 +965,27 @@ class Interpreter {
         Interpreter child(prompter_, dep_source, &dep_pack.deps,
                           include_depth_ + 1);
         child.set_timeouts_disabled(timeouts_disabled_);
-        child.set_ask_total(count_ask_statements_local(dep_program));
+        // Inherit, do not recompute. The top-level run already counted every
+        // `ask` reachable through the include tree, and the parent has been
+        // bumping `ask_index_` as its own prompts went past. The child picks
+        // up at that index and continues toward the same denominator.
+        child.set_ask_total(ask_total_);
+        child.set_ask_index(ask_index_);
+        // Visually nest the dep's prompts: a 2-space step per include level,
+        // additive over any repeat indent already in effect at the include
+        // site.
+        child.set_indent_floor(indent_floor_ + repeat_depth_ + 1);
+        // If the parent is currently inside a `repeat` at the include point,
+        // every `ask` in the dep is effectively under that repeat. Treat the
+        // dep's top-level prompts the same way `ask`-in-`repeat` is treated
+        // here: do not bump the static counter.
+        child.set_enclosing_repeat_depth(enclosing_repeat_depth_ +
+                                         repeat_depth_);
+        std::vector<std::pair<std::int64_t, std::int64_t>> child_inherited =
+            inherited_iters_;
+        child_inherited.insert(child_inherited.end(), repeat_iters_.begin(),
+                               repeat_iters_.end());
+        child.set_inherited_iters(std::move(child_inherited));
 
         try {
             for (const auto& stmt : dep_program.statements) {
@@ -958,6 +999,10 @@ class Interpreter {
             throw;
         }
 
+        // Carry the child's final counter back so prompts after the include
+        // continue from where the dep left off.
+        ask_index_ = child.ask_index();
+
         std::vector<PendingOp> child_pending = child.take_pending();
         for (auto&& op : child_pending) {
             pending_.push_back(std::move(op));
@@ -965,19 +1010,6 @@ class Interpreter {
         std::unordered_set<std::string> child_created =
             child.take_created_paths();
         created_during_run_.merge(child_created);
-    }
-
-    // Same shape as the file-scope `count_ask_statements`, defined as a
-    // class member so the include path can call it without the lambda
-    // dance the file-scope helper would otherwise need.
-    static int count_ask_statements_local(const Program& program) {
-        int total = 0;
-        for (const auto& stmt : program.statements) {
-            if (stmt && std::holds_alternative<AskStmt>(stmt->data)) {
-                ++total;
-            }
-        }
-        return total;
     }
 
     void execute_repeat(const RepeatStmt& s) {
@@ -1522,28 +1554,93 @@ class Interpreter {
     int ask_total_{0};
     int ask_index_{0};
     int repeat_depth_{0};
+    // Base indent (in `repeat`-equivalent levels) the parent passes down at
+    // an include site. Zero on the top-level program; non-zero when this
+    // interpreter is running an included child. Each `ask` renders at
+    // `indent_floor_ + repeat_depth_` levels.
+    int indent_floor_{0};
+    // Parent's `repeat_depth_` at the include site, snapshotted at child
+    // construction time. Combined with this interpreter's own
+    // `repeat_depth_` it gates the static-counter increment so a static
+    // `ask` under any enclosing repeat (in the parent or here) does not
+    // bump the index past `ask_total_`.
+    int enclosing_repeat_depth_{0};
     // One {1-based current, total} pair pushed per active `repeat` iteration,
     // outermost first. `execute_repeat` pushes at the top of each iteration
     // body and pops on both normal-exit and exception paths so the stack is
     // never left dirty.
     std::vector<std::pair<std::int64_t, std::int64_t>> repeat_iters_;
+    // Parent's full iter chain at the include site. Prepended to this
+    // interpreter's `repeat_iters_` when assembling a `PromptRequest`, so
+    // a dep prompt under nested repeats sees the whole "iteration k of n"
+    // ladder from outermost down.
+    std::vector<std::pair<std::int64_t, std::int64_t>> inherited_iters_;
     // When true, every queued `run` ignores its statement-level and default
     // timeout and runs without one. Set via `--no-timeout` on the CLI.
     bool timeouts_disabled_{false};
 };
 
-int count_ask_statements(const Program& program) {
+// Recursive counter: walks the program's top-level statements (matching
+// the existing static-counter semantics where `ask` inside `repeat`/`if`
+// is not pre-counted), and recurses into each `include`'s bundled
+// dependency program. The total is used as the static denominator for
+// the whole run so prompts in included deps continue the parent's
+// `(n/m)` toward one shared M.
+//
+// `when` clauses on `include` are not consulted here. The counter is a
+// static denominator, so a conditionally-skipped include still
+// contributes its `ask` count - the same way a when-skipped top-level
+// `ask` still counts (its default binds and the index moves on). Users
+// see at most M prompts; conditional skips simply leave some unfilled.
+//
+// Decode/deserialise errors in a dep are silently treated as zero. The
+// real error is raised at the include site when the dep is actually
+// run, with proper source positions and the `RuntimeError` shape.
+int count_ask_statements(const Program& program,
+                         const std::vector<SpudpackDep>* deps,
+                         int depth = 0) {
+    if (depth > kMaxIncludeDepth) {
+        return 0;
+    }
+    std::unordered_map<std::string, const SpudpackDep*> dep_index;
+    if (deps != nullptr) {
+        for (const auto& d : *deps) {
+            dep_index.emplace(d.name, &d);
+        }
+    }
+
     int total = 0;
     for (const auto& stmt : program.statements) {
+        if (!stmt) continue;
         if (std::holds_alternative<AskStmt>(stmt->data)) {
             ++total;
+            continue;
+        }
+        if (!std::holds_alternative<IncludeStmt>(stmt->data)) continue;
+        const auto& inc = std::get<IncludeStmt>(stmt->data);
+        auto it = dep_index.find(inc.name);
+        if (it == dep_index.end()) continue;
+        try {
+            Spudpack dep_pack = spudpack_decode(it->second->bytes.data(),
+                                                it->second->bytes.size());
+            Program dep_program =
+                deserialize_program(dep_pack.program_bytes.data(),
+                                    dep_pack.program_bytes.size(),
+                                    dep_pack.version);
+            total += count_ask_statements(dep_program, &dep_pack.deps,
+                                          depth + 1);
+        } catch (...) {
+            // Dep is unreadable: leave counter at zero for this branch
+            // and let the include site surface the real error at run
+            // time with full source position context.
         }
     }
     return total;
 }
 
-void run_program(const Program& program, Interpreter& interp) {
-    interp.set_ask_total(count_ask_statements(program));
+void run_program(const Program& program, Interpreter& interp,
+                 const std::vector<SpudpackDep>* deps) {
+    interp.set_ask_total(count_ask_statements(program, deps));
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }
@@ -1805,7 +1902,7 @@ void run(const Program& program, Prompter& prompter, bool skip_authorization,
                        source != nullptr ? *source : default_source_provider(),
                        deps);
     interp.set_timeouts_disabled(timeouts_disabled);
-    run_program(program, interp);
+    run_program(program, interp, deps);
 }
 
 Environment run_for_tests(const Program& program, Prompter& prompter,
@@ -1814,7 +1911,7 @@ Environment run_for_tests(const Program& program, Prompter& prompter,
     Interpreter interp(prompter,
                        source != nullptr ? *source : default_source_provider(),
                        deps);
-    run_program(program, interp);
+    run_program(program, interp, deps);
     return std::move(interp.env());
 }
 
@@ -1993,7 +2090,7 @@ void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
     Interpreter interp(prompter,
                        source != nullptr ? *source : default_source_provider(),
                        deps);
-    interp.set_ask_total(count_ask_statements(program));
+    interp.set_ask_total(count_ask_statements(program, deps));
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -180,6 +180,8 @@ Token Lexer::nextToken() {
             return Token(TokenType::DOT, ".", start_line, start_col);
         case ',':
             return Token(TokenType::COMMA, ",", start_line, start_col);
+        case '@':
+            return Token(TokenType::AT, "@", start_line, start_col);
         case '=':
             if (!isAtEnd() && current() == '=') {
                 advance();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,5 +1,8 @@
 #include "spudplate/parser.h"
 
+#include <limits>
+#include <string>
+
 namespace spudplate {
 
 Parser::Parser(Lexer lexer) : lexer_(std::move(lexer)) {
@@ -502,11 +505,35 @@ StmtPtr Parser::parseInclude() {
     Token start = expect(TokenType::INCLUDE, "expected 'include'");
     Token name =
         expect(TokenType::IDENTIFIER, "expected template name after 'include'");
+
+    // Optional `@N` pin clause: `include foo@2`. The `@` must be the very
+    // next token (no whitespace tolerance enforced at parse level - the
+    // lexer treats `@` as a single-char token regardless), and must be
+    // followed by a positive integer literal.
+    std::optional<std::uint32_t> version_pin;
+    if (check(TokenType::AT)) {
+        Token at_tok = advance();
+        Token n =
+            expect(TokenType::INTEGER_LITERAL, "expected version number after '@'");
+        long long v = std::stoll(n.value);
+        if (v < 1) {
+            throw ParseError(
+                "include version pin must be >= 1", n.line, n.column);
+        }
+        if (v > std::numeric_limits<std::uint32_t>::max()) {
+            throw ParseError(
+                "include version pin overflows u32", n.line, n.column);
+        }
+        version_pin = static_cast<std::uint32_t>(v);
+        (void)at_tok;
+    }
+
     auto when_clause = parse_when_clause();
     expect_newline("include statement");
 
     auto stmt = std::make_unique<Stmt>();
     stmt->data = IncludeStmt{.name = name.value,
+                             .version_pin = version_pin,
                              .when_clause = std::move(when_clause),
                              .line = start.line,
                              .column = start.column};

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -46,20 +46,6 @@ constexpr std::size_t kMaxAssetCount = std::size_t{1} << 20;
 constexpr std::size_t kMaxDepCount = std::size_t{1} << 10;
 constexpr std::size_t kMaxDepBytes = kMaxAssetBytes;
 
-// A dep name must be a bare identifier matching the rules already enforced
-// by `spudplate install` for installed template names. Specifically: it
-// must be nonempty, free of `/`, free of NUL, and must not be `.` or `..`.
-// Stricter constraints (e.g. shell-safe characters) are not enforced here -
-// the install-time path resolution is the source of truth.
-bool is_valid_dep_name(std::string_view name) noexcept {
-    if (name.empty()) return false;
-    if (name == "." || name == "..") return false;
-    for (char c : name) {
-        if (c == '/' || c == '\0') return false;
-    }
-    return true;
-}
-
 // Producer convention: spudplate's own bundler masks asset modes to 0o0777
 // before encode. The decoder additionally rejects anything outside 0o7777
 // to give us forward room without accepting nonsense.
@@ -192,6 +178,22 @@ class Reader {
 
 SpudpackError::SpudpackError(std::string message, std::optional<std::size_t> offset)
     : std::runtime_error(std::move(message)), offset_(offset) {}
+
+bool is_valid_dep_name(std::string_view name) noexcept {
+    if (name.empty()) return false;
+    if (name == "." || name == "..") return false;
+    for (char c : name) {
+        if (c == '/' || c == '\0') return false;
+    }
+    return true;
+}
+
+std::filesystem::path archive_path_for(const std::filesystem::path& install_root,
+                                       std::string_view name,
+                                       std::uint32_t version_tag) {
+    return install_root / kArchiveDir /
+           (std::string(name) + ".v" + std::to_string(version_tag) + ".spp");
+}
 
 bool is_normalized_asset_path(std::string_view path) noexcept {
     if (path.empty()) return false;

--- a/src/spudpack.cpp
+++ b/src/spudpack.cpp
@@ -23,11 +23,17 @@ constexpr std::array<std::uint8_t, 4> kMagic = {'S', 'P', 'U', 'D'};
 // v3: dep_count may be nonzero. Per dep: varint name_len, name bytes,
 // varint blob_len, blob bytes. The blob is itself a complete spudpack
 // byte stream. v1 and v2 still require dep_count == 0.
+// v4: pack-level `version_tag: u32 LE` written immediately after the
+// flags byte; per-dep `version_tag: u32 LE` written between the dep
+// name and the dep blob. Both default to 1 when decoding v1/v2/v3 packs
+// so older bytes round-trip into a fully-populated `Spudpack` without
+// any callers having to handle a missing-tag case.
 // Encoder always writes the highest supported version; decoder accepts
 // every version in [kMinVersion, kVersion].
-constexpr std::uint8_t kVersion = 3;
+constexpr std::uint8_t kVersion = 4;
 constexpr std::uint8_t kMinVersion = 1;
 constexpr std::uint8_t kVersionDepsAllowed = 3;
+constexpr std::uint8_t kVersionTagsAllowed = 4;
 constexpr std::uint8_t kFlags = 0;
 
 // Per-asset, per-dep, and per-file caps. All apply to declared lengths
@@ -268,6 +274,11 @@ std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack) {
     out.push_back(kVersion);
     out.push_back(kFlags);
 
+    if (pack.version_tag == 0) {
+        throw SpudpackError("spudpack version_tag must be >= 1");
+    }
+    write_u32_le(out, pack.version_tag);
+
     write_length_prefixed(out, pack.source.data(), pack.source.size());
     write_length_prefixed(out, pack.program_bytes.data(), pack.program_bytes.size());
 
@@ -304,7 +315,12 @@ std::vector<std::uint8_t> spudpack_encode(const Spudpack& pack) {
         if (dep.bytes.size() > kMaxDepBytes) {
             throw SpudpackError("spudpack dep exceeds 256MiB cap: " + dep.name);
         }
+        if (dep.version_tag == 0) {
+            throw SpudpackError("spudpack dep version_tag must be >= 1: " +
+                                dep.name);
+        }
         write_length_prefixed(out, dep.name.data(), dep.name.size());
+        write_u32_le(out, dep.version_tag);
         write_length_prefixed(out, dep.bytes.data(), dep.bytes.size());
     }
 
@@ -346,6 +362,17 @@ Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size) {
 
     Spudpack pack;
     pack.version = version;
+    // v3 and below carry no version_tag on the wire. The struct field
+    // defaults to 1 so callers see a fully-populated pack regardless of
+    // which on-disk version they decoded.
+    if (version >= kVersionTagsAllowed) {
+        std::size_t tag_at = r.offset();
+        std::uint32_t tag = r.read_u32_le();
+        if (tag == 0) {
+            throw SpudpackError("spudpack version_tag must be >= 1", tag_at);
+        }
+        pack.version_tag = tag;
+    }
 
     std::size_t source_len = r.read_checked_length();
     r.read_bytes_into(pack.source, source_len);
@@ -417,6 +444,19 @@ Spudpack spudpack_decode(const std::uint8_t* data, std::size_t size) {
         if (!is_valid_dep_name(dep.name)) {
             throw SpudpackError(
                 "spudpack dep name is not a bare identifier", name_at);
+        }
+
+        // v4 only: read the dep's version_tag before its blob. v3 packs
+        // leave the struct's default of 1 untouched, matching the
+        // top-level fall-back.
+        if (version >= kVersionTagsAllowed) {
+            std::size_t dep_tag_at = r.offset();
+            std::uint32_t dep_tag = r.read_u32_le();
+            if (dep_tag == 0) {
+                throw SpudpackError(
+                    "spudpack dep version_tag must be >= 1", dep_tag_at);
+            }
+            dep.version_tag = dep_tag;
         }
 
         std::size_t blob_len_at = r.offset();

--- a/tests/binary_serializer_test.cpp
+++ b/tests/binary_serializer_test.cpp
@@ -376,6 +376,37 @@ TEST(BinarySerializer, RoundTripCopy) {
     expect_round_trip(program_with(std::move(stmts)));
 }
 
+TEST(BinarySerializer, RoundTripIncludeWithVersionPin) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(IncludeStmt{.name = "foo",
+                                          .version_pin = std::uint32_t{42},
+                                          .when_clause = std::nullopt,
+                                          .line = 1,
+                                          .column = 1}));
+    expect_round_trip(program_with(std::move(stmts)));
+}
+
+TEST(BinarySerializer, IncludePinAbsentInV3DecodesAsNullopt) {
+    std::vector<StmtPtr> stmts;
+    stmts.push_back(make_stmt(IncludeStmt{.name = "foo",
+                                          .version_pin = std::uint32_t{5},
+                                          .when_clause = std::nullopt,
+                                          .line = 1,
+                                          .column = 1}));
+    auto bytes = serialize_program(program_with(std::move(stmts)));
+    // Decoding the same bytes as v3 ignores the trailing pin field. The
+    // decoded IncludeStmt should have nullopt version_pin even though the
+    // bytes carry one. The trailing line/column reads will land on the
+    // wrong offsets (since the v4 trailing flag+pin sit before them), so
+    // we only assert that decode does not throw and that pin is nullopt.
+    Program p = deserialize_program(bytes.data(), bytes.size(),
+                                    /*pack_version=*/3);
+    ASSERT_EQ(p.statements.size(), 1u);
+    auto& inc = std::get<IncludeStmt>(p.statements[0]->data);
+    EXPECT_EQ(inc.name, "foo");
+    EXPECT_FALSE(inc.version_pin.has_value());
+}
+
 TEST(BinarySerializer, RoundTripIncludeAndRunWithCwd) {
     PathExpr cwd;
     cwd.segments.emplace_back(PathVar{.name = "modulepath", .line = 2, .column = 14});

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -530,7 +530,7 @@ TEST(CliTest, ListShowsInstalledNamesSorted) {
     ScriptedPrompter prompter({});
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 0);
-    EXPECT_EQ(out.str(), "alpha\nzebra\n");
+    EXPECT_EQ(out.str(), "alpha (v1)\nzebra (v1)\n");
 }
 
 TEST(CliTest, InspectPrintsSource) {
@@ -545,7 +545,7 @@ TEST(CliTest, InspectPrintsSource) {
     ScriptedPrompter prompter({});
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 0);
-    EXPECT_EQ(out.str(), body);
+    EXPECT_EQ(out.str(), "demo (v1)\n\n" + body);
 }
 
 TEST(CliTest, InspectUnknownExitsFive) {
@@ -961,7 +961,7 @@ TEST(CliTest, InspectPrintsSourceFromSpudpack) {
     std::stringstream err;
     ScriptedPrompter prompter({});
     EXPECT_EQ(cli_main(args.argc(), args.argv(), out, err, prompter), 0) << err.str();
-    EXPECT_EQ(out.str(), body);
+    EXPECT_EQ(out.str(), "demo (v1)\n\n" + body);
 }
 
 TEST(CliTest, InstallRunDeleteSourceMaterialisesAssets) {
@@ -1031,7 +1031,7 @@ TEST(CliTest, ListWarnsAboutShadowedLegacy) {
     std::stringstream err;
     ScriptedPrompter prompter({});
     EXPECT_EQ(cli_main(args.argc(), args.argv(), out, err, prompter), 0);
-    EXPECT_EQ(out.str(), "demo\n");
+    EXPECT_EQ(out.str(), "demo (v1)\n");
     EXPECT_NE(err.str().find("shadowed"), std::string::npos);
 }
 
@@ -1471,4 +1471,361 @@ TEST(CliTest, RunInstalledParentPromptsInSourceOrder) {
                         run_prompter);
     EXPECT_EQ(code, 0) << run_err.str();
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "start_end"));
+}
+
+// --- Version tags: install/bump/archive/sticky/pin/drift -------------------
+
+namespace {
+
+// Run a single CLI invocation with the supplied argv and return its stdout,
+// stderr, and exit code. Helps the version-tag tests stay readable.
+struct CliRun {
+    int code;
+    std::string out;
+    std::string err;
+};
+
+CliRun run_cli(std::vector<std::string> argv) {
+    Argv args(argv);
+    std::stringstream out, err;
+    ScriptedPrompter p({});
+    int code = cli_main(args.argc(), args.argv(), out, err, p);
+    return {code, out.str(), err.str()};
+}
+
+}  // namespace
+
+TEST(CliTest, FirstInstallTagsAsV1) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "foo.spud", "ask q \"q?\" string default \"x\"\n");
+    auto r = run_cli({"spudplate", "install",
+                      (td.path() / "foo.spud").string()});
+    ASSERT_EQ(r.code, 0) << r.err;
+    EXPECT_NE(r.out.find("(v1)"), std::string::npos) << r.out;
+    auto p = spudplate::spudpack_read_file(home_path / "foo.spp");
+    EXPECT_EQ(p.version_tag, 1u);
+}
+
+TEST(CliTest, IdenticalReinstallIsAlreadyUpToDate) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "foo.spud", "ask q \"q?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    auto r = run_cli(
+        {"spudplate", "install", (td.path() / "foo.spud").string()});
+    EXPECT_EQ(r.code, 0) << r.err;
+    EXPECT_NE(r.out.find("already up to date"), std::string::npos) << r.out;
+    auto p = spudplate::spudpack_read_file(home_path / "foo.spp");
+    EXPECT_EQ(p.version_tag, 1u);
+}
+
+TEST(CliTest, ChangedReinstallBumpsAndArchives) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "foo.spud", "ask q \"q?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "foo.spud", "ask q \"q changed?\" string default \"x\"\n");
+    auto r = run_cli({"spudplate", "install", "--yes",
+                      (td.path() / "foo.spud").string()});
+    ASSERT_EQ(r.code, 0) << r.err;
+    EXPECT_NE(r.out.find("(v2)"), std::string::npos) << r.out;
+    auto p = spudplate::spudpack_read_file(home_path / "foo.spp");
+    EXPECT_EQ(p.version_tag, 2u);
+    EXPECT_TRUE(std::filesystem::is_regular_file(home_path / ".archive" /
+                                                 "foo.v1.spp"));
+}
+
+TEST(CliTest, ParentBundlesDepAtCurrentVersion) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud", "include child\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "parent.spud").string()})
+                  .code,
+              0);
+    auto p = spudplate::spudpack_read_file(home_path / "parent.spp");
+    ASSERT_EQ(p.deps.size(), 1u);
+    EXPECT_EQ(p.deps[0].name, "child");
+    EXPECT_EQ(p.deps[0].version_tag, 2u);
+}
+
+TEST(CliTest, ReinstallParentIsStickyForUnpinnedDeps) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud", "include child\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "parent.spud").string()})
+                  .code,
+              0);
+    // Child gets bumped to v2 in the install root.
+    write_file(td.path() / "child.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    // Parent reinstall without --update-deps must keep child at v1 - the
+    // bytes are unchanged, so the bundler's content compare flags this
+    // as a no-op.
+    auto r = run_cli({"spudplate", "install", "--yes",
+                      (td.path() / "parent.spud").string()});
+    ASSERT_EQ(r.code, 0) << r.err;
+    EXPECT_NE(r.out.find("already up to date"), std::string::npos) << r.out;
+    auto p = spudplate::spudpack_read_file(home_path / "parent.spp");
+    EXPECT_EQ(p.deps[0].version_tag, 1u);
+}
+
+TEST(CliTest, UpdateDepsRefreshesBundledDep) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud", "include child\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "parent.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    auto r = run_cli({"spudplate", "install", "--yes", "--update-deps",
+                      "child", (td.path() / "parent.spud").string()});
+    ASSERT_EQ(r.code, 0) << r.err;
+    auto p = spudplate::spudpack_read_file(home_path / "parent.spp");
+    EXPECT_EQ(p.deps[0].version_tag, 2u);
+    EXPECT_EQ(p.version_tag, 2u);  // parent itself bumped because content changed
+}
+
+TEST(CliTest, PinResolvesAgainstArchive) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    // child is now v2 in the install root; v1 is in archive.
+    write_file(td.path() / "parent.spud", "include child@1\n");
+    auto r = run_cli({"spudplate", "install",
+                      (td.path() / "parent.spud").string()});
+    ASSERT_EQ(r.code, 0) << r.err;
+    auto p = spudplate::spudpack_read_file(home_path / "parent.spp");
+    EXPECT_EQ(p.deps[0].version_tag, 1u);
+}
+
+TEST(CliTest, PinForUnknownVersionFails) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud", "include child@9\n");
+    auto r = run_cli({"spudplate", "install",
+                      (td.path() / "parent.spud").string()});
+    EXPECT_NE(r.code, 0);
+    EXPECT_NE(r.err.find("version pin v9"), std::string::npos) << r.err;
+}
+
+TEST(CliTest, UpdateDepsOnPinnedPrintsNoteAndDoesNothing) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud", "include child@1\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "parent.spud").string()})
+                  .code,
+              0);
+    auto r = run_cli({"spudplate", "install", "--yes", "--update-deps",
+                      "child", (td.path() / "parent.spud").string()});
+    EXPECT_EQ(r.code, 0) << r.err;
+    EXPECT_NE(r.err.find("'child' is pinned"), std::string::npos) << r.err;
+    EXPECT_NE(r.out.find("already up to date"), std::string::npos) << r.out;
+}
+
+TEST(CliTest, UninstallSweepsArchiveEntries) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "foo.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "foo.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    EXPECT_TRUE(std::filesystem::is_regular_file(home_path / ".archive" /
+                                                 "foo.v1.spp"));
+    auto r = run_cli({"spudplate", "uninstall", "foo"});
+    EXPECT_EQ(r.code, 0) << r.err;
+    EXPECT_FALSE(std::filesystem::exists(home_path / "foo.spp"));
+    EXPECT_FALSE(std::filesystem::exists(home_path / ".archive" /
+                                         "foo.v1.spp"));
+}
+
+TEST(CliTest, UninstallLeavesOtherNamesArchive) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "foo.spud", "ask q \"q?\" string default \"x\"\n");
+    write_file(td.path() / "foobar.spud",
+               "ask q \"q?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "foobar.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "foobar.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "foobar.spud").string()})
+                  .code,
+              0);
+    // Uninstalling foo must not touch foobar.v1.spp (different name).
+    auto r = run_cli({"spudplate", "uninstall", "foo"});
+    ASSERT_EQ(r.code, 0) << r.err;
+    EXPECT_TRUE(std::filesystem::is_regular_file(home_path / ".archive" /
+                                                 "foobar.v1.spp"));
+}
+
+TEST(CliTest, ListShowsTagsAndSkipsArchive) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "foo.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "foo.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "foo.spud").string()})
+                  .code,
+              0);
+    auto r = run_cli({"spudplate", "list"});
+    EXPECT_EQ(r.code, 0) << r.err;
+    EXPECT_EQ(r.out, "foo (v2)\n");
+}
+
+TEST(CliTest, InspectShowsVersionAndDeps) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud", "include child\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "parent.spud").string()})
+                  .code,
+              0);
+    auto r = run_cli({"spudplate", "inspect", "parent"});
+    EXPECT_EQ(r.code, 0) << r.err;
+    EXPECT_NE(r.out.find("parent (v1)"), std::string::npos) << r.out;
+    EXPECT_NE(r.out.find("child (v1)"), std::string::npos) << r.out;
+    EXPECT_NE(r.out.find("Dependencies:"), std::string::npos) << r.out;
+}
+
+TEST(CliTest, RunDriftWarnsWhenInstalledDepNewer) {
+    TmpDir td;
+    auto home_path = td.path() / "home";
+    ScopedHome home(home_path);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v1?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "parent.spud",
+               "include child\nask done \"done?\" string default \"d\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install",
+                       (td.path() / "parent.spud").string()})
+                  .code,
+              0);
+    write_file(td.path() / "child.spud",
+               "ask q \"q v2?\" string default \"x\"\n");
+    ASSERT_EQ(run_cli({"spudplate", "install", "--yes",
+                       (td.path() / "child.spud").string()})
+                  .code,
+              0);
+    // Run parent: drift expected.
+    Argv run_args({"spudplate", "run", "--yes", "parent"});
+    std::stringstream rout, rerr;
+    ScriptedPrompter rprompter({"a", "b"});
+    int code = cli_main(run_args.argc(), run_args.argv(), rout, rerr,
+                        rprompter);
+    EXPECT_EQ(code, 0) << rerr.str();
+    EXPECT_NE(rerr.str().find("warning: dep 'child'"), std::string::npos)
+        << rerr.str();
+    EXPECT_NE(rerr.str().find("bundled at v1, installed v2"),
+              std::string::npos)
+        << rerr.str();
 }

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -292,34 +292,6 @@ TEST(InterpreterTest, IncludeWithoutBundledDepIsRuntimeError) {
     EXPECT_THROW(run(program, prompter), RuntimeError);
 }
 
-// Records every PromptRequest the interpreter issues, in order. Each call
-// returns the matching scripted answer. Lets tests assert on counter
-// indices, indent levels, and iteration ladders for prompts buried in
-// nested includes or repeats.
-class RecordingPrompter : public Prompter {
-  public:
-    explicit RecordingPrompter(std::vector<std::string> answers)
-        : answers_(std::move(answers)) {}
-
-    std::string prompt(const PromptRequest& req) override {
-        requests_.push_back(req);
-        if (index_ >= answers_.size()) {
-            throw std::logic_error("RecordingPrompter ran out of answers");
-        }
-        return answers_[index_++];
-    }
-    bool authorize(const std::string& /*summary*/) override { return true; }
-
-    [[nodiscard]] const std::vector<PromptRequest>& requests() const {
-        return requests_;
-    }
-
-  private:
-    std::vector<std::string> answers_;
-    std::size_t index_{0};
-    std::vector<PromptRequest> requests_;
-};
-
 TEST(InterpreterTest, IncludePromptsContinueParentCounterAndIndent) {
     // Parent has two asks straddling an include; the dep has two asks. All
     // four share one denominator (1/4..4/4) in source order, with the dep's
@@ -334,7 +306,7 @@ ask b2 "b2?" string default "y"
 include child
 ask a2 "a2?" string default "q"
 )");
-    RecordingPrompter prompter({"v1", "v2", "v3", "v4"});
+    ScriptedPrompter prompter({"v1", "v2", "v3", "v4"});
     run_for_tests(program, prompter, /*source=*/nullptr, &deps);
 
     const auto& reqs = prompter.requests();
@@ -380,7 +352,7 @@ include grandchild
 
     auto program = parse(R"(include child
 )");
-    RecordingPrompter prompter({"a", "b"});
+    ScriptedPrompter prompter({"a", "b"});
     run_for_tests(program, prompter, /*source=*/nullptr, &deps);
 
     const auto& reqs = prompter.requests();
@@ -411,7 +383,7 @@ ask d3 "d3?" string default "z"
     auto program = parse(R"(include child
 ask tail "tail?" string default "t"
 )");
-    RecordingPrompter prompter({"a", "b", "c", "d"});
+    ScriptedPrompter prompter({"a", "b", "c", "d"});
     run_for_tests(program, prompter, /*source=*/nullptr, &deps);
 
     const auto& reqs = prompter.requests();

--- a/tests/interpreter_test.cpp
+++ b/tests/interpreter_test.cpp
@@ -292,6 +292,136 @@ TEST(InterpreterTest, IncludeWithoutBundledDepIsRuntimeError) {
     EXPECT_THROW(run(program, prompter), RuntimeError);
 }
 
+// Records every PromptRequest the interpreter issues, in order. Each call
+// returns the matching scripted answer. Lets tests assert on counter
+// indices, indent levels, and iteration ladders for prompts buried in
+// nested includes or repeats.
+class RecordingPrompter : public Prompter {
+  public:
+    explicit RecordingPrompter(std::vector<std::string> answers)
+        : answers_(std::move(answers)) {}
+
+    std::string prompt(const PromptRequest& req) override {
+        requests_.push_back(req);
+        if (index_ >= answers_.size()) {
+            throw std::logic_error("RecordingPrompter ran out of answers");
+        }
+        return answers_[index_++];
+    }
+    bool authorize(const std::string& /*summary*/) override { return true; }
+
+    [[nodiscard]] const std::vector<PromptRequest>& requests() const {
+        return requests_;
+    }
+
+  private:
+    std::vector<std::string> answers_;
+    std::size_t index_{0};
+    std::vector<PromptRequest> requests_;
+};
+
+TEST(InterpreterTest, IncludePromptsContinueParentCounterAndIndent) {
+    // Parent has two asks straddling an include; the dep has two asks. All
+    // four share one denominator (1/4..4/4) in source order, with the dep's
+    // pair indented one level deeper than the parent's.
+    auto dep = dep_bytes_from_source(R"(ask b1 "b1?" string default "x"
+ask b2 "b2?" string default "y"
+)");
+    std::vector<SpudpackDep> deps;
+    deps.push_back({"child", dep});
+
+    auto program = parse(R"(ask a1 "a1?" string default "p"
+include child
+ask a2 "a2?" string default "q"
+)");
+    RecordingPrompter prompter({"v1", "v2", "v3", "v4"});
+    run_for_tests(program, prompter, /*source=*/nullptr, &deps);
+
+    const auto& reqs = prompter.requests();
+    ASSERT_EQ(reqs.size(), 4u);
+
+    EXPECT_EQ(reqs[0].text, "a1?");
+    EXPECT_EQ(reqs[0].question_index, 1);
+    EXPECT_EQ(reqs[0].question_total, 4);
+    EXPECT_EQ(reqs[0].indent_level, 0);
+
+    EXPECT_EQ(reqs[1].text, "b1?");
+    EXPECT_EQ(reqs[1].question_index, 2);
+    EXPECT_EQ(reqs[1].question_total, 4);
+    EXPECT_EQ(reqs[1].indent_level, 1);
+
+    EXPECT_EQ(reqs[2].text, "b2?");
+    EXPECT_EQ(reqs[2].question_index, 3);
+    EXPECT_EQ(reqs[2].question_total, 4);
+    EXPECT_EQ(reqs[2].indent_level, 1);
+
+    EXPECT_EQ(reqs[3].text, "a2?");
+    EXPECT_EQ(reqs[3].question_index, 4);
+    EXPECT_EQ(reqs[3].question_total, 4);
+    EXPECT_EQ(reqs[3].indent_level, 0);
+}
+
+TEST(InterpreterTest, NestedIncludesStackIndentAndShareCounter) {
+    // A dep that itself includes another dep: indent grows by one level
+    // per include, and all asks count toward one shared denominator.
+    auto inner = dep_bytes_from_source(R"(ask i1 "i1?" string default "x"
+)");
+    Program outer_program = parse(R"(ask o1 "o1?" string default "y"
+include grandchild
+)");
+    Spudpack outer_pack;
+    outer_pack.source = "<inline>";
+    outer_pack.program_bytes = serialize_program(outer_program);
+    outer_pack.deps.push_back({"grandchild", inner});
+    auto outer = spudpack_encode(outer_pack);
+
+    std::vector<SpudpackDep> deps;
+    deps.push_back({"child", outer});
+
+    auto program = parse(R"(include child
+)");
+    RecordingPrompter prompter({"a", "b"});
+    run_for_tests(program, prompter, /*source=*/nullptr, &deps);
+
+    const auto& reqs = prompter.requests();
+    ASSERT_EQ(reqs.size(), 2u);
+
+    EXPECT_EQ(reqs[0].text, "o1?");
+    EXPECT_EQ(reqs[0].question_index, 1);
+    EXPECT_EQ(reqs[0].question_total, 2);
+    EXPECT_EQ(reqs[0].indent_level, 1);
+
+    EXPECT_EQ(reqs[1].text, "i1?");
+    EXPECT_EQ(reqs[1].question_index, 2);
+    EXPECT_EQ(reqs[1].question_total, 2);
+    EXPECT_EQ(reqs[1].indent_level, 2);
+}
+
+TEST(InterpreterTest, ParentAskAfterIncludeResumesCounter) {
+    // After the dep finishes, the parent's `ask_index_` must reflect the
+    // dep's progress so the next parent prompt does not collide with one
+    // already shown.
+    auto dep = dep_bytes_from_source(R"(ask d1 "d1?" string default "x"
+ask d2 "d2?" string default "y"
+ask d3 "d3?" string default "z"
+)");
+    std::vector<SpudpackDep> deps;
+    deps.push_back({"child", dep});
+
+    auto program = parse(R"(include child
+ask tail "tail?" string default "t"
+)");
+    RecordingPrompter prompter({"a", "b", "c", "d"});
+    run_for_tests(program, prompter, /*source=*/nullptr, &deps);
+
+    const auto& reqs = prompter.requests();
+    ASSERT_EQ(reqs.size(), 4u);
+    EXPECT_EQ(reqs[3].text, "tail?");
+    EXPECT_EQ(reqs[3].question_index, 4);
+    EXPECT_EQ(reqs[3].question_total, 4);
+    EXPECT_EQ(reqs[3].indent_level, 0);
+}
+
 // --- run_for_tests returns the interpreter's environment ---
 
 TEST(InterpreterTest, RunForTestsReturnsEnvironmentOnEmptyProgram) {

--- a/tests/lexer_test.cpp
+++ b/tests/lexer_test.cpp
@@ -67,10 +67,10 @@ TEST(LexerTest, EofIsIdempotent) {
 }
 
 TEST(LexerTest, UnrecognizedCharReturnsError) {
-    Lexer lexer("@");
+    Lexer lexer("$");
     Token tok = lexer.nextToken();
     EXPECT_EQ(tok.type, TokenType::ERROR);
-    EXPECT_EQ(tok.value, "@");
+    EXPECT_EQ(tok.value, "$");
     EXPECT_EQ(tok.line, 1);
     EXPECT_EQ(tok.column, 1);
 
@@ -79,10 +79,10 @@ TEST(LexerTest, UnrecognizedCharReturnsError) {
 }
 
 TEST(LexerTest, WhitespaceBeforeUnrecognized) {
-    Lexer lexer("  @");
+    Lexer lexer("  $");
     Token tok = lexer.nextToken();
     EXPECT_EQ(tok.type, TokenType::ERROR);
-    EXPECT_EQ(tok.value, "@");
+    EXPECT_EQ(tok.value, "$");
     EXPECT_EQ(tok.column, 3);
 }
 

--- a/tests/parser_test.cpp
+++ b/tests/parser_test.cpp
@@ -1361,6 +1361,42 @@ TEST(ParserTest, IncludeAtTopLevelInProgram) {
     EXPECT_TRUE(inc.when_clause.has_value());
 }
 
+TEST(ParserTest, IncludeWithVersionPin) {
+    auto stmt = parse_include("include foo@2\n");
+    auto& inc = std::get<IncludeStmt>(stmt->data);
+    EXPECT_EQ(inc.name, "foo");
+    ASSERT_TRUE(inc.version_pin.has_value());
+    EXPECT_EQ(*inc.version_pin, 2u);
+    EXPECT_FALSE(inc.when_clause.has_value());
+}
+
+TEST(ParserTest, IncludeWithVersionPinAndWhen) {
+    auto stmt = parse_include("include foo@7 when use_foo\n");
+    auto& inc = std::get<IncludeStmt>(stmt->data);
+    EXPECT_EQ(inc.name, "foo");
+    ASSERT_TRUE(inc.version_pin.has_value());
+    EXPECT_EQ(*inc.version_pin, 7u);
+    ASSERT_TRUE(inc.when_clause.has_value());
+}
+
+TEST(ParserTest, IncludeWithoutPinHasNoVersionPin) {
+    auto stmt = parse_include("include bar\n");
+    auto& inc = std::get<IncludeStmt>(stmt->data);
+    EXPECT_FALSE(inc.version_pin.has_value());
+}
+
+TEST(ParserTest, IncludePinZeroRejected) {
+    EXPECT_THROW(parse_include("include foo@0\n"), ParseError);
+}
+
+TEST(ParserTest, IncludePinMissingNumberRejected) {
+    EXPECT_THROW(parse_include("include foo@\n"), ParseError);
+}
+
+TEST(ParserTest, IncludePinNonIntegerRejected) {
+    EXPECT_THROW(parse_include("include foo@bar\n"), ParseError);
+}
+
 TEST(ParserTest, UnexpectedTokenAtTopLevel) {
     EXPECT_THROW(parse_program("42\n"), ParseError);
 }

--- a/tests/spudpack_test.cpp
+++ b/tests/spudpack_test.cpp
@@ -164,45 +164,90 @@ TEST(SpudpackCodec, UnsupportedVersionZero) {
     }
 }
 
-TEST(SpudpackCodec, UnsupportedVersionFour) {
-    // v1, v2, and v3 are accepted; v4 (and above) is not.
+TEST(SpudpackCodec, UnsupportedVersionFive) {
+    // v1..v4 are accepted; v5 (and above) is not.
     Spudpack in = make_simple();
     auto bytes = spudpack_encode(in);
-    bytes[4] = 4;
+    bytes[4] = 5;
     rewrite_crc(bytes);
     EXPECT_THROW(spudpack_decode(bytes.data(), bytes.size()), SpudpackError);
 }
 
 TEST(SpudpackCodec, V1FixtureDecodes) {
-    // Encoder writes the highest supported version; flip the byte to 1 and
-    // rewrite the CRC. Decoding succeeds and the resulting Spudpack carries
-    // version=1 so downstream code (binary serialiser) can decode RunStmt
-    // without the trailing timeout field.
-    Spudpack in = make_simple();
-    auto bytes = spudpack_encode(in);
-    bytes[4] = 1;
+    // Hand-craft a minimal v1 envelope (no version_tag, no per-dep tags)
+    // to verify the decoder still accepts wire bytes from before v4. The
+    // resulting Spudpack falls back to version_tag=1 since the field did
+    // not exist on the wire.
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(1);                       // version
+    bytes.push_back(0);                       // flags
+    bytes.push_back(3);                       // source_len = 3
+    bytes.insert(bytes.end(), {'a', 'b', 'c'});
+    bytes.push_back(0);                       // program_len = 0
+    bytes.push_back(0);                       // asset_count = 0
+    bytes.push_back(0);                       // dep_count = 0
+    bytes.insert(bytes.end(), 4, 0);          // CRC placeholder
     rewrite_crc(bytes);
     auto out = spudpack_decode(bytes.data(), bytes.size());
     EXPECT_EQ(out.version, 1u);
-    EXPECT_EQ(out.source, in.source);
+    EXPECT_EQ(out.source, "abc");
+    EXPECT_EQ(out.version_tag, 1u);
 }
 
 TEST(SpudpackCodec, V2FixtureDecodes) {
-    // v2 packs in the wild carry no deps - flip the byte to 2 and decode.
-    Spudpack in = make_simple();
-    auto bytes = spudpack_encode(in);
-    bytes[4] = 2;
+    // Same shape as v1 - the v2 difference is internal to the program
+    // byte stream (RunStmt timeout field), invisible at the spudpack
+    // envelope. version_tag still defaults to 1.
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(2);                       // version
+    bytes.push_back(0);                       // flags
+    bytes.push_back(0);                       // source_len = 0
+    bytes.push_back(0);                       // program_len = 0
+    bytes.push_back(0);                       // asset_count = 0
+    bytes.push_back(0);                       // dep_count = 0
+    bytes.insert(bytes.end(), 4, 0);          // CRC placeholder
     rewrite_crc(bytes);
     auto out = spudpack_decode(bytes.data(), bytes.size());
     EXPECT_EQ(out.version, 2u);
     EXPECT_TRUE(out.deps.empty());
+    EXPECT_EQ(out.version_tag, 1u);
+}
+
+TEST(SpudpackCodec, V3FixtureDecodes) {
+    // v3 carries deps but still no version_tag fields. Hand-craft a v3
+    // envelope with one zero-byte dep blob (the blob would not actually
+    // round-trip through spudpack_decode, but the outer envelope decodes
+    // fine and we never recurse into the blob here).
+    std::vector<std::uint8_t> bytes;
+    bytes.insert(bytes.end(), {'S', 'P', 'U', 'D'});
+    bytes.push_back(3);                       // version
+    bytes.push_back(0);                       // flags
+    bytes.push_back(0);                       // source_len = 0
+    bytes.push_back(0);                       // program_len = 0
+    bytes.push_back(0);                       // asset_count = 0
+    bytes.push_back(1);                       // dep_count = 1
+    bytes.push_back(3);                       // dep[0] name_len = 3
+    bytes.insert(bytes.end(), {'f', 'o', 'o'});
+    bytes.push_back(0);                       // dep[0] blob_len = 0
+    bytes.insert(bytes.end(), 4, 0);          // CRC placeholder
+    rewrite_crc(bytes);
+    auto out = spudpack_decode(bytes.data(), bytes.size());
+    EXPECT_EQ(out.version, 3u);
+    ASSERT_EQ(out.deps.size(), 1u);
+    EXPECT_EQ(out.deps[0].name, "foo");
+    EXPECT_EQ(out.deps[0].version_tag, 1u);
+    EXPECT_EQ(out.version_tag, 1u);
 }
 
 TEST(SpudpackCodec, CrcMismatchDetected) {
     Spudpack in = make_simple();
     auto bytes = spudpack_encode(in);
-    // Flip a byte inside the source field, leaving the trailer alone.
-    bytes[10] ^= 0xFF;
+    // Flip a byte inside the source content. v4 layout: magic(4) +
+    // version(1) + flags(1) + version_tag(4) + source_len varint (1 byte
+    // for "Name?" length 24 = 0x18). Source content begins at byte 11.
+    bytes[12] ^= 0xFF;
     try {
         spudpack_decode(bytes.data(), bytes.size());
         FAIL() << "expected throw";
@@ -250,15 +295,19 @@ TEST(SpudpackCodec, RoundTripWithDeps) {
     auto inner_b_bytes = spudpack_encode(inner_b);
 
     Spudpack in = make_simple();
-    in.deps.push_back({"inner_a", inner_a_bytes});
-    in.deps.push_back({"inner_b", inner_b_bytes});
+    in.version_tag = 7;
+    in.deps.push_back({"inner_a", inner_a_bytes, 3});
+    in.deps.push_back({"inner_b", inner_b_bytes, 11});
     auto bytes = spudpack_encode(in);
     Spudpack out = spudpack_decode(bytes.data(), bytes.size());
-    EXPECT_EQ(out.version, 3u);
+    EXPECT_EQ(out.version, 4u);
+    EXPECT_EQ(out.version_tag, 7u);
     ASSERT_EQ(out.deps.size(), 2u);
     EXPECT_EQ(out.deps[0].name, "inner_a");
+    EXPECT_EQ(out.deps[0].version_tag, 3u);
     EXPECT_EQ(out.deps[0].bytes, inner_a_bytes);
     EXPECT_EQ(out.deps[1].name, "inner_b");
+    EXPECT_EQ(out.deps[1].version_tag, 11u);
     EXPECT_EQ(out.deps[1].bytes, inner_b_bytes);
 
     // The dep bytes must round-trip back through the codec untouched.
@@ -400,10 +449,11 @@ TEST(SpudpackCodec, DecodeRejectsModeWithReservedBits) {
     in.assets.push_back({"foo", 0644, {1, 2, 3}});
     auto bytes = spudpack_encode(in);
 
-    // Locate the mode field. After magic(4)+version(1)+flags(1)+source_len(1
-    // varint byte = 0)+program_len(1 = 0)+asset_count(1 = 1)+path_len(1)+
-    // path("foo" = 3 bytes), the next 2 bytes are the mode.
-    std::size_t mode_off = 4 + 1 + 1 + 1 + 1 + 1 + 1 + 3;
+    // Locate the mode field. v4 layout:
+    // magic(4) + version(1) + flags(1) + version_tag(4) + source_len(1=0)
+    // + program_len(1=0) + asset_count(1=1) + path_len(1) + path("foo"=3),
+    // the next 2 bytes are the mode.
+    std::size_t mode_off = 4 + 1 + 1 + 4 + 1 + 1 + 1 + 1 + 3;
     bytes[mode_off] = 0xFF;
     bytes[mode_off + 1] = 0xFF;
     rewrite_crc(bytes);

--- a/tests/spudpack_test.cpp
+++ b/tests/spudpack_test.cpp
@@ -316,6 +316,38 @@ TEST(SpudpackCodec, RoundTripWithDeps) {
     EXPECT_EQ(a_decoded.source, inner_a.source);
 }
 
+TEST(SpudpackCodec, EncodeRejectsZeroVersionTag) {
+    Spudpack in = make_simple();
+    in.version_tag = 0;
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, EncodeRejectsZeroDepVersionTag) {
+    Spudpack in = make_simple();
+    in.deps.push_back({"foo", {1, 2, 3}, /*version_tag=*/0});
+    EXPECT_THROW(spudpack_encode(in), SpudpackError);
+}
+
+TEST(SpudpackCodec, DecodeRejectsZeroVersionTag) {
+    Spudpack in = make_simple();
+    auto bytes = spudpack_encode(in);
+    // version_tag sits at bytes[6..9] (LE u32) in v4. Zero it out.
+    bytes[6] = 0;
+    bytes[7] = 0;
+    bytes[8] = 0;
+    bytes[9] = 0;
+    rewrite_crc(bytes);
+    try {
+        spudpack_decode(bytes.data(), bytes.size());
+        FAIL() << "expected throw";
+    } catch (const SpudpackError& e) {
+        EXPECT_NE(std::string(e.what()).find("version_tag must be >= 1"),
+                  std::string::npos);
+        ASSERT_TRUE(e.offset().has_value());
+        EXPECT_EQ(*e.offset(), 6u);
+    }
+}
+
 TEST(SpudpackCodec, EncodeRejectsDepNameWithSlash) {
     Spudpack in;
     in.deps.push_back({"a/b", {1, 2, 3}});

--- a/tests/test_helpers.cpp
+++ b/tests/test_helpers.cpp
@@ -219,6 +219,7 @@ bool stmts_equal(const Stmt& a, const Stmt& b) {
                 return av.line == bv.line && av.column == bv.column;
             } else if constexpr (std::is_same_v<T, IncludeStmt>) {
                 if (av.name != bv.name) return false;
+                if (av.version_pin != bv.version_pin) return false;
                 if (!optional_expr_equal(av.when_clause, bv.when_clause)) {
                     return false;
                 }


### PR DESCRIPTION
## Summary

Two user-facing changes that bundle into the unreleased v0.4.0. `include` prompts now continue the parent's `(n/m)` counter and inherit indent, so the user sees one progress ladder across the whole template tree. Installed templates carry a monotonic version tag that bumps on every install whose content differs, with a per-template archive of previous versions and a hard-pin syntax for deps.

## Changes
- Counter and indent inheritance across includes
  - The interpreter threads the parent's `ask_index_`, `ask_total_`, indent floor, enclosing repeat depth, and iter chain into included children. 
  - A dep prompt continues the parent's count toward one shared denominator, sits one nesting level deeper, and shows the parent's repeat iter ladder if the include sits inside a repeat
  - Nested includes stack the indent further. The static counter for the whole run is computed by walking included programs recursively at the top level.
- New spudpack v4 pack-level `version_tag: u32 LE` written immediately after the flags byte
   - New per-dep `version_tag: u32 LE` written between the dep name and the dep blob. Both must be at least 1.
   - v1, v2, and v3 packs decode unchanged with both tags defaulting to 1
   - The encoder always writes v4 spudpacks
   -  The binary AST gains a trailing optional `version_pin` on `IncludeStmt` for the new pin syntax.
- New token `@` and grammar `include <name>[@<int>] [when <expr>]`
  - Pin must be at least 1, parse error otherwise.
  - Pinned and unpinned encounters of the same name in one program are reconciled (matching pin reused, mismatched pins rejected).
- First install of a template is v1. 
  - Reinstalling identical content is a no-op and prints `already up to date (vN)`
  - Reinstalling changed content bumps to N+1 and copies the previous on-disk pack to `<install-root>/.archive/<name>.v<N>.spp` before overwriting
  - The CLI compares tentative-encoded bytes against the existing file to detect the no-op case.
- Sticky deps and `--update-deps`
  - Reinstalling a parent reuses the dep bytes the previous parent already carried
  - Source-only edits to the parent no longer silently swap a dep for the latest installed version
  - `spudplate install bar.spud --update-deps foo,baz` refreshes the listed unpinned deps from the install root.
  - Pinned deps are unaffectedm the flag emits a one-line `note: '<name>' is pinned in source; --update-deps ignored` and proceeds
- `include foo@N` reads `<install-root>/foo.spp` if its `version_tag` is N; otherwise reads `<install-root>/.archive/foo.vN.spp`, otherwise raises a bundle error naming both paths it tried.
- `spudplate run <name>` compares each top-level bundled dep's `version_tag` against the currently-installed copy. 
  - A mismatch produces one warning line per drifted dep with direction noted (newer installed, suggesting reinstall or older installed, noting the parent expected newer)
  -  Bundled bytes always run.
- `spudplate list` prints `name (vN)` per line and skips the archive directory.
- `spudplate inspect <name>` prints a header line `<name> (vN)`, a Dependencies section listing each bundled dep as `<dep> (vM)`, and the original source.
- `spudplate uninstall foo` removes both `<install-root>/foo.spp` and every `<install-root>/.archive/foo.v*.spp` matching the name. A safe prefix match guards against unrelated names like `foobar`.

### Docs

- `CHANGELOG.md` v0.4.0 section gains the new feature notes.
- `docs/spudpack-format.md` updated for v4 layout, version_tag fields, and the new error.
- `docs/lang/statements/include.md` documents the pin syntax, sticky default, and `--update-deps`.
- `README.md` install section mentions sticky deps, `--update-deps`, version tag, and archive.

## Test plan

- All 752 (29 new) tests pass locally.
- New unit coverage spans:
  - Spudpack codec: v4 round-trip including non-default tags on pack and deps, encode and decode rejection of zero tags, hand-crafted v1/v2/v3 fixtures decoding with default tags.
  - Binary serialiser: round-trip of `IncludeStmt` with a version pin; decoding the same bytes as v3 leaves `version_pin` at nullopt.
  - Parser: `include foo@N`, with and without `when`, plus rejection of `@0`, missing integer, and non-integer pins.
  - Interpreter: counter and indent inherited across one include level, nested includes stacking indent and sharing the denominator, parent ask after an include resuming the counter.
  - CLI: first install tags as v1, identical reinstall is a no-op, changed reinstall bumps and archives, parent bundles dep at current version, sticky default keeps the previous bundled bytes, `--update-deps` refreshes, pin resolves against the archive, unknown pin fails with both paths in the error, `--update-deps` on a pinned dep prints the note and is no-op, uninstall sweeps archive entries for the name, uninstall leaves other names alone, `list` shows tags and skips the archive, `inspect` shows version and dep versions, run-time drift warning fires when the installed dep is newer than the bundled one.
- End-to-end smoke run against the rebuilt binary: install foo at v1, install bar including foo, bump foo to v2 (foo.v1 archived), reinstall bar sticky stays no-op, `--update-deps foo` refreshes bar, install baz with `include foo@1` resolving from archive, run baz under foo at v2 emits the drift warning, uninstall foo sweeps the archive entries while bar still runs off its bundled bytes.