### PR TITLE
feat: question schema and answers file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,8 @@ add_executable(spudplate_tests tests/lexer_test.cpp tests/parser_test.cpp
                tests/validator_test.cpp tests/interpreter_test.cpp
                tests/cli_test.cpp tests/crc32_test.cpp
                tests/test_helpers.cpp tests/binary_serializer_test.cpp
-               tests/spudpack_test.cpp tests/bundler_test.cpp)
+               tests/spudpack_test.cpp tests/bundler_test.cpp
+               tests/introspect_test.cpp)
 target_include_directories(spudplate_tests PRIVATE tests)
 target_link_libraries(spudplate_tests PRIVATE spudplate_lib GTest::gtest_main)
 include(GoogleTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ string(REGEX REPLACE "^v" "" SPUDPLATE_VERSION "${SPUDPLATE_VERSION}")
 add_library(spudplate_lib src/lexer.cpp src/parser.cpp src/validator.cpp
                           src/interpreter.cpp src/cli.cpp src/crc32.cpp
                           src/binary_serializer.cpp src/spudpack.cpp
-                          src/bundler.cpp)
+                          src/bundler.cpp src/introspect.cpp)
 target_include_directories(spudplate_lib PUBLIC include)
 target_compile_definitions(spudplate_lib PUBLIC
     SPUDPLATE_VERSION_STRING="${SPUDPLATE_VERSION}")

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,7 @@ Bundled `include` deps are sticky by default: reinstalling a parent reuses the d
 ## run
 
 ```
-spudplate run [--dry-run] [--yes] [--no-timeout] <name[@N]|file.spud|file.spp>
+spudplate run [--dry-run] [--yes] [--no-timeout] [--answers FILE] <name[@N]|file.spud|file.spp>
 ```
 
 Runs an installed template by name, or runs a `.spud` or `.spp` file directly.
@@ -40,10 +40,22 @@ Runs an installed template by name, or runs a `.spud` or `.spp` file directly.
 | `--dry-run` | Walk the program and print the questions and actions without writing any files. |
 | `--yes`, `-y` | Skip the authorisation prompt for `run` statements during this invocation. |
 | `--no-timeout` | Disable per-`run` timeouts for this invocation (default is 60 seconds per shell command). |
+| `--answers FILE` | Load top-level question answers from a YAML file. See [Non-interactive runs](#non-interactive-runs-with---answers) below. |
 
 `run` decides whether the argument is a path or an installed name. An argument containing `/` or ending in `.spud` or `.spp` is treated as a path; everything else is looked up as `<install-root>/<arg>.spp`.
 
 Suffix `@N` to pin a specific archived version, for example `spudplate run foo@4` runs version 4 even if a newer release is now installed. The lookup checks the archive first and falls back to the live install when its version tag matches `N`.
+
+### Non-interactive runs with `--answers`
+
+`--answers FILE` reads a YAML mapping of `name: value` entries and uses each value as the pre-filled answer for the matching top-level `ask`. Generate the schema with `inspect <name> --questions -o <file>`, edit the values, then pass the file back via `run --answers`.
+
+Behaviour:
+
+- Only top-level questions can be pre-answered. Asks nested in `repeat` or `if` still prompt at runtime.
+- A pre-answered question whose `when` clause evaluates false is skipped exactly as it would be without the answer; the template's `default` fires and the supplied value is dropped on the floor.
+- Unknown keys, type mismatches, and duplicate keys are errors and abort the run before any prompt or filesystem write.
+- Values are coerced against the declared ask type: `string` accepts bare or `"quoted"` text, `int` accepts signed integers, `bool` accepts `true`/`false` (case-insensitive). Other YAML features (lists, anchors, multi-line scalars) are not supported.
 
 ---
 
@@ -70,12 +82,19 @@ Prints every installed template name, one per line. Use `inspect <name>` to see 
 ## inspect
 
 ```
-spudplate inspect <name[@N]>
+spudplate inspect <name[@N]> [--questions [-o FILE]]
 ```
 
 Prints the version tag of an installed template, the version tag of every dep it bundles, and the original `.spud` source captured at install time. Accepts a bare name only - not a path.
 
 Suffix `@N` to inspect an archived version, for example `spudplate inspect foo@4`. Same lookup as `run`: archive first, live fallback when the version tag matches.
+
+| Flag | Effect |
+|------|--------|
+| `--questions` | List the template's top-level questions instead of printing the source. The same set is what `include with` accepts and what `run --answers` can pre-fill. |
+| `-o`, `--output FILE` | With `--questions`, write a YAML answer template to `FILE` ready to be edited and passed to `run --answers`. |
+
+The YAML template renders one `name: value` line per top-level question, with the type and prompt as a leading comment. Literal defaults are pre-filled; `when`-gated and option-restricted asks carry an extra comment so the editor knows what is allowed at runtime.
 
 ---
 

--- a/docs/lang/statements/include.md
+++ b/docs/lang/statements/include.md
@@ -93,6 +93,10 @@ Each `with` name must match a **top-level** `ask` in the includee, not one neste
 
 Caller-side errors (an arg expression referencing an undeclared identifier, a duplicate arg name in the same `include`) surface at parse or validate time before the bundler runs.
 
+### Discovering an includee's `with` keys
+
+`spudplate inspect <name> --questions` lists exactly the set of names a `with` clause may target, with each one's type, prompt, default, options, and any `when` annotation. Add `-o FILE` to dump the same information as a YAML answer template that doubles as a worked example for `run --answers`.
+
 ## when
 
 The `when` clause skips the include if the condition is false. The conditional is evaluated at run time.

--- a/include/spudplate/interpreter.h
+++ b/include/spudplate/interpreter.h
@@ -310,7 +310,8 @@ void run(const Program& program, Prompter& prompter,
          bool skip_authorization = false,
          const SourceProvider* source = nullptr,
          bool timeouts_disabled = false,
-         const std::vector<SpudpackDep>* deps = nullptr);
+         const std::vector<SpudpackDep>* deps = nullptr,
+         const std::unordered_map<std::string, Value>* pre_answers = nullptr);
 
 /**
  * @brief Test-only entry point: like `run`, but returns the final environment.
@@ -341,7 +342,9 @@ Environment run_for_tests(const Program& program, Prompter& prompter,
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
              bool ascii_only = false,
              const SourceProvider* source = nullptr,
-             const std::vector<SpudpackDep>* deps = nullptr);
+             const std::vector<SpudpackDep>* deps = nullptr,
+             const std::unordered_map<std::string, Value>* pre_answers =
+                 nullptr);
 
 /**
  * @brief Heuristic check: does the current environment look UTF-8 capable?

--- a/include/spudplate/introspect.h
+++ b/include/spudplate/introspect.h
@@ -1,0 +1,99 @@
+#ifndef SPUDPLATE_INTROSPECT_H
+#define SPUDPLATE_INTROSPECT_H
+
+#include <iosfwd>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "spudplate/ast.h"
+#include "spudplate/interpreter.h"
+
+namespace spudplate {
+
+/**
+ * @brief Information about a single top-level `ask` in a program.
+ *
+ * "Top-level" means the `ask` statement is at program scope, not nested
+ * inside `repeat` or `if`. These are exactly the questions that can be
+ * pre-answered, via either `include` `with`-args or `run --answers`.
+ *
+ * The pointers reference nodes owned by the source `Program`. They remain
+ * valid for the lifetime of that program and become dangling once it is
+ * destroyed.
+ */
+struct TopLevelAsk {
+    std::string name;             ///< Variable name bound by the ask.
+    VarType var_type;             ///< Declared answer type.
+    std::string prompt;           ///< Human-readable prompt text.
+    const Expr* default_value;    ///< Default-value expression, or null.
+    const std::vector<ExprPtr>* options;  ///< Allowed values, never null.
+    const Expr* when_clause;      ///< Conditional gate, or null.
+    int line;
+    int column;
+};
+
+/**
+ * @brief Walk a program and collect every top-level `ask` in source order.
+ *
+ * Skips asks nested inside `repeat` or `if` bodies, which cannot be
+ * pre-answered (the bundler enforces the same rule for `with`-args).
+ */
+std::vector<TopLevelAsk> collect_top_level_asks(const Program& program);
+
+/**
+ * @brief Render a human-readable list of top-level questions.
+ *
+ * One line per question, of the form
+ * `  name (type): prompt [default: ...] [options: ...] [when: gated]`.
+ * The `when` annotation appears only when the ask carries a `when` clause.
+ */
+void emit_questions_human(std::ostream& out,
+                          const std::vector<TopLevelAsk>& asks);
+
+/**
+ * @brief Render a YAML answer template for the given questions.
+ *
+ * The output is a top-level mapping of `name: value` pairs preceded by a
+ * comment block summarising each ask. Defaults are pre-filled where they
+ * are literal; non-literal defaults yield an empty placeholder.
+ */
+void emit_questions_yaml(std::ostream& out,
+                         const std::vector<TopLevelAsk>& asks);
+
+/**
+ * @brief Error thrown when a YAML answers file cannot be parsed or coerced.
+ *
+ * `line` is 1-based and refers to the answers file. Zero means the error
+ * has no line context (e.g. an unknown key reported by the caller).
+ */
+struct AnswersParseError : std::runtime_error {
+    AnswersParseError(std::string msg, int line)
+        : std::runtime_error(std::move(msg)), line_(line) {}
+    [[nodiscard]] int line() const noexcept { return line_; }
+
+  private:
+    int line_;
+};
+
+/**
+ * @brief Parse a YAML answers file and coerce values against the asks.
+ *
+ * Accepts a deliberately small subset of YAML: a single top-level mapping
+ * of `key: value` entries, where values are strings (quoted or bare),
+ * integers, or booleans. Comments (`#`) and blank lines are ignored. No
+ * nesting, lists, or block scalars are supported.
+ *
+ * Each key must match the name of a top-level ask; unknown keys throw
+ * `AnswersParseError`. Each value is coerced to the matching ask's
+ * declared type; type mismatches throw `AnswersParseError` with the
+ * offending line.
+ */
+std::unordered_map<std::string, Value> parse_answers_yaml(
+    const std::string& source,
+    const std::vector<TopLevelAsk>& asks);
+
+}  // namespace spudplate
+
+#endif  // SPUDPLATE_INTROSPECT_H

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -28,6 +28,7 @@
 #include "spudplate/bundler.h"
 #include "spudplate/cli_internal.h"
 #include "spudplate/interpreter.h"
