### PR TITLE
ci: run on pull requests to dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

The CI workflow only runs on pull requests targeting main, so PRs against dev get no automatic build or test feedback. This adds dev to the pull_request branch list.

## Test plan

- This PR itself should now show a CI run (was the missing trigger).