### PR TITLE
docs: fix doxygen rendering glitches

### DIFF
--- a/docs/lang/best-practices.md
+++ b/docs/lang/best-practices.md
@@ -17,7 +17,7 @@ ask project_name "Project name?" string
 let kebab_slug = lower(replace(trim(project_name), " ", "-"))
 ```
 
-### Name `ask` variables after the value, not the question
+### Name ask variables after the value, not the question
 
 The variable holds the answer, not the prompt. Aim for names that describe what the value **is**, not what was asked.
 
@@ -29,7 +29,7 @@ ask format "Output format?" string options "pdf" "html"        # value is the ch
 
 Names that read as a question (`should_we_include_tests`, `how_many_weeks`) age badly: they make `if use_tests` read fine but `if should_we_include_tests` clunky.
 
-### Boolean gates start with `use_` or are simply the feature name
+### Boolean gates start with use_ or are simply the feature name
 
 Most boolean asks are gates on optional sections. The conventional prefixes make the intent obvious at a glance:
 
@@ -43,13 +43,13 @@ A direct feature name (`tests`, `docs`) also works for the boolean form. Pick on
 
 ## Asking questions
 
-### Always supply a `default` if the answer is optional
+### Always supply a default if the answer is optional
 
 A question with no default is **required**. The user cannot skip it. That is exactly right for the project name, but wrong for the test runner: a user who does not care should be able to press enter.
 
 A useful rule of thumb: if you can describe a sensible default in one sentence, the question deserves a `default`.
 
-### Use `options` to bound free-form answers
+### Use options to bound free-form answers
 
 `options` turns an answer into a numbered menu. The user can type the literal value or the menu number. Two reasons this is worth using even when typing the value is easy:
 
@@ -71,7 +71,7 @@ ask num_weeks "How many weeks?" int default 0 when use_tests
 
 A well-ordered question sequence reads like a guided conversation.
 
-### Gate dependent questions with `when`
+### Gate dependent questions with when
 
 A `when`-gated question is only asked if its condition is true. The default is bound when the gate is false, so subsequent code always sees a real value. This is cleaner than asking a question the user has already implicitly declined.
 
@@ -79,7 +79,7 @@ The `when`-gated question must always have a `default`; the validator enforces i
 
 ## Variables
 
-### `let` once, use everywhere
+### let once, use everywhere
 
 If the same expression appears in two places, name it with `let`. It gives you one place to change, and a name that documents what the value means.
 
@@ -91,7 +91,7 @@ mkdir project_dir
 file project_dir/"README.md" content "# " + project_name
 ```
 
-### Prefer `as` aliases over inline path expressions you reuse
+### Prefer as aliases over inline path expressions you reuse
 
 When the same path appears twice in a row, an `as` alias is shorter and conveys "this is the same path, not a coincidentally-similar one":
 
@@ -124,7 +124,7 @@ file readme append content "\n\n## CI\n" when use_ci
 
 This is the lightest-weight way to build a sectioned file with optional parts. The same pattern works for `.gitignore`, `package.json` `scripts` blocks, etc.
 
-### Keep `let` chains short
+### Keep let chains short
 
 A `let` derived from a `let` derived from a `let` works, but each link in the chain hides the original input. Three or four steps is fine; a long chain usually means the original `ask` should be reshaped.
 
@@ -141,7 +141,7 @@ mkdir src                 # variable reference to 'src' (must be a let or alias)
 
 A common mistake is to write `mkdir templates from base_templates` and expect both names as literals. The parser interprets each as a variable reference, and the validator rejects them as undeclared. Quote them: `mkdir "templates" from "base_templates"`.
 
-### Use `{var}` only inside quoted segments
+### Use interpolation only inside quoted segments
 
 Interpolation in a path expression works only inside a quoted segment:
 