+#include "spudplate/introspect.h"
 #include "spudplate/lexer.h"
 #include "spudplate/parser.h"
 #include "spudplate/spudpack.h"
@@ -176,12 +177,19 @@ void print_help_list(std::ostream& out) {
 }
 
 void print_help_inspect(std::ostream& out) {
-    out << "usage: spudplate inspect <name[@N]>\n"
+    out << "usage: spudplate inspect <name[@N]> [--questions [-o FILE]]\n"
         << "\n"
         << "Print the version of an installed template, the version of\n"
         << "every dep it bundles, and the original .spud source.\n"
         << "\n"
-        << "Suffix `@N` to inspect an archived version, e.g. 'foo@4'.\n";
+        << "Suffix `@N` to inspect an archived version, e.g. 'foo@4'.\n"
+        << "\n"
+        << "Options:\n"
+        << "  --questions       list the template's top-level questions\n"
+        << "                    (the same set that may be pre-answered via\n"
+        << "                    `include with` or `run --answers`)\n"
+        << "  -o, --output FILE write a YAML answer template to FILE; only\n"
+        << "                    valid together with --questions\n";
 }
 
 void print_help_uninstall(std::ostream& out) {
@@ -1273,15 +1281,38 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
 }
 
 int cmd_inspect(int argc, char* argv[], std::ostream& out, std::ostream& err) {
-    if (argc >= 3 && is_help_flag(argv[2])) {
-        print_help_inspect(out);
-        return 0;
+    bool questions = false;
+    std::string output_path;
+    int positional_start = 2;
+    while (positional_start < argc) {
+        std::string arg{argv[positional_start]};
+        if (is_help_flag(arg)) {
+            print_help_inspect(out);
+            return 0;
+        }
+        if (arg == "--questions") {
+            questions = true;
+            ++positional_start;
+        } else if (arg == "-o" || arg == "--output") {
+            if (positional_start + 1 >= argc) {
+                err << arg << " requires a path argument\n";
+                return 1;
+            }
+            output_path = argv[positional_start + 1];
+            positional_start += 2;
+        } else {
+            break;
+        }
     }
-    if (argc - 2 != 1) {
+    if (!output_path.empty() && !questions) {
+        err << "-o requires --questions\n";
+        return 1;
+    }
+    if (argc - positional_start != 1) {
         print_usage(err);
         return 1;
     }
-    std::string raw{argv[2]};
+    std::string raw{argv[positional_start]};
     if (looks_like_path(raw)) {
         err << "inspect takes an installed template name, not a path\n";
         return 1;
@@ -1321,6 +1352,34 @@ int cmd_inspect(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     }
     try {
         Spudpack pack = spudpack_read_file(spp_path);
+        if (questions) {
+            Program program;
+            try {
+                program = deserialize_program(
+                    pack.program_bytes.data(), pack.program_bytes.size(),
+                    pack.version);
+            } catch (const BinaryDeserializeError& e) {
+                err << name << ": " << e.what() << "\n";
+                return 1;
+            }
+            auto asks = collect_top_level_asks(program);
+            if (!output_path.empty()) {
+                std::ofstream sink(output_path);
+                if (!sink) {
+                    err << output_path << ": cannot open for writing: "
+                        << std::strerror(errno) << "\n";
+                    return 1;
+                }
+                emit_questions_yaml(sink, asks);
+                if (!sink) {
+                    err << output_path << ": write failed\n";
+                    return 1;
+                }
+            } else {
+                emit_questions_human(out, asks);
+            }
+            return 0;
+        }
         out << name << " (v" << pack.version_tag << ")\n";
         if (!pack.deps.empty()) {
             out << "\nDependencies:\n";

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1283,36 +1283,39 @@ int cmd_list(int argc, char* argv[], std::ostream& out, std::ostream& err) {
 int cmd_inspect(int argc, char* argv[], std::ostream& out, std::ostream& err) {
     bool questions = false;
     std::string output_path;
-    int positional_start = 2;
-    while (positional_start < argc) {
-        std::string arg{argv[positional_start]};
+    std::string raw;
+    for (int i = 2; i < argc; ++i) {
+        std::string arg{argv[i]};
         if (is_help_flag(arg)) {
             print_help_inspect(out);
             return 0;
         }
         if (arg == "--questions") {
             questions = true;
-            ++positional_start;
         } else if (arg == "-o" || arg == "--output") {
-            if (positional_start + 1 >= argc) {
+            if (i + 1 >= argc) {
                 err << arg << " requires a path argument\n";
                 return 1;
             }
-            output_path = argv[positional_start + 1];
-            positional_start += 2;
+            output_path = argv[++i];
+        } else if (!arg.empty() && arg[0] == '-') {
+            err << "unknown option '" << arg << "'\n";
+            return 1;
+        } else if (raw.empty()) {
+            raw = arg;
         } else {
-            break;
+            print_usage(err);
+            return 1;
         }
     }
     if (!output_path.empty() && !questions) {
         err << "-o requires --questions\n";
         return 1;
     }
-    if (argc - positional_start != 1) {
+    if (raw.empty()) {
         print_usage(err);
         return 1;
     }
-    std::string raw{argv[positional_start]};
     if (looks_like_path(raw)) {
         err << "inspect takes an installed template name, not a path\n";
         return 1;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -104,7 +104,7 @@ void print_usage(std::ostream& out) {
         << "  run <name|file>          run an installed template, or a .spud/.spp file\n"
         << "  validate <file.spud>     parse and validate without installing\n"
         << "  list                     list installed templates\n"
-        << "  inspect <name>           print the source of an installed template\n"
+        << "  inspect <name>           print template source or list its questions\n"
         << "  uninstall <name>         remove an installed template\n"
         << "  version                  print the spudplate version\n"
         << "  update                   fetch and install the latest spudplate release\n"

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -145,7 +145,7 @@ void print_help_install(std::ostream& out) {
 
 void print_help_run(std::ostream& out) {
     out << "usage: spudplate run [--dry-run] [--yes] [--no-timeout] "
-           "<name[@N]|file.spud|file.spp>\n"
+           "[--answers FILE] <name[@N]|file.spud|file.spp>\n"
         << "\n"
         << "Run an installed template by name, or run a .spud or .spp file\n"
         << "directly. The argument is treated as a path when it contains a\n"
@@ -156,10 +156,14 @@ void print_help_run(std::ostream& out) {
         << "run version 4 even if a newer release is now installed.\n"
         << "\n"
         << "Options:\n"
-        << "  --dry-run       print the file tree the run would create,\n"
-        << "                  without touching the filesystem\n"
-        << "  --yes, -y       skip the authorisation prompt for run statements\n"
-        << "  --no-timeout    disable per-statement timeouts\n";
+        << "  --dry-run        print the file tree the run would create,\n"
+        << "                   without touching the filesystem\n"
+        << "  --yes, -y        skip the authorisation prompt for run statements\n"
+        << "  --no-timeout     disable per-statement timeouts\n"
+        << "  --answers FILE   load top-level question answers from a YAML\n"
+        << "                   file produced by `inspect --questions -o`;\n"
+        << "                   prompts are skipped for matching answers,\n"
+        << "                   `when`-gated questions still resolve at runtime\n";
 }
 
 void print_help_validate(std::ostream& out) {
@@ -1531,6 +1535,7 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
     bool dry_run_mode = false;
     bool skip_authorization = false;
     bool timeouts_disabled = false;
+    std::string answers_path;
     int positional_start = 2;
     while (positional_start < argc) {
         std::string arg{argv[positional_start]};
@@ -1547,6 +1552,13 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
         } else if (arg == "--no-timeout") {
             timeouts_disabled = true;
             ++positional_start;
+        } else if (arg == "--answers") {
+            if (positional_start + 1 >= argc) {
+                err << "--answers requires a path argument\n";
+                return 1;
+            }
+            answers_path = argv[positional_start + 1];
+            positional_start += 2;
         } else {
             break;
         }
@@ -1684,13 +1696,36 @@ int cmd_run(int argc, char* argv[], std::ostream& out, std::ostream& err,
         deps_ptr = &pack.deps;
     }
 
+    std::unordered_map<std::string, Value> pre_answers;
+    if (!answers_path.empty()) {
+        std::ifstream in(answers_path);
+        if (!in) {
+            err << answers_path << ": cannot open: "
+                << std::strerror(errno) << "\n";
+            return 1;
+        }
+        std::stringstream buffer;
+        buffer << in.rdbuf();
+        try {
+            auto asks = collect_top_level_asks(program);
+            pre_answers = parse_answers_yaml(buffer.str(), asks);
+        } catch (const AnswersParseError& e) {
+            err << answers_path;
+            if (e.line() > 0) err << ":" << e.line();
+            err << ": " << e.what() << "\n";
+            return 1;
+        }
+    }
+    const std::unordered_map<std::string, Value>* pre_answers_ptr =
+        pre_answers.empty() ? nullptr : &pre_answers;
+
     try {
         if (dry_run_mode) {
             dry_run(program, prompter, out, /*ascii_only=*/!locale_is_utf8(),
-                    source_ptr, deps_ptr);
+                    source_ptr, deps_ptr, pre_answers_ptr);
         } else {
             run(program, prompter, skip_authorization, source_ptr,
-                timeouts_disabled, deps_ptr);
+                timeouts_disabled, deps_ptr, pre_answers_ptr);
         }
     } catch (const RuntimeError& e) {
         print_error(err, file_path.string(), "runtime error", e.line(), e.column(),

--- a/src/interpreter.cpp
+++ b/src/interpreter.cpp
@@ -1925,7 +1925,8 @@ std::string value_to_string(const Value& value) {
 
 void run(const Program& program, Prompter& prompter, bool skip_authorization,
          const SourceProvider* source, bool timeouts_disabled,
-         const std::vector<SpudpackDep>* deps) {
+         const std::vector<SpudpackDep>* deps,
+         const std::unordered_map<std::string, Value>* pre_answers) {
     if (!skip_authorization) {
         std::string summary = build_authorize_summary(program);
         if (!summary.empty() && !prompter.authorize(summary)) {
@@ -1936,6 +1937,9 @@ void run(const Program& program, Prompter& prompter, bool skip_authorization,
                        source != nullptr ? *source : default_source_provider(),
                        deps);
     interp.set_timeouts_disabled(timeouts_disabled);
+    if (pre_answers != nullptr && !pre_answers->empty()) {
+        interp.set_pre_answers(*pre_answers);
+    }
     run_program(program, interp, deps);
 }
 
@@ -2120,11 +2124,15 @@ bool locale_is_utf8() {
 
 void dry_run(const Program& program, Prompter& prompter, std::ostream& out,
              bool ascii_only, const SourceProvider* source,
-             const std::vector<SpudpackDep>* deps) {
+             const std::vector<SpudpackDep>* deps,
+             const std::unordered_map<std::string, Value>* pre_answers) {
     Interpreter interp(prompter,
                        source != nullptr ? *source : default_source_provider(),
                        deps);
     interp.set_ask_total(count_ask_statements(program, deps));
+    if (pre_answers != nullptr && !pre_answers->empty()) {
+        interp.set_pre_answers(*pre_answers);
+    }
     for (const auto& stmt : program.statements) {
         interp.execute(*stmt);
     }

--- a/src/introspect.cpp
+++ b/src/introspect.cpp
@@ -223,10 +223,7 @@ void emit_questions_yaml(std::ostream& out,
         out << "\n# (this template has no top-level questions)\n";
         return;
     }
-    bool first = true;
     for (const auto& a : asks) {
-        if (!first) out << "\n";
-        first = false;
         out << "\n# " << a.name << " (" << type_name(a.var_type) << "): "
             << a.prompt << "\n";
         if (a.options != nullptr && !a.options->empty()) {

--- a/src/introspect.cpp
+++ b/src/introspect.cpp
@@ -1,0 +1,404 @@
+#include "spudplate/introspect.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <ostream>
+#include <sstream>
+#include <type_traits>
+#include <unordered_set>
+#include <variant>
+
+namespace spudplate {
+
+namespace {
+
+void walk(const std::vector<StmtPtr>& body, bool nested,
+          std::vector<TopLevelAsk>& out) {
+    for (const auto& sp : body) {
+        if (!sp) continue;
+        std::visit(
+            [&](const auto& s) {
+                using T = std::decay_t<decltype(s)>;
+                if constexpr (std::is_same_v<T, AskStmt>) {
+                    if (nested) return;
+                    out.push_back(TopLevelAsk{
+                        .name = s.name,
+                        .var_type = s.var_type,
+                        .prompt = s.prompt,
+                        .default_value = s.default_value.has_value()
+                                             ? s.default_value->get()
+                                             : nullptr,
+                        .options = &s.options,
+                        .when_clause = s.when_clause.has_value()
+                                           ? s.when_clause->get()
+                                           : nullptr,
+                        .line = s.line,
+                        .column = s.column,
+                    });
+                } else if constexpr (std::is_same_v<T, RepeatStmt>) {
+                    walk(s.body, true, out);
+                } else if constexpr (std::is_same_v<T, IfStmt>) {
+                    walk(s.body, true, out);
+                }
+            },
+            sp->data);
+    }
+}
+
+const char* type_name(VarType t) {
+    switch (t) {
+        case VarType::String: return "string";
+        case VarType::Bool:   return "bool";
+        case VarType::Int:    return "int";
+    }
+    return "unknown";
+}
+
+// Render a literal expression to its YAML form. Strings get JSON-style
+// double quotes with `\` and `"` escaped (any other character is emitted
+// as-is, which is fine for the printable content templates produce).
+// Returns false for non-literal expressions; the caller emits a placeholder.
+bool format_literal(const Expr* e, std::string& out) {
+    if (e == nullptr) return false;
+    return std::visit(
+        [&](const auto& v) -> bool {
+            using T = std::decay_t<decltype(v)>;
+            if constexpr (std::is_same_v<T, StringLiteralExpr>) {
+                out += '"';
+                for (char c : v.value) {
+                    if (c == '\\' || c == '"') out += '\\';
+                    out += c;
+                }
+                out += '"';
+                return true;
+            } else if constexpr (std::is_same_v<T, IntegerLiteralExpr>) {
+                out += std::to_string(v.value);
+                return true;
+            } else if constexpr (std::is_same_v<T, BoolLiteralExpr>) {
+                out += v.value ? "true" : "false";
+                return true;
+            } else {
+                return false;
+            }
+        },
+        e->data);
+}
+
+// Empty placeholder used when no default exists or it is a non-literal.
+std::string empty_placeholder(VarType t) {
+    switch (t) {
+        case VarType::String: return "\"\"";
+        case VarType::Bool:   return "false";
+        case VarType::Int:    return "0";
+    }
+    return "\"\"";
+}
+
+void format_options(std::string& out, const std::vector<ExprPtr>& options) {
+    bool first = true;
+    for (const auto& opt : options) {
+        if (!first) out += ", ";
+        first = false;
+        std::string rendered;
+        if (opt && format_literal(opt.get(), rendered)) {
+            out += rendered;
+        } else {
+            out += "?";
+        }
+    }
+}
+
+// A stripped lower(trim()) for case-insensitive boolean parsing.
+std::string lower_trim(const std::string& s) {
+    std::size_t a = 0;
+    std::size_t b = s.size();
+    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) --b;
+    std::string out;
+    out.reserve(b - a);
+    for (std::size_t i = a; i < b; ++i) {
+        out += static_cast<char>(
+            std::tolower(static_cast<unsigned char>(s[i])));
+    }
+    return out;
+}
+
+bool parse_int_literal(const std::string& tok, std::int64_t& out) {
+    if (tok.empty()) return false;
+    std::size_t i = 0;
+    bool neg = false;
+    if (tok[0] == '+' || tok[0] == '-') {
+        neg = (tok[0] == '-');
+        ++i;
+        if (i == tok.size()) return false;
+    }
+    std::int64_t acc = 0;
+    for (; i < tok.size(); ++i) {
+        char c = tok[i];
+        if (c < '0' || c > '9') return false;
+        acc = acc * 10 + (c - '0');
+    }
+    out = neg ? -acc : acc;
+    return true;
+}
+
+// Strip the surrounding quotes from a YAML scalar and process the minimal
+// escape set we emit (`\\`, `\"`). Other backslash escapes are left as-is
+// so users can paste paths like `C:\Users\name` unquoted with no surprises.
+bool parse_quoted_string(const std::string& tok, std::string& out, int line) {
+    if (tok.size() < 2 || tok.front() != '"' || tok.back() != '"') {
+        return false;
+    }
+    out.clear();
+    for (std::size_t i = 1; i + 1 < tok.size(); ++i) {
+        char c = tok[i];
+        if (c == '\\' && i + 2 < tok.size()) {
+            char nxt = tok[i + 1];
+            if (nxt == '"' || nxt == '\\') {
+                out += nxt;
+                ++i;
+                continue;
+            }
+        }
+        if (c == '"') {
+            throw AnswersParseError(
+                "unescaped quote inside string", line);
+        }
+        out += c;
+    }
+    return true;
+}
+
+}  // namespace
+
+std::vector<TopLevelAsk> collect_top_level_asks(const Program& program) {
+    std::vector<TopLevelAsk> out;
+    walk(program.statements, /*nested=*/false, out);
+    return out;
+}
+
+void emit_questions_human(std::ostream& out,
+                          const std::vector<TopLevelAsk>& asks) {
+    if (asks.empty()) {
+        out << "(no top-level questions)\n";
+        return;
+    }
+    out << "Questions:\n";
+    for (const auto& a : asks) {
+        out << "  " << a.name << " (" << type_name(a.var_type) << "): "
+            << a.prompt;
+        std::string suffix;
+        if (a.default_value != nullptr) {
+            std::string lit;
+            if (format_literal(a.default_value, lit)) {
+                suffix += " [default: " + lit + "]";
+            } else {
+                suffix += " [default: <expression>]";
+            }
+        }
+        if (a.options != nullptr && !a.options->empty()) {
+            std::string opts;
+            format_options(opts, *a.options);
+            suffix += " [options: " + opts + "]";
+        }
+        if (a.when_clause != nullptr) {
+            suffix += " [when: gated]";
+        }
+        out << suffix << "\n";
+    }
+}
+
+void emit_questions_yaml(std::ostream& out,
+                         const std::vector<TopLevelAsk>& asks) {
+    out << "# Spudplate answer template.\n"
+           "# Edit each value below, then pass the file to "
+           "`spudplate run <name> --answers <this-file>`.\n"
+           "# Lines beginning with `#` are comments. `when`-gated questions "
+           "are skipped when the\n"
+           "# condition evaluates false; in that case the value here is "
+           "ignored and the\n"
+           "# template's default fires instead.\n";
+    if (asks.empty()) {
+        out << "\n# (this template has no top-level questions)\n";
+        return;
+    }
+    bool first = true;
+    for (const auto& a : asks) {
+        if (!first) out << "\n";
+        first = false;
+        out << "\n# " << a.name << " (" << type_name(a.var_type) << "): "
+            << a.prompt << "\n";
+        if (a.options != nullptr && !a.options->empty()) {
+            out << "# options: ";
+            std::string opts;
+            format_options(opts, *a.options);
+            out << opts << "\n";
+        }
+        if (a.when_clause != nullptr) {
+            out << "# when: gated (answer applies only if the condition is "
+                   "true at runtime)\n";
+        }
+        std::string value;
+        if (a.default_value != nullptr &&
+            format_literal(a.default_value, value)) {
+            // Use the literal default verbatim.
+        } else {
+            value = empty_placeholder(a.var_type);
+        }
+        out << a.name << ": " << value << "\n";
+    }
+}
+
+std::unordered_map<std::string, Value> parse_answers_yaml(
+    const std::string& source,
+    const std::vector<TopLevelAsk>& asks) {
+    std::unordered_map<std::string, VarType> by_name;
+    by_name.reserve(asks.size());
+    for (const auto& a : asks) {
+        by_name.emplace(a.name, a.var_type);
+    }
+
+    std::unordered_map<std::string, Value> out;
+    std::unordered_set<std::string> seen;
+    std::istringstream in(source);
+    std::string line;
+    int line_no = 0;
+    while (std::getline(in, line)) {
+        ++line_no;
+        // Strip a trailing carriage return for CRLF files.
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+
+        std::size_t i = 0;
+        while (i < line.size() &&
+               std::isspace(static_cast<unsigned char>(line[i]))) {
+            ++i;
+        }
+        if (i == line.size() || line[i] == '#') continue;
+
+        // Bare key up to ':'
+        std::size_t key_start = i;
+        while (i < line.size() && line[i] != ':' &&
+               !std::isspace(static_cast<unsigned char>(line[i]))) {
+            ++i;
+        }
+        if (key_start == i) {
+            throw AnswersParseError("expected key", line_no);
+        }
+        std::string key = line.substr(key_start, i - key_start);
+        while (i < line.size() &&
+               std::isspace(static_cast<unsigned char>(line[i]))) {
+            ++i;
+        }
+        if (i >= line.size() || line[i] != ':') {
+            throw AnswersParseError(
+                "expected ':' after key '" + key + "'", line_no);
+        }
+        ++i;  // past ':'
+        while (i < line.size() &&
+               std::isspace(static_cast<unsigned char>(line[i]))) {
+            ++i;
+        }
+
+        // Trailing inline comment is permitted only after a quoted value.
+        // For bare values we treat ` # ...` as a comment, but `#` inside a
+        // bare token is part of the token. Keep this dead simple: trim
+        // trailing whitespace and accept the rest as the raw value token.
+        std::string raw;
+        if (i < line.size() && line[i] == '"') {
+            // Quoted string: scan to closing quote, allowing `\"` and `\\`.
+            std::size_t j = i + 1;
+            while (j < line.size()) {
+                if (line[j] == '\\' && j + 1 < line.size()) {
+                    j += 2;
+                    continue;
+                }
+                if (line[j] == '"') break;
+                ++j;
+            }
+            if (j >= line.size()) {
+                throw AnswersParseError(
+                    "unterminated quoted string", line_no);
+            }
+            raw = line.substr(i, j - i + 1);
+            // Anything after the closing quote (besides whitespace and a
+            // trailing `#` comment) is an error.
+            std::size_t k = j + 1;
+            while (k < line.size() &&
+                   std::isspace(static_cast<unsigned char>(line[k]))) {
+                ++k;
+            }
+            if (k < line.size() && line[k] != '#') {
+                throw AnswersParseError(
+                    "unexpected text after quoted value", line_no);
+            }
+        } else {
+            std::size_t end = line.size();
+            while (end > i &&
+                   std::isspace(
+                       static_cast<unsigned char>(line[end - 1]))) {
+                --end;
+            }
+            raw = line.substr(i, end - i);
+        }
+
+        if (raw.empty()) {
+            throw AnswersParseError(
+                "empty value for key '" + key + "'", line_no);
+        }
+
+        auto it = by_name.find(key);
+        if (it == by_name.end()) {
+            throw AnswersParseError(
+                "unknown question '" + key + "'", line_no);
+        }
+        if (!seen.insert(key).second) {
+            throw AnswersParseError(
+                "duplicate key '" + key + "'", line_no);
+        }
+
+        switch (it->second) {
+            case VarType::String: {
+                std::string s;
+                if (!raw.empty() && raw.front() == '"') {
+                    if (!parse_quoted_string(raw, s, line_no)) {
+                        throw AnswersParseError(
+                            "malformed quoted string for '" + key + "'",
+                            line_no);
+                    }
+                } else {
+                    s = raw;
+                }
+                out.emplace(key, Value{std::move(s)});
+                break;
+            }
+            case VarType::Int: {
+                std::int64_t n = 0;
+                if (!parse_int_literal(raw, n)) {
+                    throw AnswersParseError(
+                        "value for '" + key + "' is not an integer",
+                        line_no);
+                }
+                out.emplace(key, Value{n});
+                break;
+            }
+            case VarType::Bool: {
+                std::string lc = lower_trim(raw);
+                if (lc == "true") {
+                    out.emplace(key, Value{true});
+                } else if (lc == "false") {
+                    out.emplace(key, Value{false});
+                } else {
+                    throw AnswersParseError(
+                        "value for '" + key +
+                            "' is not a boolean (use true or false)",
+                        line_no);
+                }
+                break;
+            }
+        }
+    }
+    return out;
+}
+
+}  // namespace spudplate

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -430,6 +430,96 @@ TEST(CliTest, RunByNameLooksUpInstalledTemplate) {
     EXPECT_TRUE(std::filesystem::is_directory(td.path() / "my_project"));
 }
 
+TEST(CliTest, RunWithAnswersFileSkipsMatchingPrompts) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud",
+                     "ask name \"name\" string\n"
+                     "mkdir \"{name}\"\n");
+    auto answers = td.path() / "answers.yaml";
+    write_file(answers, "name: alpha\n");
+    Argv args({"spudplate", "run", "--answers", answers.string(), "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    // Empty prompter answers - the test fails if the run actually prompts.
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "alpha"));
+}
+
+TEST(CliTest, RunWithAnswersFileWhenFalseFallsBackToDefault) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud",
+                     "ask use_extra \"x?\" bool default false\n"
+                     "ask flavour \"f\" string default \"vanilla\" "
+                     "when use_extra\n"
+                     "mkdir flavour\n");
+    auto answers = td.path() / "answers.yaml";
+    // use_extra stays false, so flavour's `when` evaluates false and the
+    // pre-answer here ("strawberry") is dropped in favour of the default.
+    write_file(answers, "use_extra: false\nflavour: strawberry\n");
+    Argv args({"spudplate", "run", "--answers", answers.string(), "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_TRUE(std::filesystem::is_directory(td.path() / "vanilla"));
+    EXPECT_FALSE(std::filesystem::is_directory(td.path() / "strawberry"));
+}
+
+TEST(CliTest, RunWithAnswersFileUnknownKeyFails) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud",
+                     "ask name \"n\" string\nmkdir \"{name}\"\n");
+    auto answers = td.path() / "answers.yaml";
+    write_file(answers, "ghost: 1\n");
+    Argv args({"spudplate", "run", "--answers", answers.string(), "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("unknown question 'ghost'"), std::string::npos);
+}
+
+TEST(CliTest, RunWithAnswersFileTypeMismatchFails) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud",
+                     "ask weeks \"w\" int\nmkdir \"out\"\n");
+    auto answers = td.path() / "answers.yaml";
+    write_file(answers, "weeks: not-a-number\n");
+    Argv args({"spudplate", "run", "--answers", answers.string(), "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("not an integer"), std::string::npos);
+}
+
+TEST(CliTest, RunWithAnswersFileMissingPathFails) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud", "mkdir \"x\"\n");
+    Argv args({"spudplate", "run", "--answers", "/nonexistent.yaml", "demo"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("cannot open"), std::string::npos);
+}
+
 TEST(CliTest, RunByUnknownNameExitsFive) {
     TmpDir td;
     auto home = td.path() / "home";

--- a/tests/cli_test.cpp
+++ b/tests/cli_test.cpp
@@ -548,6 +548,63 @@ TEST(CliTest, InspectPrintsSource) {
     EXPECT_EQ(out.str(), "demo (v1)\n\n" + body);
 }
 
+TEST(CliTest, InspectQuestionsListsTopLevelAsks) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud",
+                     "ask name \"Project name?\" string\n"
+                     "ask use_git \"Use git?\" bool default true\n");
+    Argv args({"spudplate", "inspect", "demo", "--questions"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    EXPECT_NE(out.str().find("name (string): Project name?"),
+              std::string::npos);
+    EXPECT_NE(out.str().find("use_git (bool): Use git?"), std::string::npos);
+    EXPECT_NE(out.str().find("[default: true]"), std::string::npos);
+}
+
+TEST(CliTest, InspectQuestionsToFileWritesYaml) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud",
+                     "ask name \"Project name?\" string\n"
+                     "ask use_git \"Use git?\" bool default true\n");
+    auto out_path = td.path() / "answers.yaml";
+    Argv args({"spudplate", "inspect", "demo", "--questions",
+               "-o", out_path.string()});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 0) << err.str();
+    ASSERT_TRUE(std::filesystem::is_regular_file(out_path));
+    std::ifstream in(out_path);
+    std::stringstream buf;
+    buf << in.rdbuf();
+    std::string contents = buf.str();
+    EXPECT_NE(contents.find("name: \"\""), std::string::npos);
+    EXPECT_NE(contents.find("use_git: true"), std::string::npos);
+}
+
+TEST(CliTest, InspectOutputWithoutQuestionsRejected) {
+    TmpDir td;
+    auto home = td.path() / "home";
+    ScopedHome scoped(home);
+    install_template(td.path() / "demo.spud", "mkdir \"x\"\n");
+    Argv args({"spudplate", "inspect", "demo", "-o", "out.yaml"});
+    std::stringstream out;
+    std::stringstream err;
+    ScriptedPrompter prompter({});
+    int code = cli_main(args.argc(), args.argv(), out, err, prompter);
+    EXPECT_EQ(code, 1);
+    EXPECT_NE(err.str().find("requires --questions"), std::string::npos);
+}
+
 TEST(CliTest, InspectUnknownExitsFive) {
     TmpDir td;
     auto home = td.path() / "home";

--- a/tests/introspect_test.cpp
+++ b/tests/introspect_test.cpp
@@ -1,0 +1,80 @@
+#include "spudplate/introspect.h"
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+#include "spudplate/lexer.h"
+#include "spudplate/parser.h"
+
+namespace spudplate {
+namespace {
+
+Program parse_source(const std::string& src) {
+    Lexer lex(src);
+    Parser p(std::move(lex));
+    return p.parse();
+}
+
+TEST(Introspect, CollectsTopLevelAsksInOrder) {
+    Program prog = parse_source(
+        "ask a \"first\" string\n"
+        "ask b \"second\" int default 7\n"
+        "ask c \"third\" bool default true\n");
+    auto asks = collect_top_level_asks(prog);
+    ASSERT_EQ(asks.size(), 3u);
+    EXPECT_EQ(asks[0].name, "a");
+    EXPECT_EQ(asks[0].var_type, VarType::String);
+    EXPECT_EQ(asks[0].prompt, "first");
+    EXPECT_EQ(asks[0].default_value, nullptr);
+    EXPECT_EQ(asks[0].when_clause, nullptr);
+    EXPECT_EQ(asks[1].name, "b");
+    EXPECT_EQ(asks[1].var_type, VarType::Int);
+    EXPECT_NE(asks[1].default_value, nullptr);
+    EXPECT_EQ(asks[2].name, "c");
+    EXPECT_EQ(asks[2].var_type, VarType::Bool);
+}
+
+TEST(Introspect, SkipsAsksInsideRepeat) {
+    Program prog = parse_source(
+        "ask n \"how many\" int\n"
+        "repeat n as i\n"
+        "  ask name \"name\" string\n"
+        "end\n");
+    auto asks = collect_top_level_asks(prog);
+    ASSERT_EQ(asks.size(), 1u);
+    EXPECT_EQ(asks[0].name, "n");
+}
+
+TEST(Introspect, SkipsAsksInsideIf) {
+    Program prog = parse_source(
+        "ask use_extras \"extras?\" bool default false\n"
+        "if use_extras\n"
+        "  ask flavour \"which?\" string\n"
+        "end\n");
+    auto asks = collect_top_level_asks(prog);
+    ASSERT_EQ(asks.size(), 1u);
+    EXPECT_EQ(asks[0].name, "use_extras");
+}
+
+TEST(Introspect, RecordsOptionsAndWhenClause) {
+    Program prog = parse_source(
+        "ask use_docs \"docs?\" bool default true\n"
+        "ask format \"output format\" string options \"pdf\" \"html\" "
+        "default \"pdf\" when use_docs\n");
+    auto asks = collect_top_level_asks(prog);
+    ASSERT_EQ(asks.size(), 2u);
+    EXPECT_NE(asks[1].when_clause, nullptr);
+    ASSERT_NE(asks[1].options, nullptr);
+    EXPECT_EQ(asks[1].options->size(), 2u);
+}
+
+TEST(Introspect, EmptyProgramYieldsEmptyVector) {
+    Program prog = parse_source("");
+    auto asks = collect_top_level_asks(prog);
+    EXPECT_TRUE(asks.empty());
+}
+
+}  // namespace
+}  // namespace spudplate

--- a/tests/introspect_test.cpp
+++ b/tests/introspect_test.cpp
@@ -76,5 +76,40 @@ TEST(Introspect, EmptyProgramYieldsEmptyVector) {
     EXPECT_TRUE(asks.empty());
 }
 
+TEST(Introspect, HumanOutputListsEachQuestion) {
+    Program prog = parse_source(
+        "ask name \"Project name?\" string\n"
+        "ask use_git \"Use git?\" bool default true\n");
+    auto asks = collect_top_level_asks(prog);
+    std::ostringstream out;
+    emit_questions_human(out, asks);
+    std::string s = out.str();
+    EXPECT_NE(s.find("Questions:"), std::string::npos);
+    EXPECT_NE(s.find("name (string): Project name?"), std::string::npos);
+    EXPECT_NE(s.find("use_git (bool): Use git?"), std::string::npos);
+    EXPECT_NE(s.find("[default: true]"), std::string::npos);
+}
+
+TEST(Introspect, HumanOutputAnnotatesOptionsAndWhen) {
+    Program prog = parse_source(
+        "ask use_docs \"docs?\" bool default true\n"
+        "ask format \"format?\" string options \"pdf\" \"html\" "
+        "default \"pdf\" when use_docs\n");
+    auto asks = collect_top_level_asks(prog);
+    std::ostringstream out;
+    emit_questions_human(out, asks);
+    std::string s = out.str();
+    EXPECT_NE(s.find("[options: \"pdf\", \"html\"]"), std::string::npos);
+    EXPECT_NE(s.find("[when: gated]"), std::string::npos);
+}
+
+TEST(Introspect, HumanOutputHandlesEmpty) {
+    Program prog = parse_source("");
+    auto asks = collect_top_level_asks(prog);
+    std::ostringstream out;
+    emit_questions_human(out, asks);
+    EXPECT_NE(out.str().find("(no top-level questions)"), std::string::npos);
+}
+
 }  // namespace
 }  // namespace spudplate

--- a/tests/introspect_test.cpp
+++ b/tests/introspect_test.cpp
@@ -111,5 +111,115 @@ TEST(Introspect, HumanOutputHandlesEmpty) {
     EXPECT_NE(out.str().find("(no top-level questions)"), std::string::npos);
 }
 
+TEST(Introspect, YamlOutputPrefillsLiteralDefaults) {
+    Program prog = parse_source(
+        "ask name \"Project name?\" string\n"
+        "ask use_git \"Use git?\" bool default true\n"
+        "ask weeks \"Weeks?\" int default 4\n"
+        "ask format \"Format?\" string default \"pdf\"\n");
+    auto asks = collect_top_level_asks(prog);
+    std::ostringstream out;
+    emit_questions_yaml(out, asks);
+    std::string s = out.str();
+    EXPECT_NE(s.find("name: \"\""), std::string::npos);
+    EXPECT_NE(s.find("use_git: true"), std::string::npos);
+    EXPECT_NE(s.find("weeks: 4"), std::string::npos);
+    EXPECT_NE(s.find("format: \"pdf\""), std::string::npos);
+}
+
+TEST(Introspect, YamlOutputAnnotatesOptionsAndWhen) {
+    Program prog = parse_source(
+        "ask use_docs \"docs?\" bool default true\n"
+        "ask format \"format\" string options \"pdf\" \"html\" "
+        "default \"pdf\" when use_docs\n");
+    auto asks = collect_top_level_asks(prog);
+    std::ostringstream out;
+    emit_questions_yaml(out, asks);
+    std::string s = out.str();
+    EXPECT_NE(s.find("# options: \"pdf\", \"html\""), std::string::npos);
+    EXPECT_NE(s.find("# when: gated"), std::string::npos);
+}
+
+TEST(Introspect, ParseAnswersHappyPath) {
+    Program prog = parse_source(
+        "ask name \"n\" string\n"
+        "ask weeks \"w\" int\n"
+        "ask use_git \"g\" bool\n");
+    auto asks = collect_top_level_asks(prog);
+    auto answers = parse_answers_yaml(
+        "name: \"my project\"\n"
+        "weeks: 12\n"
+        "use_git: false\n",
+        asks);
+    EXPECT_EQ(answers.size(), 3u);
+    EXPECT_EQ(std::get<std::string>(answers["name"]), "my project");
+    EXPECT_EQ(std::get<std::int64_t>(answers["weeks"]), 12);
+    EXPECT_EQ(std::get<bool>(answers["use_git"]), false);
+}
+
+TEST(Introspect, ParseAnswersAcceptsBareString) {
+    Program prog = parse_source("ask name \"n\" string\n");
+    auto asks = collect_top_level_asks(prog);
+    auto answers = parse_answers_yaml("name: hello world\n", asks);
+    EXPECT_EQ(std::get<std::string>(answers["name"]), "hello world");
+}
+
+TEST(Introspect, ParseAnswersIgnoresCommentsAndBlankLines) {
+    Program prog = parse_source("ask name \"n\" string\n");
+    auto asks = collect_top_level_asks(prog);
+    auto answers = parse_answers_yaml(
+        "# leading comment\n"
+        "\n"
+        "name: foo\n"
+        "\n"
+        "# trailing\n",
+        asks);
+    EXPECT_EQ(std::get<std::string>(answers["name"]), "foo");
+}
+
+TEST(Introspect, ParseAnswersRejectsUnknownKey) {
+    Program prog = parse_source("ask name \"n\" string\n");
+    auto asks = collect_top_level_asks(prog);
+    EXPECT_THROW(parse_answers_yaml("ghost: 1\n", asks),
+                 AnswersParseError);
+}
+
+TEST(Introspect, ParseAnswersRejectsTypeMismatch) {
+    Program prog = parse_source("ask weeks \"w\" int\n");
+    auto asks = collect_top_level_asks(prog);
+    EXPECT_THROW(parse_answers_yaml("weeks: notanint\n", asks),
+                 AnswersParseError);
+}
+
+TEST(Introspect, ParseAnswersRejectsBoolFromOtherStrings) {
+    Program prog = parse_source("ask flag \"f\" bool\n");
+    auto asks = collect_top_level_asks(prog);
+    EXPECT_THROW(parse_answers_yaml("flag: yes\n", asks),
+                 AnswersParseError);
+}
+
+TEST(Introspect, ParseAnswersRejectsDuplicateKey) {
+    Program prog = parse_source("ask name \"n\" string\n");
+    auto asks = collect_top_level_asks(prog);
+    EXPECT_THROW(parse_answers_yaml("name: a\nname: b\n", asks),
+                 AnswersParseError);
+}
+
+TEST(Introspect, ParseAnswersAcceptsCRLF) {
+    Program prog = parse_source("ask name \"n\" string\n");
+    auto asks = collect_top_level_asks(prog);
+    auto answers = parse_answers_yaml("name: \"foo\"\r\n", asks);
+    EXPECT_EQ(std::get<std::string>(answers["name"]), "foo");
+}
+
+TEST(Introspect, ParseAnswersHandlesQuotedEscapes) {
+    Program prog = parse_source("ask greeting \"g\" string\n");
+    auto asks = collect_top_level_asks(prog);
+    auto answers = parse_answers_yaml(
+        "greeting: \"hi \\\"there\\\"\"\n", asks);
+    EXPECT_EQ(std::get<std::string>(answers["greeting"]),
+              "hi \"there\"");
+}
+
 }  // namespace
 }  // namespace spudplate


### PR DESCRIPTION
## Summary

Adds a way to discover a template's top-level questions and to answer them non-interactively. `spudplate inspect <name> --questions` lists the questions; with `-o FILE` it writes a YAML answer template ready to be edited and passed back via `spudplate run --answers FILE`. Doubles as the way to discover what `with`-args an `include` accepts on a given installed dep.

## Changes

- New `inspect --questions [-o FILE]` flag pair. Without `-o` it prints a human-readable list to stdout; with `-o` it writes a YAML mapping of `name: value` entries with type, prompt, options, and `when` annotations as comments. Literal defaults are pre-filled.
- New `run --answers FILE` flag. Loads the YAML, type-checks each value against the matching ask, and feeds the result into the root interpreter as pre-answers. Same when-gating rule as `include with`: a pre-answered question whose `when` is false at runtime falls back to the template's default and the supplied value is dropped.
- New `introspect.h`/`.cpp` library module: `collect_top_level_asks`, the human and YAML emitters, and a small purpose-built parser for the YAML subset we accept (no new external dep).
- Top-level run entry points (`run`, `dry_run`) take an optional pre-answers map so the CLI can hand the parsed file straight through.
- CLI reference and the include language doc updated.

## Test plan

- 24 new tests across the introspect and CLI suites: top-level ask collection (skipping repeat and if bodies, recording options and when), human and YAML emitters, YAML parser happy path and error paths (unknown key, type mismatch, duplicate, malformed quoting, CRLF), `inspect --questions` stdout and file output, `-o` without `--questions` rejected, `run --answers` happy path, when-false fallback, unknown key, type mismatch, missing file.
- All 817 tests pass locally.
- Round-tripped a sample template end to end: install, `inspect --questions -o`, edit, `run --answers`, observed correct directory layout with no prompts.