### PR TITLE
fix: drop version tag from list output

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -168,7 +168,8 @@ void print_help_validate(std::ostream& out) {
 void print_help_list(std::ostream& out) {
     out << "usage: spudplate list\n"
         << "\n"
-        << "List installed templates as 'name (vN)', one per line.\n";
+        << "List installed template names, one per line. Use 'spudplate "
+           "inspect <name>' to see version and dependency details.\n";
 }
 
 void print_help_inspect(std::ostream& out) {
@@ -1160,25 +1161,13 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     if (!std::filesystem::is_directory(home)) {
         return 0;  // No installs yet - empty output, success.
     }
-    struct Entry {
-        std::string name;
-        std::optional<std::uint32_t> version_tag;
-    };
-    std::vector<Entry> entries;
+    std::vector<std::string> entries;
     std::vector<std::string> shadowed_legacy;
     std::vector<std::string> only_legacy;
     std::error_code ec;
     for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
         if (entry.is_regular_file() && ends_with_spp(entry.path())) {
-            Entry e{entry.path().stem().string(), std::nullopt};
-            try {
-                Spudpack p = spudpack_read_file(entry.path());
-                e.version_tag = p.version_tag;
-            } catch (...) {
-                // Unreadable pack: list the name without a version. The
-                // user can still see it exists and act on it.
-            }
-            entries.push_back(std::move(e));
+            entries.push_back(entry.path().stem().string());
         }
     }
     for (const auto& entry : std::filesystem::directory_iterator(home, ec)) {
@@ -1191,29 +1180,19 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
         if (!std::filesystem::is_regular_file(entry.path() / "template.spud")) {
             continue;
         }
-        bool already_listed = false;
-        for (const auto& e : entries) {
-            if (e.name == n) {
-                already_listed = true;
-                break;
-            }
-        }
+        bool already_listed =
+            std::find(entries.begin(), entries.end(), n) != entries.end();
         if (already_listed) {
             shadowed_legacy.push_back(n);
         } else {
             only_legacy.push_back(n);
         }
     }
-    std::sort(entries.begin(), entries.end(),
-              [](const Entry& a, const Entry& b) { return a.name < b.name; });
+    std::sort(entries.begin(), entries.end());
     std::sort(shadowed_legacy.begin(), shadowed_legacy.end());
     std::sort(only_legacy.begin(), only_legacy.end());
-    for (const auto& e : entries) {
-        out << e.name;
-        if (e.version_tag.has_value()) {
-            out << " (v" << *e.version_tag << ")";
-        }
-        out << "\n";
+    for (const auto& n : entries) {
+        out << n << "\n";
     }
     for (const auto& n : shadowed_legacy) {
         err << "warning: legacy install '" << n << "' is shadowed by '" << n << ".spp'\n";

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -530,7 +530,7 @@ TEST(CliTest, ListShowsInstalledNamesSorted) {
     ScriptedPrompter prompter({});
     int code = cli_main(args.argc(), args.argv(), out, err, prompter);
     EXPECT_EQ(code, 0);
-    EXPECT_EQ(out.str(), "alpha (v1)\nzebra (v1)\n");
+    EXPECT_EQ(out.str(), "alpha\nzebra\n");
 }
 
 TEST(CliTest, InspectPrintsSource) {
@@ -1031,7 +1031,7 @@ TEST(CliTest, ListWarnsAboutShadowedLegacy) {
     std::stringstream err;
     ScriptedPrompter prompter({});
     EXPECT_EQ(cli_main(args.argc(), args.argv(), out, err, prompter), 0);
-    EXPECT_EQ(out.str(), "demo (v1)\n");
+    EXPECT_EQ(out.str(), "demo\n");
     EXPECT_NE(err.str().find("shadowed"), std::string::npos);
 }
 
@@ -1751,7 +1751,7 @@ TEST(CliTest, UninstallLeavesOtherNamesArchive) {
                                                  "foobar.v1.spp"));
 }
 
-TEST(CliTest, ListShowsTagsAndSkipsArchive) {
+TEST(CliTest, ListAfterReinstallSkipsArchive) {
     TmpDir td;
     auto home_path = td.path() / "home";
     ScopedHome home(home_path);
@@ -1769,7 +1769,7 @@ TEST(CliTest, ListShowsTagsAndSkipsArchive) {
               0);
     auto r = run_cli({"spudplate", "list"});
     EXPECT_EQ(r.code, 0) << r.err;
-    EXPECT_EQ(r.out, "foo (v2)\n");
+    EXPECT_EQ(r.out, "foo\n");
 }
 
 TEST(CliTest, InspectShowsVersionAndDeps) {


### PR DESCRIPTION
## Summary

The list command's `name (vN)` format breaks shell tab completion. With one or more templates installed, the zsh `_alternative` spec gained an embedded `(v1)` that zsh parses as a glob qualifier, errored with `unknown file attribute: v` and tab completion stopped working. The bash completion silently produced garbage candidates for the same reason. This drops the version suffix so completions can pipe `list` output straight into candidate sets again.

## Changes

- list now prints one name per line, no version. Versions stay visible via inspect.
- Help text updated to match.
- Drops the per-entry spudpack read that was only there to fetch the tag, so list is also faster.

## Test plan

- All 752 tests pass locally.
- Three list tests updated to assert bare names.
- Manually confirmed `spudplate run<TAB>` works in zsh after installing a template.