@@ -158,7 +158,7 @@ mkdir "static" as static_path
 mkdir static_path/"week_{n}"
 ```
 
-### `mkdir from` vs `copy into`
+### mkdir from vs copy into
 
 These two answer different questions:
 
@@ -179,7 +179,7 @@ copy "templates_extras" into templates_path when use_extras
 
 ## Conditional structure
 
-### `when` for one statement, `if` for blocks
+### when for one statement, if for blocks
 
 A single conditional statement reads fine with a `when` clause:
 
@@ -199,7 +199,7 @@ end
 
 The threshold is usually two or three statements. Below that, `when` is fine. Above it, the repeated condition obscures what is shared.
 
-### Compose two-branch decisions from negated `if`s
+### Compose two-branch decisions from negated ifs
 
 Spudlang has no `else`. For "do A or B but not both", two `if` blocks work:
 
@@ -214,13 +214,13 @@ end
 
 For more than two branches, a chain of `if` blocks with mutually-exclusive `==` conditions is the cleanest form.
 
-### Keep `repeat` bodies short
+### Keep repeat bodies short
 
 A `repeat` introduces its own scope and prompts inside it run once per iteration. Both are useful, but a long loop body with several `let`s and nested `if`s gets hard to follow. If you find yourself writing more than ten or so lines inside a `repeat`, consider whether each iteration should be its own `include`d template.
 
 ## Files and content
 
-### `file from` for large static content, `file content` for small dynamic content
+### file from for large static content, file content for small dynamic content
 
 `file from` is for files where most of the content is fixed and you want to ship them as-is, with light `{ident}` substitution.
 
@@ -228,13 +228,13 @@ A `repeat` introduces its own scope and prompts inside it run once per iteration
 
 The line is roughly: if you would think of opening the file in a text editor, it belongs in `from`. If it is a single string the template assembles, `content` is right.
 
-### Use `verbatim` for binary content and for text that contains literal `{`
+### Use verbatim for binary content and for text that contains literal braces
 
 The interpreter auto-detects binary content (anything that is not valid UTF-8) and copies it verbatim regardless of the `verbatim` keyword. So you do not need `verbatim` on PNGs, favicons, etc.
 
 You **do** need `verbatim` on text files that legitimately contain `{`, because the substitution scan would otherwise misinterpret them. LaTeX templates and shell scripts are common cases.
 
-### Set `mode` only when the system default is wrong
+### Set mode only when the system default is wrong
 
 Most files want the system default. The two cases worth setting `mode` for are:
 
@@ -256,7 +256,7 @@ run "git add ." in proj
 run "git commit -m 'initial'" in proj
 ```
 
-### Restrict free-form inputs that flow into `run`
+### Restrict free-form inputs that flow into run
 
 A user's `string` answer can be anything, including a shell injection payload. Two ways to defend:
 
@@ -265,11 +265,11 @@ A user's `string` answer can be anything, including a shell injection payload. T
 
 Most templates do not need user input inside a `run`. The trust prompt and the user reading their own commands are a good safety net, but the safest design avoids the problem.
 
-### Use `timeout` for slow commands
+### Use timeout for slow commands
 
 The default timeout is 60 seconds, which is right for `git init` but wrong for `npm install` or a multi-minute build. Set `timeout` explicitly when you know the command will take longer.
 
-### Reach for `run` only when there is no native form
+### Reach for run only when there is no native form
 
 `run` is the most powerful and the most dangerous statement. Use it for things that cannot be expressed structurally:
 
@@ -310,7 +310,7 @@ A few categories of error are inherently run-time:
 
 Lean on the parse-time guarantees: a template that survives `spudplate validate` is much closer to working than one that has not been validated.
 
-### Use `spudplate validate` while writing
+### Use spudplate validate while writing
 
 `spudplate validate <file.spud>` runs the lexer, parser, and validator without prompting or installing. Run it after each substantive edit. The errors it produces are precise about line and column.
 

--- a/docs/lang/lexical.md
+++ b/docs/lang/lexical.md
@@ -57,7 +57,7 @@ n
 total_days
 ```
 
-Identifiers are case-sensitive. `Name` and `name` are different identifiers. The convention used throughout this reference, the test suite, and the example library is **`snake_case`**.
+Identifiers are case-sensitive. `Name` and `name` are different identifiers. The convention used throughout this reference, the test suite, and the example library is `snake_case`.
 
 ## Keywords
 
@@ -93,9 +93,9 @@ second line
 "
 ```
 
-A double quote cannot appear inside a string. There is no `\"` escape. Use `{expr}` interpolation if you need to compose a string that contains a quote (for example, by binding the quote to an `ask` value or another `let`).
+A double quote cannot appear inside a string. There is no escape sequence for it. Use `{expr}` interpolation if you need to compose a string that contains a quote (for example, by binding the quote to an `ask` value or another `let`).
 
-Strings may contain `{expr}` interpolations. See [Types and expressions](types-and-expressions.md) for the rules.
+Strings may contain `{expr}` interpolations. See @ref lang_types "Types and expressions" for the rules.
 
 ### Integer
 
@@ -125,7 +125,7 @@ let ready = true
 | Token | Used in                                                                       |
 |-------|-------------------------------------------------------------------------------|
 | `+`, `-`, `*`, `/` | Arithmetic and string concatenation (`+`)                          |
-| `==`, `!=`, `&lt;`, `&lt;=`, `>`, `>=` | Comparison operators                           |
+| `==`, `!=`, `<`, `<=`, `>`, `>=` | Comparison operators                                |
 | `=`   | Assignment in `let` and reassignment statements                               |
 | `(`, `)` | Grouping in expressions; argument lists for `lower`, `upper`, `trim`, `replace` |
 | `{`, `}` | Open and close interpolation in path expressions                            |

--- a/docs/lang/paths.md
+++ b/docs/lang/paths.md
@@ -35,13 +35,13 @@ mkdir "static" as static_path
 mkdir static_path/"week_{n}"
 ```
 
-## `mkdir -p` semantics
+## mkdir -p semantics
 
 `mkdir` always creates intermediate directories. `mkdir "a/b/c"` creates `a`, `a/b`, and `a/b/c` in turn if any do not exist. There is no separate `mkdir -p` form.
 
 A `mkdir` whose path resolves to an already-existing path that the current run did not create is a runtime error. The interpreter only allows writing to paths it created itself within the same run, so there is no risk of silently overwriting a directory that pre-existed.
 
-## Path aliases with `as`
+## Path aliases with as
 
 The `as <name>` clause on `mkdir` or `file` binds the resolved path to a name. Subsequent path expressions may use that name as a bare identifier segment.
 
@@ -61,7 +61,7 @@ file readme append content "## Testing\n" when use_tests
 
 An `as` clause is optional. If you do not need to refer back to the path, omit it.
 
-### Alias scoping under `when`
+### Alias scoping under when
 
 When a `mkdir` or `file` carries a `when` clause, the alias it binds is **conditional**. It cannot be used outside a statement guarded by an equivalent condition. The validator rejects references that escape the gate.
 
@@ -79,7 +79,7 @@ Conditions are compared after normalisation. Equivalences the validator recognis
 
 If the binding statement has no `when` clause, the alias is unconditional and can be used anywhere.
 
-## `let`-bound strings as path roots
+## let-bound strings as path roots
 
 A string declared with `let` can be used as a bare path segment, just like an alias.
 

--- a/docs/lang/pitfalls.md
+++ b/docs/lang/pitfalls.md
@@ -40,7 +40,7 @@ line2
 
 There is also no `\"` escape. A double-quote inside a string literal closes the string. To compose a string that contains `"`, bind the value via `ask` or `let`.
 
-## `{var}` outside quoted path segments is rejected
+## Interpolation outside quoted path segments is rejected
 
 Inside a path expression, `{...}` interpolation is allowed **only inside a quoted segment**:
 
@@ -81,7 +81,7 @@ file x_path/"z" content "" when both
 
 This is a known limitation. It may be lifted in a future version; for now, write the same condition the same way every time.
 
-## A `when`-gated `ask` must have a `default`
+## A when-gated ask must have a default
 
 A bare `ask` is required: the user cannot skip it. A `when`-gated `ask` is asked only sometimes, but the variable must be bound after the statement either way. So the validator requires a `default`:
 
@@ -92,7 +92,7 @@ ask num_weeks "Weeks?" int default 0 when use_tests        # ok
 
 When `use_tests` is `false`, the default is bound and `num_weeks` is ready for any later code that reads it. When `use_tests` is `true`, the user is prompted as normal, and the default fills in for empty input.
 
-## `copy into` errors if the destination does not exist
+## copy into errors if the destination does not exist
 
 `copy <source> into <dest>` requires `<dest>` to already exist. It will not create it for you. If you want a fresh directory populated from one source, use `mkdir from` instead.
 
@@ -104,7 +104,7 @@ copy "templates" into "missing_dir"    # runtime error: missing_dir does not exi
 
 The pattern that combines both: `mkdir from` to create and seed, then `copy into` to merge add-ons.
 
-## `file append` errors if the file is not from this run
+## file append errors if the file is not from this run
 
 The interpreter tracks paths created during a single run. `file ... append` requires the target file to have been created earlier in the **same run**. Appending to a pre-existing file from outside the run is rejected on principle: spudplate never modifies files it did not create.
 
@@ -117,7 +117,7 @@ file "/etc/hosts" append content "..."   # runtime error: file pre-existed
 
 This is also why an aliased file path (`as`) is the conventional way to wire up conditional appends: the alias makes it impossible to typo a different filename.
 
-## Shell injection through `run` interpolation
+## Shell injection through run interpolation
 
 `run` builds a shell command from a string expression and dispatches it via `/bin/sh -c`. The trust prompt shows the **literal source** but the **evaluated string** is what executes:
 
@@ -132,7 +132,7 @@ A malicious `url` such as `; rm -rf $HOME` is passed straight to the shell. Defe
 
 See @ref lang_stmt_run "run" for the full security treatment.
 
-## `run` without `in <path>` uses the parent's working directory
+## run without in clause uses the parent's working directory
 
 Without `in`, a `run` inherits the working directory of `spudplate`, which is wherever the user invoked it from (rarely the project subdirectory the template just created). Always pin commands that depend on a particular cwd:
 
@@ -152,7 +152,7 @@ This usually only matters for `run` commands: a `run` failing mid-flush leaves t
 
 The "all or nothing" guarantee covers the common case: a user aborting at any prompt, before the flush starts. The first prompt is the cheapest place to back out.
 
-## `--no-timeout` is a CLI flag, not a per-statement clause
+## no-timeout is a CLI flag, not a per-statement clause
 
 The default `run` timeout is 60 seconds. A per-statement `timeout 600` overrides it for one command. There is no per-statement way to say "no timeout"; the only escape is the CLI `--no-timeout` flag, which applies to every `run` in the invocation.
 

--- a/docs/lang/statements/include.md
+++ b/docs/lang/statements/include.md
@@ -46,7 +46,7 @@ include claude_setup@3
 
 The bundler tries `<install-root>/claude_setup.spp` first; if its `version_tag` is not `3`, it falls back to `<install-root>/.archive/claude_setup.v3.spp`. If neither carries v3, the install fails with a clear error pointing to both paths it tried.
 
-Pinned deps are unaffected by `--update-deps`; the flag is silently no-op for them with a one-line `note: '<name>' is pinned in source; --update-deps ignored`.
+Pinned deps are unaffected by `--update-deps`; the flag is silently no-op for them with a one-line note `'NAME' is pinned in source; --update-deps ignored`.
 
 ## when
 

--- a/docs/lang/statements/index.md
+++ b/docs/lang/statements/index.md
@@ -79,7 +79,7 @@ A few patterns recur across most templates and are covered in @ref lang_best_pra
 - The **alias-then-append** idiom: `file ... as readme; file readme append content "..." when use_X` for sectioned README files.
 - The **slug-and-dir** idiom: an early `let dir = lower(slug) + "-project"` makes one path root that every subsequent statement reuses.
 - The **bool-question gate**: `ask use_tests bool default false` followed by `if use_tests ... end` keeps optional sections together.
-- The **`mkdir from` then `copy into`** idiom: create a base directory from one template tree, then merge optional add-ons in.
+- The **mkdir-then-copy** idiom: `mkdir <path> from <source>` to create a base directory from one template tree, then `copy <source> into <path>` to merge optional add-ons in.
 
 ## See also
 

--- a/docs/lang/types-and-expressions.md
+++ b/docs/lang/types-and-expressions.md
@@ -139,7 +139,7 @@ file "src/{slug}/main.cpp" content ""
 
 `{...}` outside a quoted segment in a path is a parse error: bare-identifier path segments must be plain identifiers (variable references), and there is no syntax for inline interpolation in an unquoted segment. See @ref lang_paths "Path expressions" for the full path grammar.
 
-### 3. `from` source files and `copy` source files
+### 3. from source files and copy source files
 
 When a `file ... from <source>` or `copy <source> into <dest>` reads a file from the bundle, the file's contents are scanned for bare `{ident}` substitutions. **Only bare identifier substitution applies.** Function calls, arithmetic, and string concatenation inside the braces are not supported in source-file contents. For full expression power, use `content <expr>` instead of `from`.
 

--- a/include/spudplate/bundler.h
+++ b/include/spudplate/bundler.h
@@ -66,7 +66,11 @@ class BundleError : public std::runtime_error {
  * resolution always honours the pin.
  */
 struct BundleOptions {
+    /// Previously-installed parent whose bundled deps the bundler should
+    /// reuse by default ("sticky" mode). Null when there is no prior install.
     const Spudpack* existing_parent = nullptr;
+    /// Names of unpinned deps the caller wants refreshed from the install
+    /// root despite the sticky default. Null means "no overrides".
     const std::unordered_set<std::string>* update_deps = nullptr;
 };
 
@@ -78,6 +82,8 @@ struct BundleOptions {
  * ignored" hint without the bundler having to take a stream parameter.
  */
 struct BundleNotes {
+    /// Names of deps that were listed in `--update-deps` but are pinned in
+    /// source; the bundler honoured the pin and ignored the override.
     std::vector<std::string> ignored_update_pins;
 };
 


### PR DESCRIPTION
## Summary

The lang reference had a few rendering glitches on the GitHub Pages site. This fixes them and clears the doxygen warnings.

## Changes

- Lexical reference: rephrase the no-escape-sequence sentence so the literal backslash-quote no longer breaks doxygen, switch the comparison-operator table cell to plain less-than, drop the bold around the snake_case code span, and use `@ref` for the types-and-expressions link.
- Pitfalls, paths, best practices, types and expressions: drop backticks from all markdown headings. Doxygen turns them into a `tt` tag and the navtree shows the raw markup.
- Statements index: drop the bold wrapping around the mkdir-from then copy-into idiom bullet, since bold around a code span does not render.
- Include reference: rephrase the pinned dep note so doxygen does not treat the angle-bracket placeholder as an unknown HTML tag.
- Bundler header: document the three optional fields on `BundleOptions` and `BundleNotes`.

## Test plan

- `cmake --build build --target docs` runs clean (no warnings).
- All 752 tests pass.
- Spot-checked the rendered HTML: the punctuation table renders, snake_case is in code only, headings show plain text, navtree entries are clean.